### PR TITLE
Using existing version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/DebugSwift/DebugSwift.git", from: "2.0.0")
+    .package(url: "https://github.com/DebugSwift/DebugSwift.git", from: "1.0.0")
 ]
 ```
 


### PR DESCRIPTION
Hey! When testing out this package I just grabbed `.package(url: "https://github.com/DebugSwift/DebugSwift.git", from: "2.0.0")` from README and couldn’t build the app. Than I decided to check the latest version and found out that it 1-something. 

I think this small change to using `1.0.0` as the latest major version might help someone like me :) 