### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/git-version.yml
+++ b/.github/workflows/git-version.yml
@@ -40,13 +40,13 @@ jobs:
         xcode-version: '16.4'
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0
+      uses: gittools/actions/gitversion/setup@v4
       with:
         versionSpec: '5.x'
 
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v0
+      uses: gittools/actions/gitversion/execute@v4
 
     - name: Display GitVersion
       run: |


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `gittools/actions/gitversion/execute` | [`v0`](https://github.com/gittools/actions/gitversion/execute/releases/tag/v0) | [`v4`](https://github.com/gittools/actions/gitversion/execute/releases/tag/v4) | [Release](https://github.com/gittools/actions/gitversion/execute/releases/tag/v4) | git-version.yml |
| `gittools/actions/gitversion/setup` | [`v0`](https://github.com/gittools/actions/gitversion/setup/releases/tag/v0) | [`v4`](https://github.com/gittools/actions/gitversion/setup/releases/tag/v4) | [Release](https://github.com/gittools/actions/gitversion/setup/releases/tag/v4) | git-version.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
