### PR TITLE
[Bugfix] URL whitelisting logic in DebugSwift.Network.onlyURLs

### DIFF
--- a/DebugSwift/Sources/Features/Network/DataSource/HTTP.Datasource.swift
+++ b/DebugSwift/Sources/Features/Network/DataSource/HTTP.Datasource.swift
@@ -19,10 +19,9 @@ final class HttpDatasource {
         }
 
         if !DebugSwift.Network.onlyURLs.isEmpty {
-            for urlString in DebugSwift.Network.onlyURLs {
-                if model.url?.absoluteString.lowercased().contains(
-                    urlString.lowercased()
-                ) == false {
+            if let modelUrl = model.url?.absoluteString.lowercased() {
+                let found = DebugSwift.Network.onlyURLs.contains { modelUrl.contains($0.lowercased()) }
+                if !found {
                     return false
                 }
             }

--- a/Example/Tests/Features/Network/DataSource/HttpDatasourceTests.swift
+++ b/Example/Tests/Features/Network/DataSource/HttpDatasourceTests.swift
@@ -1,0 +1,58 @@
+//
+//  HttpDatasourceTests.swift
+//  DebugSwift
+//
+//  Created by Steven Lewi on 01/05/25.
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class HttpDatasourceTests: XCTestCase {
+
+    private final let httpDataSource = HttpDatasource()
+
+    func testAddHttpRequest_onlyURLs() {
+        // Given
+        DebugSwift.Network.onlyURLs = [
+            "www.example.com",
+            "github.com",
+            "https://cocoapods.org"
+        ]
+
+        // When
+        let httpModel = HttpModel()
+        httpModel.url = URL(string: "https://github.com/DebugSwift/DebugSwift")!
+        let isAddedUrl1 = httpDataSource.addHttpRequest(httpModel)
+
+        let httpModel2 = HttpModel()
+        httpModel2.url = URL(string: "https://google.com/")!
+        let isAddedUrl2 = httpDataSource.addHttpRequest(httpModel2)
+
+        // Then
+        XCTAssertTrue(isAddedUrl1)
+        XCTAssertFalse(isAddedUrl2)
+    }
+
+    func testAddHttpRequest_ignoredURLs() {
+        // Given
+        DebugSwift.Network.ignoredURLs = [
+            "www.example.com",
+            "github.com",
+            "https://cocoapods.org"
+        ]
+
+        // When
+        let httpModel = HttpModel()
+        httpModel.url = URL(string: "https://google.com/q=DebugSwift")!
+        let isAddedUrl1 = httpDataSource.addHttpRequest(httpModel)
+
+        let httpModel2 = HttpModel()
+        httpModel2.url = URL(string: "https://github.com/DebugSwift/DebugSwift")!
+        let isAddedUrl2 = httpDataSource.addHttpRequest(httpModel2)
+
+        // Then
+        XCTAssertTrue(isAddedUrl1)
+        XCTAssertFalse(isAddedUrl2)
+    }
+}


### PR DESCRIPTION
Logic in DebugSwift.Network.onlyURLs will only check for first URL if not matched, then it will fail fast, while it should continue to check all the rest of the array.
```
if model.url?.absoluteString.lowercased().contains(urlString.lowercased()) == false {
    return false
}
```

Validated by unit test.