### PR TITLE
Fix KMP API call logging

### DIFF
--- a/DebugSwift/Sources/Features/Network/Helpers/Helpers/SwizzleSessionConfiguration.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/Helpers/SwizzleSessionConfiguration.swift
@@ -14,58 +14,68 @@ extension URLSessionConfiguration {
             return
         }
         
-        swizzleProtocolSetter()
+        swizzleDefaultSessionConfiguration()
+        swizzleEphemeralSessionConfiguration()
+    }
+}
 
-        let defaultSessionConfiguration = class_getClassMethod(
-            URLSessionConfiguration.self,
-            #selector(getter: URLSessionConfiguration.default)
-        )
-        let swizzledDefaultSessionConfiguration = class_getClassMethod(
-            URLSessionConfiguration.self,
-            #selector(getter: URLSessionConfiguration.swizzledDefaultSessionConfiguration)
-        )
 
-        method_exchangeImplementations(defaultSessionConfiguration!, swizzledDefaultSessionConfiguration!)
-
-        let ephemeralSessionConfiguration = class_getClassMethod(
-            URLSessionConfiguration.self,
-            #selector(getter: URLSessionConfiguration.ephemeral)
-        )
-        let swizzledEphemeralSessionConfiguration = class_getClassMethod(
-            URLSessionConfiguration.self,
-            #selector(getter: URLSessionConfiguration.swizzledEphemeralSessionConfiguration)
-        )
-
-        method_exchangeImplementations(ephemeralSessionConfiguration!, swizzledEphemeralSessionConfiguration!)
+//MARK: - Private Helper functions
+private extension URLSessionConfiguration {
+    static func swizzleDefaultSessionConfiguration() {
+        swizzleSessionConfigurationClassMethod(
+            original: #selector(getter: URLSessionConfiguration.default),
+            swizzled: #selector(getter: URLSessionConfiguration.swizzledDefaultSessionConfiguration))
+        
+        swizzleProtocolSetterMethod(of: URLSessionConfiguration.default)
     }
     
-    private static func swizzleProtocolSetter() {
-        let defaultInstance = URLSessionConfiguration.default
-        let ephemeralInstance =  URLSessionConfiguration.ephemeral
+    static func swizzleEphemeralSessionConfiguration() {
+        swizzleSessionConfigurationClassMethod(
+            original: #selector(getter: URLSessionConfiguration.ephemeral),
+            swizzled: #selector(getter: URLSessionConfiguration.swizzledEphemeralSessionConfiguration))
         
-        let aClassDefault: AnyClass = object_getClass(defaultInstance)!
-        let aClassEphemeral: AnyClass = object_getClass(ephemeralInstance)!
-        
-        let origSelector = #selector(setter: URLSessionConfiguration.protocolClasses)
-        let newSelector = #selector(setter: URLSessionConfiguration.protocolClasses_Swizzled)
-        
-        let origMethodDefault = class_getInstanceMethod(aClassDefault, origSelector)!
-        let origMethodEphemeral = class_getInstanceMethod(aClassEphemeral, origSelector)!
-       
-        let newMethodDefault = class_getInstanceMethod(aClassDefault, newSelector)!
-        let newMethodEphemeral = class_getInstanceMethod(aClassEphemeral, newSelector)!
-        
-        method_exchangeImplementations(origMethodDefault, newMethodDefault)
-        method_exchangeImplementations(origMethodEphemeral, newMethodEphemeral)
+        swizzleProtocolSetterMethod(of: URLSessionConfiguration.ephemeral)
     }
     
-    @objc private var protocolClasses_Swizzled: [AnyClass]? {
+    static func swizzleSessionConfigurationClassMethod(original: Selector, swizzled: Selector) {
+        guard
+            let sessionConfiguration = class_getClassMethod(
+                URLSessionConfiguration.self,
+                original),
+            
+                let swizzledSessionConfiguration = class_getClassMethod(
+                    URLSessionConfiguration.self,
+                    swizzled)
+        else { return }
+        
+        method_exchangeImplementations(sessionConfiguration, swizzledSessionConfiguration)
+    }
+    
+    static func swizzleProtocolSetterMethod(of objClass: Any) {
+        let originalSelector = #selector(setter: URLSessionConfiguration.protocolClasses)
+        let swizzledSelector = #selector(setter: URLSessionConfiguration.protocolClasses_Swizzled)
+        
+        guard
+            let aclass = object_getClass(objClass),
+            let original = class_getInstanceMethod(aclass, originalSelector),
+            let swizzled = class_getInstanceMethod(aclass, swizzledSelector)
+        else { return }
+        
+        method_exchangeImplementations(original, swizzled)
+    }
+    
+    @objc
+    var protocolClasses_Swizzled: [AnyClass]? {
         get {
             // Unused, but required for compiler
             return self.protocolClasses_Swizzled
         }
         set {
-            guard let newTypes = newValue else { self.protocolClasses_Swizzled = nil; return }
+            guard let newTypes = newValue else {
+                self.protocolClasses_Swizzled = nil
+                return
+            }
             
             var types = [AnyClass]()
             
@@ -78,28 +88,24 @@ extension URLSessionConfiguration {
             
             // Ensure custom protocol is still in there:
             if !types.contains(where: { $0 == CustomHTTPProtocol.self }) {
-              types.insert(CustomHTTPProtocol.self, at: 0)
+                types.insert(CustomHTTPProtocol.self, at: 0)
             }
             
             self.protocolClasses_Swizzled = types
         }
     }
-
+    
     @objc
-    private class var swizzledDefaultSessionConfiguration: URLSessionConfiguration {
-        get {
-            let configuration =  URLSessionConfiguration.swizzledDefaultSessionConfiguration
-            configuration.protocolClasses?.insert(CustomHTTPProtocol.self, at: .zero)
-            return configuration
-        }
+    class var swizzledDefaultSessionConfiguration: URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.swizzledDefaultSessionConfiguration
+        configuration.protocolClasses?.insert(CustomHTTPProtocol.self, at: .zero)
+        return configuration
     }
     
     @objc
-    private class var swizzledEphemeralSessionConfiguration: URLSessionConfiguration {
-        get {
-            let configuration = URLSessionConfiguration.swizzledEphemeralSessionConfiguration
-            configuration.protocolClasses?.insert(CustomHTTPProtocol.self, at: .zero)
-            return configuration
-        }
+    class var swizzledEphemeralSessionConfiguration: URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.swizzledEphemeralSessionConfiguration
+        configuration.protocolClasses?.insert(CustomHTTPProtocol.self, at: .zero)
+        return configuration
     }
 }


### PR DESCRIPTION
Fixes: #117 
**Description:**
This PR fixes an issue where API calls from Kotlin Multiplatform (KMP) were not being logged.

**Changes:**

-  Swizzled URLSessionConfiguration.default and ephemeral factory methods to inject the custom protocol (CustomHTTPProtocol) during configuration creation.
- Added a swizzle for the protocolClasses setter to ensure the custom protocol is preserved, even when modified by Ktor or other frameworks.

**Impact:**

-  Ensures that all API calls, including those initiated via KMP, are logged consistently.
-  Prevents potential issues with double-swizzling or subclass interference.

**Testing:**

- Verified that API calls from KMP are intercepted and logged as expected.
- Ensured no regression in existing behavior with standard URLSessionConfiguration usage.

