### PR TITLE
fix: update GitVersion spec to 6.x for compatibility

### DIFF
--- a/.github/workflows/git-version.yml
+++ b/.github/workflows/git-version.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v4
       with:
-        versionSpec: '5.x'
+        versionSpec: '6.x'
 
     - name: Determine Version
       id: gitversion


### PR DESCRIPTION
## Summary

Fixed GitVersion compatibility issue in GitHub Actions workflow.

## Problem
The workflow was failing with error:


## Solution
- Updated GitVersion versionSpec from '5.x' to '6.x' in 
- The  action requires GitVersion 6.1.0 or higher
- This change ensures compatibility with the action's requirements

## Changes Made
- Modified  line 45:  → 

## Testing
- [x] GitHub Actions workflow should now run successfully without version compatibility errors