### PR TITLE
fix: Respect app's user interface style override

### DIFF
--- a/DebugSwift/Sources/Features/Interface/Helpers/UserInterfaceToolkit.swift
+++ b/DebugSwift/Sources/Features/Interface/Helpers/UserInterfaceToolkit.swift
@@ -97,7 +97,13 @@ class UserInterfaceToolkit: @unchecked Sendable {
     // MARK: - Setup
     
     private func setupInitialState() {
-        darkModeEnabled = UIScreen.main.traitCollection.userInterfaceStyle == .dark
+        // Check if app explicitly overridden the user interface style
+        if let window = UIWindow.keyWindow {
+            darkModeEnabled = window.traitCollection.userInterfaceStyle == .dark
+        } else {
+            // Fallback to system preference if no window is available yet
+            darkModeEnabled = UIScreen.main.traitCollection.userInterfaceStyle == .dark
+        }
         
         // Set initial color scheme
         if let colorScheme = gridOverlay.colorScheme,


### PR DESCRIPTION
Hey guys, I'm working on an app that doesn't support dark mode yet (I know, it's a shame 😅). I ran into some issues when activating the debugger, and this PR solves that problem.

## Summary

Respect host app's user interface style override when determining dark mode state in UserInterfaceToolkit to prevent forced dark mode in apps that explicitly disable it.

## Problem

When a UIKit app explicitly overrides `overrideUserInterfaceStyle` to `.light` (e.g., in AppDelegate), DebugSwift still applies dark mode to its interface. This causes visual issues where all views appear black/incorrect because the library's dark mode theming conflicts with the host app's light-only configuration.

## Root Cause

* `UserInterfaceToolkit.swift` was checking `UIScreen.main.traitCollection.userInterfaceStyle` to determine dark mode state
* This system-level check returns the device's dark mode preference, ignoring any app-specific overrides
* Apps that explicitly set `overrideUserInterfaceStyle` to disable dark mode support were having their preference bypassed
* This creates visual inconsistencies and broken UI when DebugSwift applies dark theming to light-mode-only apps

## Solution

Check the actual window's trait collection first before falling back to the system preference. The window's trait collection respects app-level `overrideUserInterfaceStyle` settings, ensuring DebugSwift adapts to the host app's configuration. This approach maintains compatibility with all integration scenarios:
- UIKit apps with explicit light/dark mode overrides
- UIKit apps that follow system appearance
- SwiftUI apps

## Changes

* Modified dark mode detection in `UserInterfaceToolkit.swift:100-109`
* Now checks `UIWindow.keyWindow?.traitCollection.userInterfaceStyle` first (respects app overrides)
* Falls back to `UIScreen.main.traitCollection.userInterfaceStyle` if no window is available yet (system preference)