### PR TITLE
feat: Add response code rewrite and save rules on UserDefault

### DIFF
--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
@@ -245,16 +245,24 @@ public struct NetworkFailureConfig: Sendable {
 }
 
 /// A single response body rewrite rule.
-public struct ResponseBodyRewriteRule: Sendable, Equatable {
+public struct ResponseBodyRewriteRule: Sendable, Equatable, Codable {
     /// URL pattern to match (supports wildcard `*` and `?`)
     public var urlPattern: String
     
     /// Replacement response body text
     public var responseBody: String
     
-    public init(urlPattern: String, responseBody: String) {
+    /// Optional HTTP status code override for rewritten response
+    public var responseStatusCode: Int?
+    
+    public init(
+        urlPattern: String,
+        responseBody: String,
+        responseStatusCode: Int? = nil
+    ) {
         self.urlPattern = urlPattern
         self.responseBody = responseBody
+        self.responseStatusCode = responseStatusCode
     }
 }
 

--- a/Example/ExampleTests/Tests/Features/Network/Helpers/NetworkInjectionConfigTests.swift
+++ b/Example/ExampleTests/Tests/Features/Network/Helpers/NetworkInjectionConfigTests.swift
@@ -462,6 +462,37 @@ final class NetworkInjectionConfigTests: XCTestCase {
         XCTAssertNil(config.matchingRule(for: request))
     }
     
+    func testResponseBodyRewriteConfigContainsStatusCodeOverride() {
+        let config = ResponseBodyRewriteConfig(
+            isEnabled: true,
+            rules: [
+                ResponseBodyRewriteRule(
+                    urlPattern: "https://api.example.com/users/*",
+                    responseBody: "{\"mocked\":true}",
+                    responseStatusCode: 418
+                )
+            ]
+        )
+        
+        let request = URLRequest(url: URL(string: "https://api.example.com/users/1")!)
+        let matched = config.matchingRule(for: request)
+        
+        XCTAssertEqual(matched?.responseStatusCode, 418)
+    }
+    
+    func testResponseBodyRewriteRuleCodableRoundTrip() throws {
+        let rule = ResponseBodyRewriteRule(
+            urlPattern: "https://api.example.com/users/*",
+            responseBody: "{\"mocked\":true}",
+            responseStatusCode: 202
+        )
+        
+        let encoded = try JSONEncoder().encode(rule)
+        let decoded = try JSONDecoder().decode(ResponseBodyRewriteRule.self, from: encoded)
+        
+        XCTAssertEqual(decoded, rule)
+    }
+    
     // MARK: - URL Wildcard Matcher Real-world Scenarios
     
     func testURLWildcardSubsetMatchesCheckoutURLWithTrackingParamsAndSession() {

--- a/Example/ExampleTests/Tests/Features/Network/Helpers/NetworkInjectionManagerTests.swift
+++ b/Example/ExampleTests/Tests/Features/Network/Helpers/NetworkInjectionManagerTests.swift
@@ -202,7 +202,8 @@ final class NetworkInjectionManagerTests: XCTestCase {
     func testSetRewriteConfig() {
         let rule = ResponseBodyRewriteRule(
             urlPattern: "https://api.example.com/*",
-            responseBody: "{\"ok\":true}"
+            responseBody: "{\"ok\":true}",
+            responseStatusCode: 201
         )
         let config = ResponseBodyRewriteConfig(isEnabled: true, rules: [rule])
         
@@ -211,6 +212,7 @@ final class NetworkInjectionManagerTests: XCTestCase {
         let retrieved = manager.getRewriteConfig()
         XCTAssertTrue(retrieved.isEnabled)
         XCTAssertEqual(retrieved.rules, [rule])
+        XCTAssertEqual(retrieved.rules.first?.responseStatusCode, 201)
     }
     
     func testMatchingRewriteRule() {
@@ -229,5 +231,20 @@ final class NetworkInjectionManagerTests: XCTestCase {
         let matched = manager.matchingRewriteRule(for: request)
         
         XCTAssertEqual(matched, secondRule)
+    }
+    
+    func testRewriteRulesRemainWhenRewriteIsDisabled() {
+        let rule = ResponseBodyRewriteRule(
+            urlPattern: "https://api.example.com/*",
+            responseBody: "{\"ok\":true}",
+            responseStatusCode: 200
+        )
+        
+        manager.setRewriteConfig(ResponseBodyRewriteConfig(isEnabled: true, rules: [rule]))
+        manager.setRewriteConfig(ResponseBodyRewriteConfig(isEnabled: false, rules: [rule]))
+        
+        let retrieved = manager.getRewriteConfig()
+        XCTAssertFalse(retrieved.isEnabled)
+        XCTAssertEqual(retrieved.rules, [rule])
     }
 }


### PR DESCRIPTION
## Summary

- Added optional HTTP status code override support to response body rewrite rules.
- Persisted rewrite rules in `UserDefaults` so rules survive app restarts while keeping enable/disable state session-based.
- Updated network interception flow to rewrite response metadata (status code + headers) when a rewrite rule is matched.
- Improved rewrite rule editor UI to capture optional status code input with validation (100-599).
- Added/updated tests for rewrite rule codable round-trip, status code matching, manager behavior, and disabled-state rule retention.

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [x] Unit tests updated
- [ ] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Open Network Injection settings, add a rewrite rule with URL/pattern, body, and optional status code (e.g. `418`), then save.
2. Trigger a request matching the configured pattern and verify rewritten body is returned with overridden status code.
3. Disable rewrite injection, return to settings, and verify previously added rewrite rules are still present.

## Screenshots / recordings (if applicable)

![ezgif-1dcaa18b1f068360](https://github.com/user-attachments/assets/500fbc96-97d1-40fb-bac5-a01602c95a57)

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility