### PR TITLE
fix: missing network injection menu icon on iOS 15 (Main + Detail views)

### DIFF
--- a/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
+++ b/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
@@ -34,7 +34,7 @@ final class NetworkViewControllerDetail: BaseTableController {
         title = "Request Details"
         navigationItem.rightBarButtonItems = [
             UIBarButtonItem(
-                image: UIImage(systemName: "syringe"),
+                image: injectionSymbolImage(),
                 style: .plain,
                 target: self,
                 action: #selector(configureInjectionForEndpoint)
@@ -64,6 +64,14 @@ final class NetworkViewControllerDetail: BaseTableController {
                 action: #selector(replayButtonTapped)
             )
         ]
+    }
+
+    private func injectionSymbolImage() -> UIImage? {
+        if #available(iOS 16.0, *) {
+            return UIImage(systemName: "syringe")
+        }
+
+        return UIImage(systemName: "pencil")
     }
     
     @objc private func configureInjectionForEndpoint() {

--- a/DebugSwift/Sources/Features/Network/Main/Network.Controller.swift
+++ b/DebugSwift/Sources/Features/Network/Main/Network.Controller.swift
@@ -587,7 +587,7 @@ final class NetworkViewController: BaseController, MainFeatureType {
         case .http, .webview:
             // Add network injection settings button
             let injectionButton = UIBarButtonItem(
-                image: UIImage(systemName: "syringe"),
+                image: injectionSymbolImage(),
                 style: .plain,
                 target: self,
                 action: #selector(showNetworkInjectionSettings)
@@ -655,6 +655,14 @@ final class NetworkViewController: BaseController, MainFeatureType {
         }
         
         navigationItem.rightBarButtonItems = rightBarButtons
+    }
+
+    private func injectionSymbolImage() -> UIImage? {
+        if #available(iOS 16.0, *) {
+            return UIImage(systemName: "syringe")
+        }
+
+        return UIImage(systemName: "pencil")
     }
     
     @objc private func showNetworkInjectionSettings() {


### PR DESCRIPTION
## Summary
This PR fixes the missing injection menu button icon on iOS 15 in both Network screens:
- Network Main View
- Network Request Detail View

## What Changed
- Replaced direct `UIImage(systemName: "syringe")` usage with a compatibility helper in both controllers.
- Added `injectionSymbolImage()` to return:
  - iOS 16+: `syringe`
  - iOS 15 fallback: `pencil`

## Why
The `syringe` SF Symbol is not available on iOS 15, causing the injection menu icon to be missing.  
This update ensures the action remains visible and accessible on older OS versions.

## Scope
- `DebugSwift/Sources/Features/Network/Main/Network.Controller.swift`
- `DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift`

## Testing
- Verified icon appears on iOS 15 in:
  - Network Main View
  - Network Request Detail View
- Verified `syringe` icon is still used on iOS 16+.

Before:

<img width="750" height="1334" alt="IMG_0345" src="https://github.com/user-attachments/assets/2bbc5da7-138f-4205-9153-e753535d76f1" />

After:

<img width="750" height="1334" alt="IMG_0346" src="https://github.com/user-attachments/assets/0fe64de8-80fc-4b68-bfea-b5ee45d2d908" />
