### PR TITLE
Fix NSRangeException when reopening floating debugger with UI measurements enabled

### DIFF
--- a/DebugSwift/Sources/Features/Interface/HyperionSwift/Measurement/Helpers/MeasurementWindowManager.swift
+++ b/DebugSwift/Sources/Features/Interface/HyperionSwift/Measurement/Helpers/MeasurementWindowManager.swift
@@ -110,7 +110,9 @@ final class MeasurementWindow: UIWindow {
                 let ballViewInScreen = ballView.convert(ballView.bounds, to: nil)
                 
                 if ballViewInScreen.contains(pointInScreen) {
-                    MeasurementWindowManager.attachedWindow = nil
+                    DispatchQueue.main.async {
+                        MeasurementWindowManager.attachedWindow = nil
+                    }
                     return false
                 }
             }


### PR DESCRIPTION
## Summary
This PR fixes a crash caused by reopening DebugSwift from the floating button while UI measurements is active.

## Crash
- **Exception:** `NSRangeException`
- **Reason:** `*** -[NSConcretePointerArray pointerAtIndex:]: attempt to access pointer at index 2 beyond bounds 2`

## Repro Steps
1. Enable **UI measurements**
2. Minimize DebugSwift to floating button
3. Tap floating button again

## Root Cause
`MeasurementWindowManager.attachedWindow` was being set to `nil` inside `MeasurementWindow.point(inside:with:)`.

This mutates measurement/window state during UIKit hit-testing and can trigger internal pointer-array re-entrancy issues.

## Fix
Defer measurement deactivation to the next main run-loop tick instead of mutating state synchronously inside hit-testing.

### Before
```swift
MeasurementWindowManager.attachedWindow = nil
```
after
```swift
DispatchQueue.main.async {
    MeasurementWindowManager.attachedWindow = nil
}
```
Files Changed
MeasurementWindowManager.swift

Crash report from DebugSwift:
[Crash-9ACCCC1B-0982-4742-8EDC-C49589B25971.pdf](https://github.com/user-attachments/files/25598240/Crash-9ACCCC1B-0982-4742-8EDC-C49589B25971.pdf)
