### PR TITLE
fix: update GitVersion.yml configuration for v6.x compatibility

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -18,7 +18,7 @@ branches:
   main:
     regex: ^main$|^master$
     mode: ContinuousDelivery
-    tag: ''
+    label: ''
     increment: Patch
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
@@ -29,7 +29,7 @@ branches:
   develop:
     regex: ^develop$|^dev$
     mode: ContinuousDelivery
-    tag: alpha
+    label: alpha
     increment: Minor
     prevent-increment-of-merged-branch-version: false
     track-merge-target: true
@@ -40,7 +40,7 @@ branches:
   release:
     regex: ^releases?[/-]
     mode: ContinuousDelivery
-    tag: beta
+    label: beta
     increment: None
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
@@ -51,7 +51,7 @@ branches:
   feature:
     regex: ^features?[/-]
     mode: ContinuousDelivery
-    tag: useBranchName
+    label: useBranchName
     increment: Inherit
     prevent-increment-of-merged-branch-version: false
     track-merge-target: false
@@ -62,7 +62,7 @@ branches:
   pull-request:
     regex: ^(pull|pull\-requests|pr)[/-]
     mode: ContinuousDelivery
-    tag: PullRequest
+    label: PullRequest
     increment: Inherit
     prevent-increment-of-merged-branch-version: false
     track-merge-target: false
@@ -73,7 +73,7 @@ branches:
   hotfix:
     regex: ^hotfix(es)?[/-]
     mode: ContinuousDelivery
-    tag: beta
+    label: beta
     increment: Patch
     prevent-increment-of-merged-branch-version: false
     track-merge-target: false


### PR DESCRIPTION
## Summary

Updated GitVersion.yml configuration to be compatible with GitVersion 6.x after upgrading from version 5.x.

## Problem
After updating GitVersion from 5.x to 6.x, the workflow fails with:


This happens because GitVersion 6.x renamed the  property to  in branch configurations.

## Solution
- Updated all  properties to  in branch configurations
- Maintains the same versioning behavior with the new property name
- Ensures compatibility with GitVersion 6.x

## Changes Made
Updated GitVersion.yml branch configurations:
- main branch:  → 
-  branch:  →   
-  branch:  → 
-  branch:  → 
-  branch:  → 
-  branch:  → 

## Testing
- [x] Configuration syntax is valid for GitVersion 6.x
- [ ] GitHub Actions workflow runs successfully without configuration errors

Made with [Cursor](https://cursor.com)