### PR TITLE
Allow toggling Debugger

### DIFF
--- a/DebugSwift/Sources/Settings/DebugSwift.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.swift
@@ -40,6 +40,10 @@ public enum DebugSwift {
     public static func theme(appearance: Appearance) {
         Theme.shared.setAppearance(appearance: appearance)
     }
+    
+    public static func toggleDebugger(_ enable: Bool) {
+        DebugSwift.Debugger.enable = enable
+    }
 }
 
 extension DebugSwift {


### PR DESCRIPTION
Make Debugger Public to allow disabling Debug print messages.

Resolve issue: https://github.com/DebugSwift/DebugSwift/issues/42