### PR TITLE
fix: replace octokit/request-action with gh CLI in manual release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -30,26 +30,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
-    - name: Get latest release
-      uses: octokit/request-action@v2.x
-      id: get_release
-      continue-on-error: true
-      with:
-        route: GET /repos/:repository/releases/latest
-        repository: ${{ github.repository }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Extract previous tag
       id: previous_tag
       run: |
-        if [ "${{ steps.get_release.outcome }}" == "success" ]; then
-          json='${{ steps.get_release.outputs.data }}'
-          tag=$(echo "$json" | grep -o '"tag_name": *"[^"]*"' | awk -F'"' '{print $4}')
-          echo "PREVIOUS_TAG=$tag" >> $GITHUB_OUTPUT
-        else
-          echo "PREVIOUS_TAG=" >> $GITHUB_OUTPUT
-        fi
+        tag=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
+        echo "PREVIOUS_TAG=$tag" >> $GITHUB_OUTPUT
+        echo "Previous tag: $tag"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract version from tag
       id: extract_version


### PR DESCRIPTION
## Summary

- Replace `octokit/request-action@v2.x` with `gh api` CLI call to fetch the latest release tag
- The previous approach inlined raw JSON into bash via `${{ steps.get_release.outputs.data }}`, which broke when the JSON body contained parentheses (e.g., `(#303)`) — causing `syntax error near unexpected token '('`
- This also eliminates the Node.js 20 deprecation warning from the `octokit/request-action`

Fixes: https://github.com/DebugSwift/DebugSwift/actions/runs/23800485584/job/69359235711

## Type of change

- [x] Fix
- [x] CI/CD

## Test plan

- [ ] CI passing
- [ ] Re-run the Manual Release workflow and verify it passes the "Extract previous tag" step

## Checklist

- [x] I reviewed my own changes
- [x] I considered backward compatibility

Made with [Cursor](https://cursor.com)