### PR TITLE
[Feature] Disable Leak Detector When New Relic Is Enable

### DIFF
--- a/DebugSwift/Sources/Features/Performance/Helpers/Performance.LeakDetector.swift
+++ b/DebugSwift/Sources/Features/Performance/Helpers/Performance.LeakDetector.swift
@@ -476,6 +476,12 @@ extension UIViewController {
     }
 
     private static let lvcdActuallySwizzleLifecycleMethods: Void = {
+        // Check if New Relic is present to avoid conflicts
+        if NSClassFromString("NewRelic") != nil {
+            print("⚠️ DebugSwift: New Relic detected - disabling leak detector to prevent conflicts")
+            return
+        }
+        
         let originalVdaMethod = class_getInstanceMethod(
             UIViewController.self,
             #selector(viewDidLoad)

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -34,6 +34,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     ) -> Bool {
         // Remove comment below to remove specific features and comment DebugSwift.setup() not to double trigger.
         // DebugSwift.setup(hideFeatures: [.interface, .app, .resources, .performance])
+        
+        // If you have New Relic, disable leak detector to prevent conflicts:
+        // debugSwift.setup(disable: [.leaksDetector])
+        
         debugSwift
             .setup()
             .show()


### PR DESCRIPTION
## Fix New Relic Compatibility Issue with Method Swizzling

### Problem
DebugSwift crashes when New Relic is present in the app with the following error:
```
Terminating app due to uncaught exception 'NRInvalidArgumentException', reason: 'New Relic detected an unrecognized selector, 'lvcdViewDidLoad', sent to 'DebugSwift.BaseController'
```

This occurs because both New Relic and DebugSwift's leak detector use method swizzling on `UIViewController` lifecycle methods. New Relic doesn't recognize DebugSwift's swizzled method names and throws an exception.

### Solution
Added automatic New Relic detection that disables the leak detector when conflicts are detected:

- **Automatic Detection**: Checks for `NewRelic` class presence before swizzling
- **Graceful Degradation**: Disables leak detector functionality when New Relic is found
- **User Notification**: Logs a warning message when conflict prevention is triggered
- **Manual Override**: Users can explicitly disable leak detector via `setup(disable: [.leaksDetector])`

### Changes Made

**DebugSwift/Sources/Features/Performance/Helpers/Performance.LeakDetector.swift**
- Added New Relic detection in `lvcdActuallySwizzleLifecycleMethods`
- Early return prevents method swizzling when New Relic is present
- Added informative warning log for developers

**Example/Example/ExampleApp.swift**
- Added documentation comment showing manual disable option
- Provides clear example for users experiencing similar conflicts

### Testing
- ✅ App launches without crash when New Relic is present
- ✅ Leak detector functions normally when New Relic is not present
- ✅ Warning message appears in console when conflict is detected
- ✅ Manual disable option works as expected

### Breaking Changes
None - this is a backward-compatible fix that maintains existing functionality while adding conflict prevention.

### Related Issues
Fixes crashes in production apps that use both DebugSwift and New Relic monitoring.