### PR TITLE
feat: Add public API to open debug menu programmatically

### DIFF
--- a/DebugSwift/Sources/Settings/DebugSwift.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.swift
@@ -47,4 +47,71 @@ public class DebugSwift {
 
         return self
     }
+
+    /// Call this before presenting the view controller returned by `debugViewController()`.
+    /// If the floating ball is currently visible it is hidden for the duration of the
+    /// presentation so it cannot open a second debug menu on top of yours.
+    ///
+    /// Always pair with `debugViewControllerDidDismiss()` — safe to call even when
+    /// the floating ball is not in use.
+    @MainActor
+    public static func debugViewControllerWillPresent() {
+        if FloatViewManager.isShowing() {
+            _floatingBallWasVisible = true
+            FloatViewManager.remove()
+        }
+    }
+
+    /// Call this after dismissing the view controller returned by `debugViewController()`.
+    /// Restores the floating ball if it was visible before `debugViewControllerWillPresent()`.
+    @MainActor
+    public static func debugViewControllerDidDismiss() {
+        if _floatingBallWasVisible {
+            FloatViewManager.show()
+            _floatingBallWasVisible = false
+        }
+    }
+
+    @MainActor private static var _floatingBallWasVisible = false
+
+    /// Returns a standalone debug menu view controller that you can present
+    /// however you like — push, present modally, embed in a tab bar, etc.
+    ///
+    /// This view controller is independent from the floating ball.
+    /// Call `setup()` before using this method.
+    ///
+    ///     let debugVC = DebugSwift.debugViewController()
+    ///     navigationController?.pushViewController(debugVC, animated: true)
+    ///
+    @MainActor
+    public static func debugViewController() -> UIViewController {
+        var controllers: [UIViewController & MainFeatureType] = [
+            NetworkViewController(),
+            PerformanceViewController(),
+            InterfaceViewController(),
+            ResourcesViewController(),
+            AppViewController()
+        ]
+
+        let hidden = FeatureHandling.hiddenFeatures
+        controllers.removeAll(where: { hidden.contains($0.controllerType) })
+
+        let custom = App.shared.customControllers?() ?? []
+
+        let tabBar = UITabBarController()
+        tabBar.viewControllers = (controllers as [UIViewController] + custom).map {
+            $0.navigationItem.largeTitleDisplayMode = .always
+            let nav = UINavigationController(rootViewController: $0)
+            nav.navigationBar.prefersLargeTitles = true
+            return nav
+        }
+        tabBar.tabBar.tintColor = .white
+        tabBar.tabBar.unselectedItemTintColor = .gray
+        tabBar.tabBar.setBackgroundColor(color: .black)
+        tabBar.tabBar.addTopBorderWithColor(color: .gray, thickness: 0.3)
+        tabBar.overrideUserInterfaceStyle = .dark
+        tabBar.view.backgroundColor = .black
+
+        return tabBar
+    }
 }

--- a/DebugSwift/Sources/Settings/FeatureHandling.swift
+++ b/DebugSwift/Sources/Settings/FeatureHandling.swift
@@ -11,9 +11,13 @@ import UIKit
 @MainActor
 enum FeatureHandling {
     static var enabledBetaFeatures: [DebugSwiftBetaFeature] = []
+    static var hiddenFeatures: [DebugSwiftFeature] = []
+
     static func setup(
         only featuresToShow: [DebugSwiftFeature] = DebugSwiftFeature.allCases
     ) {
+        hiddenFeatures = DebugSwiftFeature.allCases.filter { !featuresToShow.contains($0) }
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             MainActor.assumeIsolated {
                 DebugSwift.App.shared.defaultControllers.removeAll(where: { !featuresToShow.contains($0.controllerType) })
@@ -29,7 +33,8 @@ enum FeatureHandling {
     ) {
         setupBetaFeatures(betaFeatures)
         setupMethods(methods)
-        
+        hiddenFeatures = features
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             MainActor.assumeIsolated {
                 DebugSwift.App.shared.defaultControllers.removeAll(where: { features.contains($0.controllerType) })

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -10,9 +10,12 @@ import MapKit
 import DebugSwift
 
 struct ContentView: View {
+    @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate
 
     @State private var userTrackingMode: MKUserTrackingMode = .follow
     @State private var presentingMap = false
+    @State private var showFloatingBall = true
+    @State private var showDebugger = false
 
     var body: some View {
         NavigationView {
@@ -103,7 +106,72 @@ struct ContentView: View {
                 MapView()
             }
             .navigationBarTitle("DebugSwift Examples")
+            .toolbar {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button {
+                        if showFloatingBall {
+                            appDelegate.debugSwift.hide()
+                        } else {
+                            appDelegate.debugSwift.show()
+                        }
+                        showFloatingBall.toggle()
+                    } label: {
+                        Image(systemName: showFloatingBall ? "circle.fill" : "circle.dotted")
+                    }
+
+                    Button {
+                        DebugSwift.debugViewControllerWillPresent()
+                        showDebugger = true
+                    } label: {
+                        Image(systemName: "ladybug")
+                    }
+                    .fullScreenCover(isPresented: $showDebugger, onDismiss: {
+                        DebugSwift.debugViewControllerDidDismiss()
+                    }) {
+                        DebugViewControllerRepresentable(onDismiss: { showDebugger = false })
+                            .ignoresSafeArea()
+                    }
+                }
+            }
         }
     }
+}
 
+struct DebugViewControllerRepresentable: UIViewControllerRepresentable {
+    let onDismiss: () -> Void
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let debugVC = DebugSwift.debugViewController()
+
+        let closeButton = UIBarButtonItem(
+            image: UIImage(systemName: "xmark"),
+            style: .plain,
+            target: context.coordinator,
+            action: #selector(Coordinator.close)
+        )
+        closeButton.tintColor = .white
+        debugVC.navigationItem.rightBarButtonItem = closeButton
+
+        // Outer nav controller matches WindowManager's structure used by FloatingView
+        let nav = UINavigationController(rootViewController: debugVC)
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = .black
+        nav.navigationBar.standardAppearance = appearance
+        nav.navigationBar.scrollEdgeAppearance = appearance
+        nav.navigationBar.compactAppearance = appearance
+        nav.overrideUserInterfaceStyle = .dark
+        return nav
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(onDismiss: onDismiss) }
+
+    class Coordinator: NSObject {
+        let onDismiss: () -> Void
+        init(onDismiss: @escaping () -> Void) { self.onDismiss = onDismiss }
+
+        @objc func close() { onDismiss() }
+    }
 }

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -31,7 +31,7 @@ struct ExampleApp: App {
 }
 
 class AppDelegate: NSObject, UIApplicationDelegate {
-    private let debugSwift = DebugSwift()
+    let debugSwift = DebugSwift()
 
     func application(
         _: UIApplication,

--- a/README.md
+++ b/README.md
@@ -164,6 +164,85 @@ extension UIWindow {
 }
 ```
 
+### Open Debugger Programmatically
+
+You can get the debug menu as a standalone `UIViewController` and present it however you like — push, present modally, embed in your own navigation. No floating ball required.
+
+```swift
+// 1. Setup (without floating ball)
+#if DEBUG
+DebugSwift().setup()
+// Don't call .show() — no floating ball will appear
+#endif
+
+// 2. Get the debug view controller and present it yourself
+let debugVC = DebugSwift.debugViewController()
+
+// Push into your navigation stack
+navigationController?.pushViewController(debugVC, animated: true)
+
+// Or present modally
+let nav = UINavigationController(rootViewController: debugVC)
+present(nav, animated: true)
+```
+
+#### SwiftUI
+
+Wrap in a `UINavigationController` so the close button and dark nav bar match the FloatingView experience:
+
+```swift
+struct DebugViewControllerRepresentable: UIViewControllerRepresentable {
+    let onDismiss: () -> Void
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let debugVC = DebugSwift.debugViewController()
+
+        let closeButton = UIBarButtonItem(
+            image: UIImage(systemName: "xmark"),
+            style: .plain, target: context.coordinator,
+            action: #selector(Coordinator.close)
+        )
+        closeButton.tintColor = .white
+        debugVC.navigationItem.rightBarButtonItem = closeButton
+
+        let nav = UINavigationController(rootViewController: debugVC)
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = .black
+        nav.navigationBar.standardAppearance = appearance
+        nav.navigationBar.scrollEdgeAppearance = appearance
+        nav.navigationBar.compactAppearance = appearance
+        nav.overrideUserInterfaceStyle = .dark
+        return nav
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {}
+    func makeCoordinator() -> Coordinator { Coordinator(onDismiss: onDismiss) }
+
+    class Coordinator: NSObject {
+        let onDismiss: () -> Void
+        init(onDismiss: @escaping () -> Void) { self.onDismiss = onDismiss }
+        @objc func close() { onDismiss() }
+    }
+}
+
+// Usage — fullScreenCover matches the FloatingView full-screen appearance
+@State private var showDebugger = false
+
+Button("Open Debugger") {
+    DebugSwift.debugViewControllerWillPresent()
+    showDebugger = true
+}
+// Use onDismiss: on fullScreenCover — not inside the representable — so the
+// floating ball is restored even when the sheet is dismissed via Escape/swipe.
+.fullScreenCover(isPresented: $showDebugger, onDismiss: {
+    DebugSwift.debugViewControllerDidDismiss()
+}) {
+    DebugViewControllerRepresentable(onDismiss: { showDebugger = false })
+        .ignoresSafeArea()
+}
+```
+
 ## 🔧 Troubleshooting
 
 ### Apple Silicon Build Issues


### PR DESCRIPTION
## Summary

Add a `debugViewController()` factory method and supporting lifecycle helpers so the debug menu can be presented programmatically — from a custom button, shake gesture, or any other trigger — without the floating ball.

**New public API:**

- `DebugSwift.debugViewController() -> UIViewController` — returns a standalone `UITabBarController` containing all debug tabs. Independent of the floating ball; respects `hideFeatures` passed to `setup()`.
- `DebugSwift.debugViewControllerWillPresent()` — hides the floating ball before your presentation so it cannot open a second debug menu on top. Safe to call when the floating ball is not in use.
- `DebugSwift.debugViewControllerDidDismiss()` — restores the floating ball after dismissal (only if it was visible before).

**Other fixes:**

- Network tab stat labels (`totalRequests`, `successRate`, `avgResponseTime`, `totalTime`) were blank on first open because they relied on a 2-second timer. Fixed by initialising them with default values.
- `hiddenFeatures` is now populated eagerly in `FeatureHandling` so `debugViewController()` correctly filters tabs even before the 1-second delayed setup completes.

**Example app:**

- Moved floating-ball toggle and open-debugger controls from the list into the navigation bar toolbar (circle / ladybug icons) to keep demo content separate from DebugSwift controls.
- Demonstrates `debugViewController()` via `fullScreenCover` with a `UIViewControllerRepresentable` that matches the FloatingView visual appearance (outer `UINavigationController`, black nav bar, dark mode, xmark close button).

## Type of change

- [x] Feature
- [x] Fix

## Test plan

- [x] Manual testing completed
- [x] CI passing

### Manual test steps

1. Launch the example app — floating ball appears as before
2. Tap the **ladybug** icon in the nav bar → debug menu opens as full-screen modal; floating ball disappears
3. Close via **✕** button → floating ball reappears
4. Close via **Escape** (simulator) → floating ball reappears
5. Tap **circle** icon to hide the floating ball, then tap **ladybug** → modal opens; on close the ball stays hidden (not unexpectedly shown)
6. With floating ball visible, open it → tap ladybug → only one debug menu is shown (no double-stack)
7. Open Network tab immediately on first launch → stat labels show `0 / 0.0% / 0ms` instead of blank

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility