### PR TITLE
Fix: Disable interactive pop gesture in WindowManager

### DIFF
--- a/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
+++ b/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
@@ -26,6 +26,7 @@ enum WindowManager {
         window.windowLevel = .alert + 1
 
         let navigation = UINavigationController(rootViewController: UIViewController())
+        navigation.interactivePopGestureRecognizer?.isEnabled = false
         navigation.setBackgroundColor(color: .clear)
         window.rootViewController = navigation
         window.isHidden = false


### PR DESCRIPTION
## Summary
Disable interactive pop gesture recognizer in navigation controller within WindowManager to ensure proper debugger cleanup and state management.

## Problem
Although `navigationItem.hidesBackButton = true` is set in TabBarController.swift:41, the edge swipe gesture for going back still exists. When users navigate back via this gesture, the `closeButtonTapped()` method (TabBarController.swift:53) is bypassed, which means `WindowManager.removeDebugger()` is never called. This leads to improper cleanup and potential state management issues.

## Root Cause
- Edge swipe gesture navigation bypasses the intended cleanup flow
- Users can exit the debugger without triggering the proper `removeDebugger()` method
- This creates inconsistent application state

## Solution
Completely disable the interactive pop gesture recognizer in the WindowManager navigation controller by setting `navigation.interactivePopGestureRecognizer?.isEnabled = false`. This ensures users can only exit via the close button, guaranteeing proper cleanup execution.

## Changes
- Added `navigation.interactivePopGestureRecognizer?.isEnabled = false` in WindowManager.swift:29