### PR TITLE
Fix crash when removing simulated location

### DIFF
--- a/DebugSwift/Sources/Features/App/Location/Helpers/CLLocationManager.swift
+++ b/DebugSwift/Sources/Features/App/Location/Helpers/CLLocationManager.swift
@@ -87,7 +87,9 @@ extension CLLocationManager {
         if let simulatedLocation {
             delegate?.locationManager?(self, didUpdateLocations: [simulatedLocation])
         } else {
-            swizzedRequestLocation()
+            if delegate != nil {
+                swizzedRequestLocation()
+            }
         }
     }
 


### PR DESCRIPTION
If you have CLLocationManager in your code without a delegate, then removing the simulated location leads to a crash