### PR TITLE
fix: Add clearNetworkHistory() to resolve issue #232

### DIFF
--- a/DebugSwift/Sources/Settings/DebugSwift.Network.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.Network.swift
@@ -83,6 +83,50 @@ extension DebugSwift {
             NetworkThresholdTracker.shared.getDetailedLogs()
         }
         
+        // MARK: - Network History Management
+        
+        /// Clear all HTTP/HTTPS network request history
+        /// Use this to clear the Network tab when switching environments or testing different scenarios
+        ///
+        /// Example:
+        /// ```swift
+        /// // Clear network history when switching from dev to prod
+        /// DebugSwift.Network.shared.clearNetworkHistory()
+        /// ```
+        public func clearNetworkHistory() {
+            HttpDatasource.shared.removeAll()
+            NotificationCenter.default.post(
+                name: NSNotification.Name("reloadHttp_DebugSwift"),
+                object: nil
+            )
+        }
+        
+        /// Clear all WebSocket connection and frame history
+        /// Use this to clear WebSocket data when switching environments
+        ///
+        /// Example:
+        /// ```swift
+        /// DebugSwift.Network.shared.clearWebSocketHistory()
+        /// ```
+        @MainActor
+        public func clearWebSocketHistory() {
+            WebSocketDataSource.shared.removeAllConnections()
+        }
+        
+        /// Clear all network data including HTTP requests and WebSocket connections
+        /// This is a convenience method that clears both HTTP and WebSocket history
+        ///
+        /// Example:
+        /// ```swift
+        /// // Clear all network data when switching stands (dev/prod)
+        /// DebugSwift.Network.shared.clearAllNetworkData()
+        /// ```
+        @MainActor
+        public func clearAllNetworkData() {
+            clearNetworkHistory()
+            clearWebSocketHistory()
+        }
+        
         // MARK: - Encryption/Decryption API
         
         /// Enable or disable response decryption

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -47,6 +47,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // To fix Alamofire `uploadProgress`
 //        DebugSwift.Network.delegate = self
         
+        // MARK: Custom Actions Demo - Including Network History Clear
+        setupCustomActions()
+        
         // Request push notification permissions for APNS token demo
         requestPushNotificationPermissions()
 
@@ -57,6 +60,48 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         let viewController = UITableViewController()
         viewController.title = "PURE"
         return [viewController]
+    }
+    
+    // MARK: - Custom Actions Setup
+    
+    private func setupCustomActions() {
+        DebugSwift.App.shared.customAction = {
+            [
+                .init(title: "Environment Management", actions: [
+                    .init(title: "Clear Network History") {
+                        DebugSwift.Network.shared.clearNetworkHistory()
+                        print("✅ Network history cleared!")
+                    },
+                    .init(title: "Clear All Network Data") {
+                        Task { @MainActor in
+                            await DebugSwift.Network.shared.clearAllNetworkData()
+                            print("✅ All network data cleared!")
+                        }
+                    },
+                    .init(title: "Switch to Development") {
+                        // Your environment switch logic here
+                        print("🔄 Switching to Development...")
+                        DebugSwift.Network.shared.clearNetworkHistory()
+                        print("✅ Switched to Development & cleared network history")
+                    },
+                    .init(title: "Switch to Production") {
+                        // Your environment switch logic here
+                        print("🔄 Switching to Production...")
+                        DebugSwift.Network.shared.clearNetworkHistory()
+                        print("✅ Switched to Production & cleared network history")
+                    }
+                ]),
+                .init(title: "Development Tools", actions: [
+                    .init(title: "Clear UserDefaults") {
+                        // Example: Clear specific user data
+                        print("🗑️ UserDefaults cleared")
+                    },
+                    .init(title: "Reset App State") {
+                        print("🔄 App state reset")
+                    }
+                ])
+            ]
+        }
     }
     
     // MARK: - Push Notification Setup

--- a/README.md
+++ b/README.md
@@ -305,6 +305,35 @@ DebugSwift.Network.shared.ignoredURLs = ["https://analytics.com"]
 DebugSwift.Network.shared.onlyURLs = ["https://api.myapp.com"]
 ```
 
+### Network History Management
+
+```swift
+// Clear HTTP/HTTPS request history (useful when switching environments)
+DebugSwift.Network.shared.clearNetworkHistory()
+
+// Clear WebSocket connection history
+await DebugSwift.Network.shared.clearWebSocketHistory()
+
+// Clear all network data (HTTP + WebSocket)
+await DebugSwift.Network.shared.clearAllNetworkData()
+
+// Example: Clear network data when switching environments
+DebugSwift.App.shared.customAction = {
+    [
+        .init(title: "Environment", actions: [
+            .init(title: "Switch to Production") {
+                // Your environment switch logic
+                DebugSwift.Network.shared.clearNetworkHistory()
+            },
+            .init(title: "Switch to Development") {
+                // Your environment switch logic
+                DebugSwift.Network.shared.clearNetworkHistory()
+            }
+        ])
+    ]
+}
+```
+
 ### Manual URLSessionConfiguration Injection
 
 If you create `URLSessionConfiguration` instances **before** calling `DebugSwift.setup()`, you can manually inject the network monitoring protocol:


### PR DESCRIPTION
## Description
This PR adds methods to clear network request history when switching environments or testing different scenarios.

## Problem
Issue #232 reported that users couldn't clear network history when switching between different stands (dev/prod). The existing methods:
- `clearThresholdHistory()` - only cleared threshold breach data, not actual requests
- `disableRequestTracking()` - only disabled tracking, didn't clear existing data

## Solution
Added three new public methods to `DebugSwift.Network`:

### 1. `clearNetworkHistory()`
Clears all HTTP/HTTPS request history from the Network tab.

```swift
DebugSwift.Network.shared.clearNetworkHistory()
```

### 2. `clearWebSocketHistory()` (MainActor)
Clears all WebSocket connection and frame history.

```swift
await DebugSwift.Network.shared.clearWebSocketHistory()
```

### 3. `clearAllNetworkData()` (MainActor)
Convenience method that clears both HTTP and WebSocket history.

```swift
await DebugSwift.Network.shared.clearAllNetworkData()
```

## Changes
- ✅ Added `clearNetworkHistory()` to clear HTTP requests
- ✅ Added `clearWebSocketHistory()` to clear WebSocket data
- ✅ Added `clearAllNetworkData()` convenience method
- ✅ Updated README with usage examples
- ✅ Added custom action examples in Example app
- ✅ Build verified successfully

## Use Case Example
```swift
DebugSwift.App.shared.customAction = {
    [
        .init(title: "Environment Management", actions: [
            .init(title: "Switch to Production") {
                // Your environment switch logic
                DebugSwift.Network.shared.clearNetworkHistory()
            },
            .init(title: "Switch to Development") {
                // Your environment switch logic
                DebugSwift.Network.shared.clearNetworkHistory()
            }
        ])
    ]
}
```

Fixes #232