### PR TITLE
fix: memory leak in CustomHTTPProtocol

### DIFF
--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -240,6 +240,10 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             task.cancel()
             dataTask = nil
         }
+        
+        // Invalidate session to break retain cycle
+        session?.invalidateAndCancel()
+        session = nil
 
         Task { @Sendable in
             guard await NetworkHelper.shared.isNetworkEnable else {
@@ -483,6 +487,10 @@ extension CustomHTTPProtocol: URLSessionDataDelegate {
                     didFailWithError: error
                 )
                 self.client?.urlProtocol(self, didFailWithError: error)
+                
+                // Invalidate session to break retain cycle
+                self.session?.finishTasksAndInvalidate()
+                self.session = nil
                 return
             }
             
@@ -503,6 +511,10 @@ extension CustomHTTPProtocol: URLSessionDataDelegate {
             if self.cachePolicy == .allowed {
                 URLCache.customHttp.storeIfNeeded(for: task, data: self.data)
             }
+            
+            // Invalidate session to break retain cycle
+            self.session?.finishTasksAndInvalidate()
+            self.session = nil
         }
     }
 }


### PR DESCRIPTION
## Summary

Thanks @lifution for find this bug:

Before
<img width="200" alt="Screenshot 2026-03-05 at 01 54 12" src="https://github.com/user-attachments/assets/24b9ac90-9543-4af3-9e01-2e038eec1d11" />

After
<img width="200" alt="Screenshot 2026-03-05 at 01 55 44" src="https://github.com/user-attachments/assets/f65263b1-7fef-4256-b59d-72d8442ada17" />



- Fixed memory leak caused by retain cycle in `CustomHTTPProtocol`
- URLSession was holding a strong reference to `self` as delegate, preventing deallocation
- Added session invalidation to break the retain cycle when requests complete or are cancelled

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Run the app with network monitoring enabled
2. Perform multiple network requests
3. Verify that `CustomHTTPProtocol` instances are properly deallocated after requests complete
4. Check memory usage doesn't grow unbounded with repeated requests

## Technical Details

**Root cause:** `URLSession` retains its delegate strongly, creating a cycle:
- `CustomHTTPProtocol` → `session` (strong)
- `session` → delegate (`self`) (strong)

**Solution:** Invalidate the session when done:
- Call `session?.invalidateAndCancel()` in `stopLoading()` (immediate cancellation)
- Call `session?.finishTasksAndInvalidate()` in `didCompleteWithError` (after completion)

This follows Apple's recommended pattern and is simpler than introducing a delegate wrapper class.

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility

Made with [Cursor](https://cursor.com)