### PR TITLE
fix float ball position when changing landscape

### DIFF
--- a/DebugSwift/Sources/Helpers/FloatingButton/Helpers/FloatBallPositionHelper.swift
+++ b/DebugSwift/Sources/Helpers/FloatingButton/Helpers/FloatBallPositionHelper.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 enum FloatBallPositionHelper {
     private enum Layout {
         static let minLeadingCenterX: CGFloat = 20

--- a/DebugSwift/Sources/Helpers/FloatingButton/Helpers/FloatBallPositionHelper.swift
+++ b/DebugSwift/Sources/Helpers/FloatingButton/Helpers/FloatBallPositionHelper.swift
@@ -1,0 +1,106 @@
+import UIKit
+
+enum FloatBallPositionHelper {
+    private enum Layout {
+        static let minLeadingCenterX: CGFloat = 20
+        static let minTrailingInset: CGFloat = 20
+        static let minTopCenterY: CGFloat = 80
+        static let minBottomInset: CGFloat = 100
+    }
+
+    private static var savedX: Double {
+        get {
+            UserDefaults.standard.double(forKey: "debug_swift_float_ball_x") != 0
+                ? UserDefaults.standard.double(forKey: "debug_swift_float_ball_x")
+                : 20
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "debug_swift_float_ball_x")
+        }
+    }
+
+    private static var savedY: Double {
+        get {
+            UserDefaults.standard.double(forKey: "debug_swift_float_ball_y") != 0
+                ? UserDefaults.standard.double(forKey: "debug_swift_float_ball_y")
+                : (UIScreen.main.bounds.height / 2 - 80.0)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "debug_swift_float_ball_y")
+        }
+    }
+
+    static func restoreSavedPosition(in window: UIWindow) -> CGPoint {
+        let position = clampedSavedPosition(in: window)
+        persist(position)
+        return position
+    }
+
+    static func finalizedDragPosition(from currentPosition: CGPoint, in window: UIWindow) -> CGPoint {
+        let clamped = clampedPosition(currentPosition, in: window)
+        let targetRange = centerXRange(in: window)
+        let targetX =
+            clamped.x <= window.bounds.width / 2
+            ? targetRange.lowerBound
+            : targetRange.upperBound
+
+        let targetPosition = clampedPosition(
+            .init(x: targetX, y: clamped.y),
+            in: window
+        )
+        persist(targetPosition)
+        return targetPosition
+    }
+
+    static func hiddenBottomFrame(in window: UIWindow) -> CGRect {
+        .init(
+            x: window.bounds.width,
+            y: window.bounds.height,
+            width: DSFloatChat.bottomViewFloatWidth,
+            height: DSFloatChat.bottomViewFloatHeight
+        )
+    }
+
+    static func visibleBottomFrame(in window: UIWindow) -> CGRect {
+        .init(
+            x: window.bounds.width - DSFloatChat.bottomViewFloatWidth,
+            y: window.bounds.height - DSFloatChat.bottomViewFloatHeight,
+            width: DSFloatChat.bottomViewFloatWidth,
+            height: DSFloatChat.bottomViewFloatHeight
+        )
+    }
+
+    private static func clampedSavedPosition(in window: UIWindow) -> CGPoint {
+        clampedPosition(.init(x: savedX, y: savedY), in: window)
+    }
+
+    private static func persist(_ position: CGPoint) {
+        savedX = Double(position.x)
+        savedY = Double(position.y)
+    }
+
+    private static func clampedPosition(_ position: CGPoint, in window: UIWindow) -> CGPoint {
+        let horizontalRange = centerXRange(in: window)
+        let verticalRange = centerYRange(in: window)
+
+        return CGPoint(
+            x: min(max(position.x, horizontalRange.lowerBound), horizontalRange.upperBound),
+            y: min(max(position.y, verticalRange.lowerBound), verticalRange.upperBound)
+        )
+    }
+
+    private static func centerXRange(in window: UIWindow) -> ClosedRange<CGFloat> {
+        let minX = window.safeAreaInsets.left + Layout.minLeadingCenterX
+        let maxX = window.bounds.width - window.safeAreaInsets.right - Layout.minTrailingInset
+        return minX...max(minX, maxX)
+    }
+
+    private static func centerYRange(in window: UIWindow) -> ClosedRange<CGFloat> {
+        let minY = max(Layout.minTopCenterY, window.safeAreaInsets.top + Layout.minLeadingCenterX)
+        let maxY = max(
+            minY,
+            window.bounds.height - max(Layout.minBottomInset, window.safeAreaInsets.bottom + 44)
+        )
+        return minY...maxY
+    }
+}

--- a/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
+++ b/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
@@ -27,39 +27,13 @@ class FloatBallView: UIView {
     lazy var label: UILabel = buildLabel()
     lazy var ballView: UIView = buildBallView()
 
-    // MARK: - Storage
-    private static var savedX: Double {
-        get {
-            UserDefaults.standard.double(forKey: "debug_swift_float_ball_x") != 0 
-                ? UserDefaults.standard.double(forKey: "debug_swift_float_ball_x") 
-                : 20
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: "debug_swift_float_ball_x")
-        }
-    }
-    
-    private static var savedY: Double {
-        get {
-            UserDefaults.standard.double(forKey: "debug_swift_float_ball_y") != 0 
-                ? UserDefaults.standard.double(forKey: "debug_swift_float_ball_y") 
-                : (UIScreen.main.bounds.height / 2 - 80.0)
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: "debug_swift_float_ball_y")
-        }
-    }
-
     var show = false {
         didSet {
             guard oldValue != show else { return }
             if show {
                 label.text = "0"
                 WindowManager.window.addSubview(self)
-                layer.position = .init(
-                    x: Self.savedX,
-                    y: Self.savedY
-                )
+                restoreSavedPosition()
                 alpha = .zero
                 UIView.animate(withDuration: DSFloatChat.animationDuration) {
                     self.alpha = 1.0
@@ -162,6 +136,10 @@ class FloatBallView: UIView {
 
     func reset() {
         label.text = "0"
+    }
+
+    private func restoreSavedPosition() {
+        layer.position = FloatBallPositionHelper.restoreSavedPosition(in: WindowManager.window)
     }
 }
 
@@ -283,27 +261,14 @@ extension FloatBallView {
             delegate?.floatViewMoved(floatView: self, point: .init(x: x, y: y))
         case .ended, .cancelled:
             let velocityPoint = pan.velocity(in: self)
-            let bounds = UIScreen.main.bounds
-
-            let targetX: CGFloat
-            if layer.position.x <= bounds.width / 2 {
-                targetX = 20
-            } else {
-                targetX = bounds.width - 20
-            }
-
-            var targetY = layer.position.y
-            if targetY < 80 {
-                targetY = 80
-            } else if targetY > bounds.height - 100 {
-                targetY = bounds.height - 100
-            }
+            let window = WindowManager.window
 
             delegate?.floatViewCancelMove(floatView: self)
-            
-            // Save the final position
-            Self.savedX = Double(targetX)
-            Self.savedY = Double(targetY)
+
+            let targetPosition = FloatBallPositionHelper.finalizedDragPosition(
+                from: layer.position,
+                in: window
+            )
 
             UIView.animate(
                 withDuration: 0.5,
@@ -312,7 +277,7 @@ extension FloatBallView {
                 initialSpringVelocity: abs(velocityPoint.x / layer.position.x),
                 options: [],
                 animations: {
-                    self.layer.position = CGPoint(x: targetX, y: targetY)
+                    self.layer.position = targetPosition
                 }
             )
         default:

--- a/DebugSwift/Sources/Helpers/Managers/FloatViewManager.swift
+++ b/DebugSwift/Sources/Helpers/Managers/FloatViewManager.swift
@@ -99,12 +99,7 @@ final class FloatViewManager: NSObject {
 
 extension FloatViewManager {
     private func setup() {
-        ballRedCancelView.frame = .init(
-            x: DSFloatChat.screenWidth,
-            y: DSFloatChat.screenHeight,
-            width: DSFloatChat.bottomViewFloatWidth,
-            height: DSFloatChat.bottomViewFloatHeight
-        )
+        ballRedCancelView.frame = FloatBallPositionHelper.hiddenBottomFrame(in: WindowManager.window)
         ballRedCancelView.type = BottomFloatViewType.red
         WindowManager.window.addSubview(ballRedCancelView)
 
@@ -143,11 +138,8 @@ extension FloatViewManager: FloatViewDelegate {
         UIView.animate(
             withDuration: 0.2,
             animations: {
-                self.ballRedCancelView.frame = CGRect(
-                    x: DSFloatChat.screenWidth - DSFloatChat.bottomViewFloatWidth,
-                    y: DSFloatChat.screenHeight - DSFloatChat.bottomViewFloatHeight,
-                    width: DSFloatChat.bottomViewFloatWidth,
-                    height: DSFloatChat.bottomViewFloatHeight
+                self.ballRedCancelView.frame = FloatBallPositionHelper.visibleBottomFrame(
+                    in: WindowManager.window
                 )
             }
         ) { _ in
@@ -193,11 +185,8 @@ extension FloatViewManager: FloatViewDelegate {
         UIView.animate(
             withDuration: DSFloatChat.animationCancelMoveDuration,
             animations: {
-                self.ballRedCancelView.frame = .init(
-                    x: DSFloatChat.screenWidth,
-                    y: DSFloatChat.screenHeight,
-                    width: DSFloatChat.bottomViewFloatWidth,
-                    height: DSFloatChat.bottomViewFloatHeight
+                self.ballRedCancelView.frame = FloatBallPositionHelper.hiddenBottomFrame(
+                    in: WindowManager.window
                 )
             }
         ) { _ in

--- a/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
+++ b/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
@@ -125,6 +125,18 @@ enum WindowManager {
 }
 
 final class CustomWindow: UIWindow {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        for subview in subviews {
+            if let ballView = subview as? FloatBallView {
+                ballView.layer.position = FloatBallPositionHelper.restoreSavedPosition(in: self)
+            } else if let bottomView = subview as? BottomFloatView {
+                bottomView.frame = FloatBallPositionHelper.hiddenBottomFrame(in: self)
+            }
+        }
+    }
+
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         if WindowManager.isSelectingWindow { return true }
 


### PR DESCRIPTION
## What changed
- Extracted float-ball position persistence and clamping into a helper.
- Restore the saved float-ball position on window layout updates.
- Keep the bottom cancel view aligned off-screen when hidden.

## Why
The float-ball position logic was spread across the view and manager, which made it easy to drift during layout changes and rotation.

## Impact
- Float ball position persists across launches and stays within safe-area bounds.
- Layout changes keep the float ball and cancel view aligned.

https://github.com/user-attachments/assets/118078b0-4ef8-4b32-8d94-c9e953ef4edf


Fixes #333
