### PR TITLE
updates to fix bug with placeholder directory for app groups

### DIFF
--- a/DebugSwift/Sources/Features/Resources/Files/Resources.Files.Controller.swift
+++ b/DebugSwift/Sources/Features/Resources/Files/Resources.Files.Controller.swift
@@ -183,7 +183,7 @@ final class ResourcesFilesViewController: BaseTableController {
                 return path
             } else {
                 // Show app group identifiers as "directories"
-                return NSTemporaryDirectory() // Placeholder path
+                return (NSTemporaryDirectory() as NSString).appendingPathComponent("DEBUGSWIFTAGPH") // Placeholder path
             }
         }
     }


### PR DESCRIPTION
Fix bug causing app groups paths are not showing up when files are present  in the NSTemporaryDirectory, which shows folders and files as AppGroups and masks all the correct AppGroups