### PR TITLE
fix: className in Mac Catalyst

### DIFF
--- a/DebugSwift/Sources/Features/App/LoadedLibraries/ClassExplorer/ClassExplorer.Controller.swift
+++ b/DebugSwift/Sources/Features/App/LoadedLibraries/ClassExplorer/ClassExplorer.Controller.swift
@@ -12,7 +12,7 @@ final class ClassExplorerViewController: BaseController {
     // MARK: - Properties
     
     private let libraryName: String
-    private let className: String
+    private let clazzName: String
     private let viewModel: ClassExplorerViewModel
     
     private lazy var tableView: UITableView = {
@@ -41,7 +41,7 @@ final class ClassExplorerViewController: BaseController {
     
     init(libraryName: String, className: String) {
         self.libraryName = libraryName
-        self.className = className
+        self.clazzName = className
         self.viewModel = ClassExplorerViewModel(className: className)
         super.init()
     }
@@ -57,7 +57,7 @@ final class ClassExplorerViewController: BaseController {
     // MARK: - Setup
     
     private func setup() {
-        title = className
+        title = clazzName
         
         view.addSubview(tableView)
         


### PR DESCRIPTION
```text
// tuist cache --external-only

Building scheme Binaries-Cache-iOS for Mac Catalyst
...
❌ /path/to/DebugSwift/DebugSwift/Sources/Features/App/LoadedLibraries/ClassExplorer/ClassExplorer.Controller.swift:15:17: overriding property must be as accessible as its enclosing type
❌ /path/to/DebugSwift/DebugSwift/Sources/Features/App/LoadedLibraries/ClassExplorer/ClassExplorer.Controller.swift:15:17: cannot override with a stored property 'className'
❌ /path/to/DebugSwift/DebugSwift/Sources/Features/App/LoadedLibraries/ClassExplorer/ClassExplorer.Controller.swift:60:17: ambiguous use of 'className'
```

Reference: https://developer.apple.com/documentation/objectivec/nsobject-swift.class/classname
