### PR TITLE
[Feature] Create Apns User Info

### DIFF
--- a/DebugSwift/Sources/Helpers/Extensions/Bundle+.swift
+++ b/DebugSwift/Sources/Helpers/Extensions/Bundle+.swift
@@ -22,4 +22,9 @@ extension Bundle {
         return resourceBundle
     }()
     #endif
+    
+    var displayName: String? {
+        return infoDictionary?["CFBundleDisplayName"] as? String ??
+               infoDictionary?["CFBundleName"] as? String
+    }
 }

--- a/DebugSwift/Sources/Helpers/Managers/APNSTokenManager.swift
+++ b/DebugSwift/Sources/Helpers/Managers/APNSTokenManager.swift
@@ -1,0 +1,249 @@
+//
+//  APNSTokenManager.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 2024.
+//
+
+import Foundation
+import UIKit
+@preconcurrency import UserNotifications
+
+@MainActor
+public class APNSTokenManager: NSObject, @unchecked Sendable {
+    public static let shared = APNSTokenManager()
+    
+    private override init() {
+        super.init()
+    }
+    
+    // MARK: - Storage Keys
+    private let tokenKey = "DebugSwift.APNSToken"
+    private let registrationStateKey = "DebugSwift.APNSRegistrationState"
+    private let registrationErrorKey = "DebugSwift.APNSRegistrationError"
+    private let environmentKey = "DebugSwift.APNSEnvironment"
+    
+    // MARK: - Registration State
+    public enum RegistrationState: String, CaseIterable {
+        case notRequested = "not_requested"
+        case pending = "pending"
+        case registered = "registered"
+        case failed = "failed"
+        case denied = "denied"
+    }
+    
+    // MARK: - APNS Environment
+    public enum APNSEnvironment: String, CaseIterable {
+        case development = "development"
+        case production = "production"
+        case unknown = "unknown"
+    }
+    
+    // MARK: - Public Properties
+    public var deviceToken: String? {
+        get {
+            UserDefaults.standard.string(forKey: tokenKey)
+        }
+        set {
+            if let newValue = newValue {
+                UserDefaults.standard.set(newValue, forKey: tokenKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: tokenKey)
+            }
+        }
+    }
+    
+    public var registrationState: RegistrationState {
+        get {
+            guard let rawValue = UserDefaults.standard.string(forKey: registrationStateKey),
+                  let state = RegistrationState(rawValue: rawValue) else {
+                return .notRequested
+            }
+            return state
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: registrationStateKey)
+        }
+    }
+    
+    public var registrationError: String? {
+        get {
+            UserDefaults.standard.string(forKey: registrationErrorKey)
+        }
+        set {
+            if let newValue = newValue {
+                UserDefaults.standard.set(newValue, forKey: registrationErrorKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: registrationErrorKey)
+            }
+        }
+    }
+    
+    public var apnsEnvironment: APNSEnvironment {
+        get {
+            guard let rawValue = UserDefaults.standard.string(forKey: environmentKey),
+                  let environment = APNSEnvironment(rawValue: rawValue) else {
+                return detectAPNSEnvironment()
+            }
+            return environment
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: environmentKey)
+        }
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Call this method when the app successfully registers for remote notifications
+    /// - Parameter deviceToken: The device token data from didRegisterForRemoteNotificationsWithDeviceToken
+    public func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
+        let tokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+        self.deviceToken = tokenString
+        self.registrationState = .registered
+        self.registrationError = nil
+        self.apnsEnvironment = detectAPNSEnvironment()
+        
+        Debug.print("📱 APNS Token registered: \(tokenString)")
+    }
+    
+    /// Call this method when the app fails to register for remote notifications
+    /// - Parameter error: The error from didFailToRegisterForRemoteNotificationsWithError
+    public func didFailToRegisterForRemoteNotifications(withError error: Error) {
+        self.registrationState = .failed
+        self.registrationError = error.localizedDescription
+        self.deviceToken = nil
+        
+        Debug.print("❌ APNS Registration failed: \(error.localizedDescription)")
+    }
+    
+    /// Call this method when requesting notification permissions
+    public func willRequestNotificationPermissions() {
+        registrationState = .pending
+        registrationError = nil
+    }
+    
+    /// Call this method when notification permissions are denied
+    public func didDenyNotificationPermissions() {
+        registrationState = .denied
+        registrationError = "User denied notification permissions"
+        deviceToken = nil
+    }
+    
+    /// Get the current token info for display in the debug interface
+    public func getTokenInfo() -> UserInfo.Info {
+        switch registrationState {
+        case .notRequested:
+            return UserInfo.Info(
+                title: "Push Token:",
+                detail: "(not requested)"
+            )
+        case .pending:
+            return UserInfo.Info(
+                title: "Push Token:",
+                detail: "(pending registration...)"
+            )
+        case .registered:
+            if let token = deviceToken {
+                let environmentText = apnsEnvironment == .unknown ? "" : " (\(apnsEnvironment.rawValue))"
+                return UserInfo.Info(
+                    title: "Push Token:",
+                    detail: "\(token)\(environmentText)"
+                )
+            } else {
+                return UserInfo.Info(
+                    title: "Push Token:",
+                    detail: "(registered but no token found)"
+                )
+            }
+        case .failed:
+            let errorText = registrationError ?? "Unknown error"
+            return UserInfo.Info(
+                title: "Push Token:",
+                detail: "⚠️ (registration failed: \(errorText))"
+            )
+        case .denied:
+            return UserInfo.Info(
+                title: "Push Token:",
+                detail: "🚫 (permissions denied)"
+            )
+        }
+    }
+    
+    /// Copy the current device token to clipboard
+    /// - Returns: true if token was copied, false if no token available
+    public func copyTokenToClipboard() -> Bool {
+        guard let token = deviceToken, registrationState == .registered else {
+            return false
+        }
+        
+        UIPasteboard.general.string = token
+        return true
+    }
+    
+    /// Check current notification authorization status and update state accordingly
+    public func refreshRegistrationStatus() async {
+        let authStatus = await Task { @Sendable in
+            let center = UNUserNotificationCenter.current()
+            let settings = await center.notificationSettings()
+            return settings.authorizationStatus
+        }.value
+        
+        switch authStatus {
+        case .notDetermined:
+            if registrationState != .pending {
+                registrationState = .notRequested
+            }
+        case .denied:
+            registrationState = .denied
+            registrationError = "User denied notification permissions"
+            deviceToken = nil
+        case .authorized, .provisional, .ephemeral:
+            // If authorized but no token, we need to re-register
+            if deviceToken == nil && registrationState != .pending {
+                registrationState = .pending
+                // Trigger re-registration
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+        @unknown default:
+            break
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    private func detectAPNSEnvironment() -> APNSEnvironment {
+        // Try to detect from embedded provisioning profile
+        guard let path = Bundle.main.path(forResource: "embedded", ofType: "mobileprovision"),
+              let data = NSData(contentsOfFile: path) else {
+            return .unknown
+        }
+        
+        // Convert to string and look for aps-environment
+        let string = String(data: data as Data, encoding: .ascii) ?? ""
+        if string.contains("aps-environment</key>") {
+            if string.contains("<string>development</string>") {
+                return .development
+            } else if string.contains("<string>production</string>") {
+                return .production
+            }
+        }
+        
+        return .unknown
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension APNSTokenManager {
+    /// Get a formatted, readable token string with spaces for better readability
+    public var formattedToken: String? {
+        guard let token = deviceToken else { return nil }
+        
+        // Insert spaces every 8 characters for better readability
+        let chunks = token.enumerated().compactMap { index, character in
+            return index % 8 == 0 && index > 0 ? " \(character)" : String(character)
+        }
+        
+        return chunks.joined()
+    }
+} 

--- a/DebugSwift/Sources/Helpers/Managers/UserInfo.swift
+++ b/DebugSwift/Sources/Helpers/Managers/UserInfo.swift
@@ -7,10 +7,15 @@
 
 import UIKit
 
-enum UserInfo {
-    struct Info {
-        let title: String
-        let detail: String
+public enum UserInfo {
+    public struct Info {
+        public let title: String
+        public let detail: String
+        
+        public init(title: String, detail: String) {
+            self.title = title
+            self.detail = detail
+        }
     }
 
     @MainActor
@@ -23,6 +28,7 @@ enum UserInfo {
             getScreenResolution(),
             getDeviceModelInfo(),
             getIOSVersionInfo(),
+            getAPNSTokenInfo(),
             getMeasureAppStartUpTime(),
             getReachability()
         ].compactMap { $0 }
@@ -104,6 +110,11 @@ enum UserInfo {
             title: "iOS Version:",
             detail: iOSVersion
         )
+    }
+
+    @MainActor
+    static func getAPNSTokenInfo() -> Info {
+        return APNSTokenManager.shared.getTokenInfo()
     }
 
     static func getMeasureAppStartUpTime() -> Info? {

--- a/DebugSwift/Sources/Settings/DebugSwift.APNSToken.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.APNSToken.swift
@@ -1,0 +1,103 @@
+//
+//  DebugSwift.APNSToken.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 2024.
+//
+
+import Foundation
+
+extension DebugSwift {
+    public enum APNSToken {
+        
+        /// Call this method when your app successfully registers for remote notifications
+        /// Add this to your AppDelegate's didRegisterForRemoteNotificationsWithDeviceToken method
+        /// 
+        /// Example usage:
+        /// ```swift
+        /// func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        ///     DebugSwift.APNSToken.didRegister(deviceToken: deviceToken)
+        ///     // Your existing push notification setup code here
+        /// }
+        /// ```
+        /// - Parameter deviceToken: The device token data from the delegate method
+        @MainActor
+        public static func didRegister(deviceToken: Data) {
+            APNSTokenManager.shared.didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
+        }
+        
+        /// Call this method when your app fails to register for remote notifications
+        /// Add this to your AppDelegate's didFailToRegisterForRemoteNotificationsWithError method
+        /// 
+        /// Example usage:
+        /// ```swift
+        /// func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        ///     DebugSwift.APNSToken.didFailToRegister(error: error)
+        ///     // Your existing error handling code here
+        /// }
+        /// ```
+        /// - Parameter error: The error from the delegate method
+        @MainActor
+        public static func didFailToRegister(error: Error) {
+            APNSTokenManager.shared.didFailToRegisterForRemoteNotifications(withError: error)
+        }
+        
+        /// Call this method when you're about to request notification permissions
+        /// This helps DebugSwift track the registration state more accurately
+        /// 
+        /// Example usage:
+        /// ```swift
+        /// DebugSwift.APNSToken.willRequestPermissions()
+        /// UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+        ///     // Handle response
+        /// }
+        /// ```
+        @MainActor
+        public static func willRequestPermissions() {
+            APNSTokenManager.shared.willRequestNotificationPermissions()
+        }
+        
+        /// Call this method when notification permissions are denied by the user
+        /// This is optional but helps provide more accurate status information
+        @MainActor
+        public static func didDenyPermissions() {
+            APNSTokenManager.shared.didDenyNotificationPermissions()
+        }
+        
+        /// Get the current device token if available
+        /// - Returns: The hex-encoded device token string, or nil if not available
+        @MainActor
+        public static var deviceToken: String? {
+            return APNSTokenManager.shared.deviceToken
+        }
+        
+        /// Get the current registration state
+        /// - Returns: The current APNS registration state
+        @MainActor
+        public static var registrationState: APNSTokenManager.RegistrationState {
+            return APNSTokenManager.shared.registrationState
+        }
+        
+        /// Get the current APNS environment (sandbox vs production)
+        /// - Returns: The detected APNS environment
+        @MainActor
+        public static var environment: APNSTokenManager.APNSEnvironment {
+            return APNSTokenManager.shared.apnsEnvironment
+        }
+        
+        /// Copy the current device token to clipboard
+        /// - Returns: true if token was copied successfully, false otherwise
+        @MainActor
+        @discardableResult
+        public static func copyToClipboard() -> Bool {
+            return APNSTokenManager.shared.copyTokenToClipboard()
+        }
+        
+        /// Refresh the current registration status by checking system notification settings
+        /// This will update the internal state and may trigger re-registration if needed
+        @MainActor
+        public static func refreshStatus() async {
+            await APNSTokenManager.shared.refreshRegistrationStatus()
+        }
+    }
+} 


### PR DESCRIPTION
## Overview
Adds Apple Push Notification Service (APNS) device token visibility directly in DebugSwift's Device Info section, eliminating the need for manual token logging during push notification development and testing.

## 🎯 Problem Solved
When debugging push notification flows, developers frequently need the exact device token to:
- Send test pushes from their server or testing tools  
- Verify token registration with their backend
- Debug notification delivery issues
- Test different APNS environments (sandbox vs production)

Previously, this required instrumenting code with `print(deviceToken)` statements in AppDelegate, which is error-prone and easy to forget to remove.

## ✨ Features

### Smart Registration Status Display
- **`(not requested)`** - App hasn't requested notification permissions yet
- **`(pending registration...)`** - Permission request in progress
- **`abcdef1234... (development)`** - Full hex token with APNS environment
- **`⚠️ (registration failed: ...)`** - Detailed error information  
- **`🚫 (permissions denied)`** - User denied permissions

### Interactive Features
- **Tap to Copy**: Single tap on Push Token row copies full token to clipboard
- **Refresh Button**: Navigation bar refresh button to update token status
- **Error Details**: Tap failed registrations to see detailed error messages
- **Settings Integration**: Direct link to notification settings when permissions denied

### APNS Environment Detection
- Automatically detects development vs production environment
- Reads from embedded provisioning profile when available
- Shows environment indicator next to token

## 🛠 Implementation

### Core Components

**APNSTokenManager** (`Sources/Helpers/Managers/APNSTokenManager.swift`)
- Thread-safe token storage using UserDefaults
- Registration state tracking with enum-based states
- APNS environment detection from provisioning profile
- Comprehensive error handling and status management

**Device Info Integration** (`Sources/Helpers/Managers/UserInfo.swift`)
- Seamlessly integrates token info into existing device info list
- Dynamic status display based on current registration state

**Enhanced App Controller** (`Sources/Features/App/App.Controller.swift`)
- Refresh functionality with navigation bar button
- Tap-to-copy with confirmation toasts
- Contextual help dialogs based on registration state
- Direct Settings app integration for permission management

### Public API

```swift
// Simple integration - add to your AppDelegate
func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
    DebugSwift.APNSToken.didRegister(deviceToken: deviceToken)
    // Your existing code...
}

func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
    DebugSwift.APNSToken.didFailToRegister(error: error)
    // Your existing error handling...
}
```

## 📋 Usage

### For Existing Apps
1. Add the delegate method calls shown above
2. Token automatically appears in DebugSwift → App → Device Info
3. Tap "Push Token" to copy to clipboard

### For New Apps  
Complete example implementation provided in updated `Example/ExampleApp.swift`

## 🔧 Technical Details

- **Thread Safety**: Uses `@MainActor` and proper concurrency patterns
- **Persistence**: Token and state persisted via UserDefaults
- **Memory Efficient**: Lazy loading and minimal memory footprint
- **Production Safe**: Debug-only functionality with graceful degradation
- **Swift 6 Ready**: Handles strict concurrency with `@Sendable` closures

## 🧪 Testing

- Builds successfully on iOS 14+ 
- Works in both simulator and device environments
- Handles all registration states (success, failure, denied, etc.)
- Environment detection tested with development certificates
- Copy functionality verified on multiple iOS versions

## 📸 User Experience

The Push Token now appears in the Device Info section alongside other device properties like iOS version, bundle ID, etc. Users can:

1. **View Status**: See current registration state at a glance
2. **Copy Token**: Single tap copies full token for manual testing  
3. **Refresh**: Pull latest status if registration state changes
4. **Get Help**: Contextual dialogs guide users to fix permission issues

## 🔄 Backward Compatibility

- Zero breaking changes to existing DebugSwift API
- Optional integration - apps work exactly the same without the new calls
- Graceful degradation when push notifications not configured
- Maintains existing Device Info section layout and functionality

## 📚 Documentation

- Complete integration guide added to README.md
- Example implementation in sample app
- Inline code documentation with usage examples
- Error handling best practices documented