### PR TITLE
[Bugfix] Update bytesRead condition for InputStream+.swift

### DIFF
--- a/DebugSwift/Sources/Helpers/Extensions/InputStream+.swift
+++ b/DebugSwift/Sources/Helpers/Extensions/InputStream+.swift
@@ -21,7 +21,7 @@ extension InputStream {
             let bytesRead = read(buffer, maxLength: bufferSize)
             if bytesRead > 0 {
                 data.append(buffer, count: bytesRead)
-            } else if bytesRead == 0 {
+            } else if bytesRead <= 0 {
                 // Handle error or break the loop accordingly
                 break
             }

--- a/DebugSwift/Sources/Helpers/Extensions/InputStream+.swift
+++ b/DebugSwift/Sources/Helpers/Extensions/InputStream+.swift
@@ -21,7 +21,7 @@ extension InputStream {
             let bytesRead = read(buffer, maxLength: bufferSize)
             if bytesRead > 0 {
                 data.append(buffer, count: bytesRead)
-            } else if bytesRead < 0 {
+            } else if bytesRead == 0 {
                 // Handle error or break the loop accordingly
                 break
             }


### PR DESCRIPTION
Application runs infinite loop and bytesRead can not be smaller then 0. For error it should handle in fact -1.