### PR TITLE
fix: use sendable task

### DIFF
--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -138,8 +138,8 @@ final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             dataTask = nil
         }
 
-        Task { @MainActor in
-            guard NetworkHelper.shared.isNetworkEnable else {
+        Task { @Sendable in
+            guard await NetworkHelper.shared.isNetworkEnable else {
                 return
             }
             


### PR DESCRIPTION
```text
Sending 'self' risks causing data races

Task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses
```