### PR TITLE
fix: Temporarily disable code coverage check due to xcresult format incompatibility

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -216,10 +216,17 @@ fileprivate extension UnitTestValidator {
     }
 
     func checkUnitTestCoverage() {
-        Coverage.xcodeBuildCoverage(
-            .xcresultBundle("Example/fastlane/test_output/Example.xcresult"),
-            minimumCoverage: 70,
-            excludedTargets: ["DangerSwiftCoverageTests.xctest"]
-        )
+        // Temporarily disabled due to xcresult format incompatibility with Xcode 16.4+
+        // Error: XCResultStorage.ResultBundleFactory.Error - Failed to read metadata
+        // The DangerSwiftCoverage plugin calls fail() internally (doesn't throw), causing CI to fail
+        // TODO: Re-enable when DangerSwiftCoverage supports Xcode 16.4+ or migrate to alternative
+        
+        warn("⚠️ Code coverage check is temporarily disabled due to xcresult format incompatibility. Please verify coverage manually in Xcode.")
+        
+        // Coverage.xcodeBuildCoverage(
+        //     .xcresultBundle("Example/fastlane/test_output/Example.xcresult"),
+        //     minimumCoverage: 70,
+        //     excludedTargets: ["DangerSwiftCoverageTests.xctest"]
+        // )
     }
 }


### PR DESCRIPTION
## Summary
Fixes the Danger bot failing with "The data couldn't be read because it isn't in the correct format" error.

## Problem
DangerSwiftCoverage plugin is incompatible with the newer Xcode 16.4 / xcresult format, causing Danger runs to fail completely when trying to read coverage data.

## Solution
- Temporarily disable the coverage check in Dangerfile
- Add warning message to remind developers to check coverage manually in Xcode
- Add TODO comment for re-enabling when plugin is updated

## Alternative Solutions Considered
1. Update DangerSwiftCoverage - but no recent updates available
2. Use xcov or slather - requires significant setup changes
3. Graceful error handling - Coverage.xcodeBuildCoverage doesn't throw errors

## Impact
- ✅ Danger bot will no longer fail on PRs
- ⚠️ Coverage must be verified manually in Xcode until this is re-enabled
- 📝 Added clear warning in Danger output

## Testing
- Verified locally that Danger can now run without crashing
- Coverage data still exists in Example.xcresult for manual inspection

## Follow-up
Track DangerSwiftCoverage updates or migrate to alternative coverage reporting in future PR.