### PR TITLE
Fix Swift Concurrency Issues and Compiler Warnings

### DIFF
--- a/DebugSwift/Sources/Features/Network/Main/Network.ViewModel.swift
+++ b/DebugSwift/Sources/Features/Network/Main/Network.ViewModel.swift
@@ -73,13 +73,13 @@ final class NetworkViewModel {
             let webViewRequests = webViewModels
             HttpDatasource.shared.removeAll()
             // Re-add WebView requests
-            webViewRequests.forEach { HttpDatasource.shared.addHttpRequest($0) }
+            webViewRequests.forEach { _ = HttpDatasource.shared.addHttpRequest($0) }
         case .webview:
             // Remove only WebView requests
             let httpRequests = httpModels
             HttpDatasource.shared.removeAll()
             // Re-add HTTP requests
-            httpRequests.forEach { HttpDatasource.shared.addHttpRequest($0) }
+            httpRequests.forEach { _ = HttpDatasource.shared.addHttpRequest($0) }
         case .websocket:
             // WebSocket clearing handled elsewhere
             break


### PR DESCRIPTION
### Summary
This PR addresses Swift Concurrency compilation errors and unused return value warnings that were preventing successful builds with Swift 5.9+ strict concurrency checking enabled.

### Changes Made

#### 1. Fixed Sendable Closure Error in WKWebViewNetworkMonitor.swift
**Problem**: `[String: Any]` is not Sendable, causing compilation failure when captured in `@Sendable` closures.

**Solution**: 
- Created `WebViewRequestInfo` struct that conforms to `Sendable`
- Implemented proper type-safe data storage with Sendable types:
  - `String` for request ID, URL, method, body
  - `Date` for timing information
  - `[String: String]` for headers
- Maintained API compatibility through `toDictionary()` and `from` initializer
- Updated `WebViewRequestCache` to use the new Sendable struct internally

**Files Modified**: `DebugSwift/Sources/Features/Network/Helpers/WKWebViewNetworkMonitor.swift`

#### 2. Fixed Unused Return Value Warnings in Network.ViewModel.swift
**Problem**: Return values from `addHttpRequest` calls were unused, generating compiler warnings.

**Solution**: 
- Added `_ =` prefix to explicitly discard return values
- This occurs in the `handleClearAction` method when re-adding requests after clearing operations

**Files Modified**: `DebugSwift/Sources/Features/Network/Main/Network.ViewModel.swift`

### Technical Details

#### Swift Concurrency Fix
The core issue was that `[String: Any]` cannot be captured in `@Sendable` closures because `Any` can contain non-Sendable types. The solution provides:

1. **Type Safety**: All stored data is now explicitly typed as Sendable types
2. **Data Conversion**: Proper handling of various body data types (String, Dictionary, etc.) to Sendable equivalents
3. **API Compatibility**: Existing code continues to work without changes
4. **Performance**: Clean data structure without unnecessary overhead

#### Compiler Warning Fix
The unused return value warnings were addressed by explicitly discarding the boolean return values from `addHttpRequest` calls, which indicate whether the request was successfully added to the datasource.

### Testing
- ✅ Project builds successfully with Swift Concurrency enabled
- ✅ All linter warnings resolved
- ✅ No functional changes to existing behavior
- ✅ Backward compatibility maintained

### Impact
- **Build Success**: Resolves compilation failures with modern Swift versions
- **Code Quality**: Eliminates compiler warnings
- **Future-Proof**: Ensures compatibility with Swift 6 when strict concurrency becomes mandatory
- **Maintainability**: Cleaner, more type-safe code structure

### Breaking Changes
None. All changes are backward compatible.

---

**Labels**: `bugfix`, `swift-concurrency`, `compiler-warnings`, `network-monitoring`