### PR TITLE
Fix build error on Xcode 26.0

### DIFF
--- a/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
+++ b/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
@@ -164,22 +164,22 @@ extension FloatBallView {
             label.centerXAnchor.constraint(equalTo: centerXAnchor),
             label.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
-
-        let animator = UIViewPropertyAnimator(
-            duration: 2,
-            dampingRatio: 0.7
-        ) {
-            label.transform = CGAffineTransform(translationX: 0, y: -40)
-            label.alpha = 0
-        }
-
-        animator.addCompletion { position in
+        
+        Task { @MainActor in
+            let animator = UIViewPropertyAnimator(
+                duration: 2,
+                dampingRatio: 0.7
+            ) {
+                label.transform = CGAffineTransform(translationX: 0, y: -40)
+                label.alpha = 0
+            }
+            animator.startAnimation()
+            
+            let position = await animator.addCompletion()
             if position == .end {
                 label.removeFromSuperview()
             }
         }
-
-        animator.startAnimation()
     }
 }
 


### PR DESCRIPTION
This PR fixes a build error that occurs when compiling with Xcode 26.0 Beta.

<img width="1000" src="https://github.com/user-attachments/assets/c6aa1515-3310-4a44-a1d4-17b2c57e2e71" />


The issue was caused by a change in the behavior of `UIViewPropertyAnimator.addCompletion`, which appears to have stricter requirements or different semantics in this version of Xcode.
 For more context on the underlying change, see: [swiftlang/swift#82127](https://github.com/swiftlang/swift/issues/82127)