### PR TITLE
fix: add conditional scroll and reload table on network controller

### DIFF
--- a/DebugSwift/Sources/Features/Network/Main/Network.Controller.swift
+++ b/DebugSwift/Sources/Features/Network/Main/Network.Controller.swift
@@ -167,7 +167,7 @@ final class NetworkViewController: BaseController, MainFeatureType {
             let success = notification.object as? Bool ?? false
             MainActor.assumeIsolated {
                 self?.reloadHttp(
-                    needScrollToEnd: self?.viewModel.reachEnd ?? true,
+                    needScrollToEnd: (self?.viewModel.isReachEnd ?? true) && self?.view.window != nil,
                     success: success
                 )
                 self?.updateHTTPStatistics()
@@ -944,5 +944,13 @@ extension NetworkViewController: UITableViewDelegate, UITableViewDataSource {
             
             return UISwipeActionsConfiguration(actions: actions)
         }
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard currentMode == .http || currentMode == .webview else { return }
+        let offsetY = scrollView.contentOffset.y
+        let contentHeight = scrollView.contentSize.height
+        let visibleHeight = scrollView.frame.height
+        viewModel.isReachEnd = offsetY >= max(0, contentHeight - visibleHeight)
     }
 }

--- a/DebugSwift/Sources/Features/Network/Main/Network.ViewModel.swift
+++ b/DebugSwift/Sources/Features/Network/Main/Network.ViewModel.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 final class NetworkViewModel {
-    var reachEnd = true
+    var isReachEnd = true
     var firstIn = true
     var reloadDataFinish = true
 


### PR DESCRIPTION
## Summary

Issue #294 : Cause high cpu load caused by auto scroll behavior. Some fixing approach:
- Fix `NetworkViewController` auto-scroll behavior so `scrollToBottom()` does not run when the view is not visible  (view.window != nil)

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Open Network screen and generate continuous HTTP/WebView traffic.
2. Scroll the table while new items arrive and confirm no forced jump-to-bottom during user interaction.
3. Navigate away from Network screen while traffic continues and confirm no visible reload/scroll side effects.
4. Use WebView-heavy flows (including SPA navigation) and confirm reduced CPU spikes with events still captured.

## Screenshots / recordings (if applicable)

<!-- Add visuals when UI or behavior changes -->

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Run high traffic request
2. Open Network Controller
3. Minimize
4. Monitor CPU using instrument

## Screenshots / recordings (if applicable)

<!-- Add visuals when UI or behavior changes -->

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [ ] I considered backward compatibility
