### PR TITLE
feat: enhance database deduplication with symlink support

### DIFF
--- a/DebugSwift/Sources/Features/Resources/Database/DatabaseBrowserViewModel.swift
+++ b/DebugSwift/Sources/Features/Resources/Database/DatabaseBrowserViewModel.swift
@@ -93,7 +93,21 @@ final class DatabaseFileManager: @unchecked Sendable {
         let tmpPath = NSTemporaryDirectory()
         databaseFiles.append(contentsOf: findDatabaseFiles(in: tmpPath))
         
-        return databaseFiles.sorted { $0.name < $1.name }
+        return deduplicateDatabaseFiles(databaseFiles).sorted {
+            if $0.name == $1.name {
+                return $0.path < $1.path
+            }
+            return $0.name < $1.name
+        }
+    }
+
+    private func deduplicateDatabaseFiles(_ databaseFiles: [DatabaseFile]) -> [DatabaseFile] {
+        var seenPaths = Set<String>()
+
+        return databaseFiles.filter { databaseFile in
+            let normalizedPath = URL(fileURLWithPath: databaseFile.path).resolvingSymlinksInPath().standardized.path
+            return seenPaths.insert(normalizedPath).inserted
+        }
     }
     
     private func findDatabaseFiles(in directory: String) -> [DatabaseFile] {
@@ -126,7 +140,7 @@ final class DatabaseFileManager: @unchecked Sendable {
 
 // MARK: - Models
 
-struct DatabaseFile {
+struct DatabaseFile: Equatable {
     let name: String
     let path: String
     let type: DatabaseType

--- a/Example/ExampleTests/Tests/Features/Resources/Database/DatabaseFileManagerTests.swift
+++ b/Example/ExampleTests/Tests/Features/Resources/Database/DatabaseFileManagerTests.swift
@@ -1,0 +1,85 @@
+//
+//  DatabaseFileManagerTests.swift
+//  ExampleTests
+//
+//  Tests for database file discovery de-duplication via indirect integration testing
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class DatabaseFileManagerTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        cleanupTestFiles()
+    }
+
+    override func tearDown() {
+        cleanupTestFiles()
+        super.tearDown()
+    }
+
+    func testDiscoverDatabaseFilesDeduplicatesEquivalentPaths() {
+        let manager = DatabaseFileManager.shared
+        let fileManager = FileManager.default
+        
+        // Search in standard directories used by DatabaseFileManager
+        guard let cachesPath = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first,
+              let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first else {
+            XCTFail("Failed to get standard directories")
+            return
+        }
+        
+        let dbName = "TestDeduplicate.db"
+        let realDBPath = (cachesPath as NSString).appendingPathComponent(dbName)
+        let symlinkPath = (documentsPath as NSString).appendingPathComponent("SymlinkDeduplicate.db")
+        
+        // Create a real database file in Caches
+        fileManager.createFile(atPath: realDBPath, contents: Data("dummy db".utf8), attributes: nil)
+        
+        // Create a symbolic link in Documents pointing to the Caches DB
+        // Both directories are searched by DatabaseFileManager.discoverDatabaseFiles()
+        do {
+            try fileManager.createSymbolicLink(atPath: symlinkPath, withDestinationPath: realDBPath)
+        } catch {
+            XCTFail("Failed to create symlink: \(error)")
+            return
+        }
+        
+        // Verify both exist on disk
+        XCTAssertTrue(fileManager.fileExists(atPath: realDBPath))
+        XCTAssertTrue(fileManager.fileExists(atPath: symlinkPath))
+        
+        // Execute discovery - this internally calls the private deduplicateDatabaseFiles method
+        let discoveredFiles = manager.discoverDatabaseFiles()
+        
+        // Verify deduplication results
+        let testDBs = discoveredFiles.filter { $0.name == dbName || $0.name == "SymlinkDeduplicate.db" }
+        
+        // If deduplication works correctly (resolving symlinks to original paths),
+        // only one entry should remain because both paths point to the same file.
+        XCTAssertEqual(testDBs.count, 1, "Discovered files should be deduplicated")
+        
+        // Either the symlink or the real path might be kept depending on search order
+        let remainingPath = testDBs.first?.path
+        XCTAssertTrue(remainingPath == realDBPath || remainingPath == symlinkPath, 
+                      "The remaining file path should be either the real path or the symlink path")
+    }
+
+    private func cleanupTestFiles() {
+        let fileManager = FileManager.default
+        let cachesPath = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first
+        let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first
+        
+        if let cachesPath = cachesPath {
+            let realDBPath = (cachesPath as NSString).appendingPathComponent("TestDeduplicate.db")
+            try? fileManager.removeItem(atPath: realDBPath)
+        }
+        
+        if let documentsPath = documentsPath {
+            let symlinkPath = (documentsPath as NSString).appendingPathComponent("SymlinkDeduplicate.db")
+            try? fileManager.removeItem(atPath: symlinkPath)
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- Feature: Added support for resolving symbolic links using `resolvingSymlinksInPath()` during database file discovery. This ensures that symbolic links and their target files are correctly identified as duplicates.
- Testing: Added a new test suite (`DatabaseFileManagerTests.swift`) that creates real files and symbolic links in the iOS Simulator's directories to verify the deduplication logic indirectly.

## Verification
- Successfully ran the integration tests on an iOS 16.2 simulator using `xcodebuild`.
- Verified that `discoverDatabaseFiles()` properly deduplicates files even when different paths (symbolic links) point to the same physical file.
Before:
<img width="1640" height="2360" alt="image" src="https://github.com/user-attachments/assets/2b286c57-e002-419b-b27c-6f5db4e37924" />

After:
<img width="1640" height="2360" alt="image" src="https://github.com/user-attachments/assets/372b9701-4c70-4905-b65a-0ce8bb98504b" />
