### PR TITLE
[Feature] Remove handler main screen

### DIFF
--- a/DebugSwift/Sources/Settings/DebugSwift.App.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.App.swift
@@ -22,5 +22,17 @@ extension DebugSwift {
         ]
 
         static var disableMethods: [DebugSwiftSwizzleFeature] = []
+
+        @discardableResult
+        public static func showScreen() -> Self.Type {
+            WindowManager.presentDebugger()
+            return self
+        }
+
+        @discardableResult
+        public static func closeScreen() -> Self.Type {
+            WindowManager.removeDebugger()
+            return self
+        }
     }
 }


### PR DESCRIPTION
### Description
Enables opening or closing of the main screen remotely through a public function, allowing custom ViewControllers to close the Debug when necessary.