### PR TITLE
feat: Add request param menu

### DIFF
--- a/DebugSwift/Sources/Features/Network/Details/HeadersViewController.swift
+++ b/DebugSwift/Sources/Features/Network/Details/HeadersViewController.swift
@@ -97,7 +97,7 @@ final class HeadersViewController: BaseTableController {
         let search = UISearchController(searchResultsController: nil)
         search.searchResultsUpdater = self
         search.obscuresBackgroundDuringPresentation = false
-        search.searchBar.placeholder = "Search headers..."
+        search.searchBar.placeholder = "Search key or value..."
         search.hidesNavigationBarDuringPresentation = false
         
         navigationItem.searchController = search
@@ -257,4 +257,3 @@ final class HeaderCell: UITableViewCell {
         }
     }
 }
-

--- a/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
+++ b/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
@@ -266,7 +266,7 @@ final class NetworkViewControllerDetail: BaseTableController {
         case .showRequestHeaders:
             showHeaders(model.requestHeaderFields, title: "Request Headers")
         case .showRequestQueryParams:
-            showHeaders(parsedRequestQueryParams(), title: "Request Params")
+            showHeaders(parsedRequestQueryParams(), title: "Request Query Params")
         case .showResponseHeaders:
             showHeaders(model.responseHeaderFields, title: "Response Headers")
         case .showRequestBody:
@@ -428,7 +428,7 @@ extension NetworkViewControllerDetail {
             let queryItems = model.url
                 .flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false)?.queryItems } ?? []
             if !queryItems.isEmpty {
-                requestItems.append(DetailItem(title: "Request Params", action: .showRequestQueryParams, badge: "\(queryItems.count)"))
+                requestItems.append(DetailItem(title: "Request Query Params", action: .showRequestQueryParams, badge: "\(queryItems.count)"))
             }
             
             if let requestData = model.requestData, !requestData.isEmpty {


### PR DESCRIPTION
## Summary

- Add request-query-parameter navigation in `NetworkViewControllerDetail` so users can inspect URL query parameters from request details.
- Show a new `Request Params` row in the `REQUEST` section only when query items exist.
- Display the number of query params as a badge.
- Reuse `HeadersViewController` to present parsed query params and handle duplicate keys with indexed labels (e.g. `key [2]`).

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Open DebugSwift network logs and tap a request that includes URL query params.
2. In the `REQUEST` section, tap `Request Params` and verify key/value rows render correctly.
3. Validate requests with no query params do not show the `Request Params` row.

## Screenshots / recordings (if applicable)

![QuickTime movie](https://github.com/user-attachments/assets/f6af79f4-5fd3-4bcd-8c21-6daa91fad486)

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility
