### PR TITLE
feat: Support browsing .store databases

### DIFF
--- a/DebugSwift/Sources/Features/Resources/Database/DatabaseBrowserViewModel.swift
+++ b/DebugSwift/Sources/Features/Resources/Database/DatabaseBrowserViewModel.swift
@@ -175,10 +175,11 @@ enum DatabaseType: Hashable {
             return .coreData
         }
         
-        if lowercased.hasSuffix(".sqlite") || 
+        if lowercased.hasSuffix(".sqlite") ||
            lowercased.hasSuffix(".sqlite3") ||
            lowercased.hasSuffix(".db") ||
-           lowercased.hasSuffix(".sqlitedb") {
+           lowercased.hasSuffix(".sqlitedb") ||
+           lowercased.hasSuffix(".store") {
             return .sqlite
         } else if lowercased.hasSuffix(".realm") {
             return .realm


### PR DESCRIPTION
## Summary
- recognize `.store` files in the existing Database Browser file discovery logic
- treat SwiftData store files as SQLite databases so they can be inspected with the current browser

## Why
SwiftData persists to SQLite-backed `.store` files, but the current browser only discovers `.sqlite`, `.sqlite3`, `.db`, and `.sqlitedb`. That keeps existing database inspection UI from surfacing SwiftData stores at all.

This is a small compatibility step toward broader SwiftData support discussed in #311, without introducing a separate SwiftData-specific browser.

## validation

Show `.store` files in Database Browser.
<img width="1640" height="2360" alt="image" src="https://github.com/user-attachments/assets/2b286c57-e002-419b-b27c-6f5db4e37924" />

