### PR TITLE
feat(swiftdata): add in​-app ​Swift​Data browser with runtime inspect/edit​/export support

### DIFF
--- a/DebugSwift/Sources/Features/App/App.Controller.swift
+++ b/DebugSwift/Sources/Features/App/App.Controller.swift
@@ -201,6 +201,19 @@ extension AppViewController: UITableViewDataSource, UITableViewDelegate {
             case .deepLink:
                 let controller = DeepLinkViewController()
                 navigationController?.pushViewController(controller, animated: true)
+            case .swiftData:
+                if #available(iOS 17.0, *) {
+                    let controller = SwiftDataBrowserViewController()
+                    navigationController?.pushViewController(controller, animated: true)
+                } else {
+                    let alert = UIAlertController(
+                        title: "SwiftData Unavailable",
+                        message: "SwiftData Browser requires iOS 17.0 or newer.",
+                        preferredStyle: .alert
+                    )
+                    alert.addAction(UIAlertAction(title: "OK", style: .default))
+                    present(alert, animated: true)
+                }
             }
         default:
             break
@@ -299,6 +312,7 @@ extension AppViewController {
         case loadedLibraries
         case pushNotifications
         case deepLink
+        case swiftData
 
         var title: String {
             switch self {
@@ -314,6 +328,8 @@ extension AppViewController {
                 return "Push Notifications"
             case .deepLink:
                 return "Deep Links"
+            case .swiftData:
+                return "SwiftData Browser"
             }
         }
 

--- a/DebugSwift/Sources/Features/App/SwiftData/SwiftDataBrowserViewController.swift
+++ b/DebugSwift/Sources/Features/App/SwiftData/SwiftDataBrowserViewController.swift
@@ -1,0 +1,272 @@
+//
+//  SwiftDataBrowserViewController.swift
+//  DebugSwift
+//
+//  Lists registered SwiftData contexts and models
+//
+
+import UIKit
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataBrowserViewController: BaseController {
+    private var contexts: [SwiftDataContextRegistration] = []
+    private var selectedContext: SwiftDataContextRegistration?
+    private var entities: [SwiftDataEntity] = []
+    private var filteredEntities: [SwiftDataEntity] = []
+
+    private var searchController: UISearchController!
+
+    private lazy var contextSegmentedControl: UISegmentedControl = {
+        let control = UISegmentedControl()
+        control.translatesAutoresizingMaskIntoConstraints = false
+        control.addTarget(self, action: #selector(contextChanged), for: .valueChanged)
+        return control
+    }()
+
+    private lazy var tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .grouped)
+        table.translatesAutoresizingMaskIntoConstraints = false
+        table.delegate = self
+        table.dataSource = self
+        table.register(UITableViewCell.self, forCellReuseIdentifier: "SwiftDataEntityCell")
+        return table
+    }()
+
+    private lazy var emptyStateLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .secondaryLabel
+        label.font = .systemFont(ofSize: 15, weight: .regular)
+        label.text = "No SwiftData containers configured.\n\nUse DebugSwift.Resources.shared.configureSwiftData(contexts:) to setup."
+        return label
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        loadData()
+    }
+}
+
+@available(iOS 17.0, *)
+private extension SwiftDataBrowserViewController {
+    func setup() {
+        title = "SwiftData Browser"
+
+        setupViews()
+        setupSearchController()
+        setupNavigation()
+    }
+
+    func setupViews() {
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    func setupSearchController() {
+        searchController = UISearchController(searchResultsController: nil)
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = "Search models"
+        navigationItem.searchController = searchController
+        definesPresentationContext = true
+    }
+
+    func setupNavigation() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .refresh,
+            target: self,
+            action: #selector(refreshData)
+        )
+    }
+
+    @objc func refreshData() {
+        loadData()
+    }
+
+    @objc func contextChanged() {
+        let index = contextSegmentedControl.selectedSegmentIndex
+        guard index >= 0, index < contexts.count else { return }
+        selectedContext = contexts[index]
+        loadEntities()
+    }
+
+    func loadData() {
+        contexts = SwiftDataManager.shared.getAvailableContexts()
+        selectedContext = SwiftDataManager.shared.getDefaultContext()
+
+        if contexts.isEmpty {
+            showEmptyState()
+            return
+        }
+
+        hideEmptyState()
+        setupContextSegmentedControl()
+        loadEntities()
+    }
+
+    func setupContextSegmentedControl() {
+        guard contexts.count > 1 else {
+            tableView.tableHeaderView = nil
+            return
+        }
+
+        contextSegmentedControl.removeAllSegments()
+        for (index, context) in contexts.enumerated() {
+            contextSegmentedControl.insertSegment(withTitle: context.name, at: index, animated: false)
+        }
+
+        let selectedIndex = contexts.firstIndex { context in
+            context.name == selectedContext?.name
+        } ?? 0
+        contextSegmentedControl.selectedSegmentIndex = selectedIndex
+
+        let containerView = UIView()
+        containerView.addSubview(contextSegmentedControl)
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            contextSegmentedControl.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8),
+            contextSegmentedControl.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            contextSegmentedControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            contextSegmentedControl.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -8),
+            containerView.heightAnchor.constraint(equalToConstant: 60)
+        ])
+
+        tableView.tableHeaderView = containerView
+        tableView.tableHeaderView?.frame.size.height = 60
+    }
+
+    func loadEntities() {
+        guard let selectedContext else {
+            entities = []
+            filteredEntities = []
+            tableView.reloadData()
+            return
+        }
+
+        entities = SwiftDataManager.shared.getEntities(for: selectedContext)
+        applyFilter()
+    }
+
+    func applyFilter() {
+        let searchText = searchController.searchBar.text ?? ""
+        if searchText.isEmpty {
+            filteredEntities = entities
+        } else {
+            filteredEntities = entities.filter { entity in
+                entity.displayName.localizedCaseInsensitiveContains(searchText) ||
+                    entity.name.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+
+        tableView.reloadData()
+        updateEmptyState()
+    }
+
+    func showEmptyState() {
+        tableView.backgroundView = emptyStateLabel
+        tableView.separatorStyle = .none
+    }
+
+    func hideEmptyState() {
+        tableView.backgroundView = nil
+        tableView.separatorStyle = .singleLine
+    }
+
+    func updateEmptyState() {
+        if filteredEntities.isEmpty {
+            emptyStateLabel.text = "No models found."
+            showEmptyState()
+        } else {
+            hideEmptyState()
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+extension SwiftDataBrowserViewController: UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        2
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == 0 {
+            return selectedContext == nil ? 0 : 1
+        }
+        return filteredEntities.count
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        if section == 0 {
+            return "Container Inspector"
+        }
+        return filteredEntities.isEmpty ? nil : "Models (\(filteredEntities.count))"
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "SwiftDataEntityCell", for: indexPath)
+        var content = cell.defaultContentConfiguration()
+
+        if indexPath.section == 0 {
+            guard let selectedContext else {
+                return cell
+            }
+            let context = selectedContext.container.mainContext
+            content.text = selectedContext.name
+            content.secondaryText = "Entities: \(selectedContext.container.schema.entities.count) | Autosave: \(context.autosaveEnabled ? "On" : "Off") | Has Changes: \(context.hasChanges ? "Yes" : "No")"
+            content.image = UIImage(systemName: "shippingbox")
+            cell.accessoryType = .none
+        } else {
+            let entity = filteredEntities[indexPath.row]
+            content.text = entity.displayName
+            content.secondaryText = "\(entity.objectCount) objects" + (entity.isBrowsable ? "" : " • register model to browse rows")
+            content.image = UIImage(systemName: entity.isBrowsable ? "square.stack.3d.up.fill" : "exclamationmark.triangle")
+            cell.accessoryType = entity.isBrowsable ? .disclosureIndicator : .none
+        }
+
+        cell.contentConfiguration = content
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        guard indexPath.section == 1 else { return }
+        guard let selectedContext else { return }
+
+        let entity = filteredEntities[indexPath.row]
+        guard entity.isBrowsable else { return }
+
+        let controller = SwiftDataEntityViewController(
+            registration: selectedContext,
+            entityName: entity.name,
+            titleText: entity.displayName
+        )
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        indexPath.section == 0 ? 64 : 80
+    }
+}
+
+@available(iOS 17.0, *)
+extension SwiftDataBrowserViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        applyFilter()
+    }
+}
+
+#endif

--- a/DebugSwift/Sources/Features/App/SwiftData/SwiftDataEntityViewController.swift
+++ b/DebugSwift/Sources/Features/App/SwiftData/SwiftDataEntityViewController.swift
@@ -1,0 +1,448 @@
+//
+//  SwiftDataEntityViewController.swift
+//  DebugSwift
+//
+//  Lists model instances and allows inspection/editing
+//
+
+import UIKit
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataEntityViewController: BaseController {
+    private let registration: SwiftDataContextRegistration
+    private let entityName: String
+
+    private var models: [any PersistentModel] = []
+    private var filteredModels: [any PersistentModel] = []
+
+    private var searchController: UISearchController!
+
+    private lazy var tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .grouped)
+        table.translatesAutoresizingMaskIntoConstraints = false
+        table.delegate = self
+        table.dataSource = self
+        table.register(UITableViewCell.self, forCellReuseIdentifier: "SwiftDataModelCell")
+        return table
+    }()
+
+    private lazy var emptyStateLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .secondaryLabel
+        label.font = .systemFont(ofSize: 15, weight: .regular)
+        label.text = "No model instances found."
+        return label
+    }()
+
+    init(
+        registration: SwiftDataContextRegistration,
+        entityName: String,
+        titleText: String
+    ) {
+        self.registration = registration
+        self.entityName = entityName
+        super.init()
+        title = titleText
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        loadModels()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        loadModels()
+    }
+}
+
+@available(iOS 17.0, *)
+private extension SwiftDataEntityViewController {
+    func setup() {
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        setupSearchController()
+        setupNavigation()
+    }
+
+    func setupSearchController() {
+        searchController = UISearchController(searchResultsController: nil)
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = "Search values"
+        navigationItem.searchController = searchController
+        definesPresentationContext = true
+    }
+
+    func setupNavigation() {
+        var buttons: [UIBarButtonItem] = [
+            UIBarButtonItem(
+                barButtonSystemItem: .refresh,
+                target: self,
+                action: #selector(refreshData)
+            ),
+            UIBarButtonItem(
+                image: UIImage(systemName: "square.and.arrow.up"),
+                style: .plain,
+                target: self,
+                action: #selector(exportData)
+            )
+        ]
+
+        if canCreate {
+            buttons.append(
+                UIBarButtonItem(
+                    barButtonSystemItem: .add,
+                    target: self,
+                    action: #selector(addModel)
+                )
+            )
+        }
+
+        navigationItem.rightBarButtonItems = buttons
+    }
+
+    var canCreate: Bool {
+        let normalizedEntityName = normalizeEntityName(entityName)
+        return registration.models.contains { model in
+            model.create != nil && normalizeEntityName(model.entityName) == normalizedEntityName
+        } && !DebugSwift.Resources.shared.swiftDataReadOnly
+    }
+
+    func normalizeEntityName(_ name: String) -> String {
+        name.split(separator: ".").last.map(String.init) ?? name
+    }
+
+    @objc func refreshData() {
+        loadModels()
+    }
+
+    @objc func exportData() {
+        do {
+            let json = try SwiftDataManager.shared.exportAsJSON(
+                entityName: entityName,
+                in: registration
+            )
+
+            let activity = UIActivityViewController(activityItems: [json], applicationActivities: nil)
+            present(activity, animated: true)
+        } catch {
+            showError(error)
+        }
+    }
+
+    @objc func addModel() {
+        do {
+            try SwiftDataManager.shared.createModel(entityName: entityName, in: registration)
+            loadModels()
+        } catch {
+            showError(error)
+        }
+    }
+
+    func loadModels() {
+        do {
+            models = try SwiftDataManager.shared.fetchModels(entityName: entityName, in: registration)
+            applyFilter()
+        } catch {
+            models = []
+            filteredModels = []
+            tableView.reloadData()
+            showError(error)
+        }
+    }
+
+    func applyFilter() {
+        let text = searchController.searchBar.text ?? ""
+        if text.isEmpty {
+            filteredModels = models
+        } else {
+            filteredModels = models.filter { model in
+                SwiftDataManager.shared.makeSummary(for: model).localizedCaseInsensitiveContains(text) ||
+                    String(describing: model).localizedCaseInsensitiveContains(text)
+            }
+        }
+        tableView.reloadData()
+        updateEmptyState()
+    }
+
+    func updateEmptyState() {
+        if filteredModels.isEmpty {
+            tableView.backgroundView = emptyStateLabel
+            tableView.separatorStyle = .none
+        } else {
+            tableView.backgroundView = nil
+            tableView.separatorStyle = .singleLine
+        }
+    }
+
+    func deleteModel(at indexPath: IndexPath, completion: @escaping (Bool) -> Void) {
+        let model = filteredModels[indexPath.row]
+
+        let alert = UIAlertController(
+            title: "Delete Model",
+            message: "This action cannot be undone.",
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
+            guard let self else {
+                completion(false)
+                return
+            }
+            do {
+                try SwiftDataManager.shared.deleteModel(
+                    model,
+                    entityName: self.entityName,
+                    in: self.registration
+                )
+                self.loadModels()
+                completion(true)
+            } catch {
+                self.showError(error)
+                completion(false)
+            }
+        })
+
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
+            completion(false)
+        })
+
+        present(alert, animated: true)
+    }
+
+    func showError(_ error: Error) {
+        let alert = UIAlertController(
+            title: "SwiftData Error",
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+@available(iOS 17.0, *)
+extension SwiftDataEntityViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        filteredModels.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "SwiftDataModelCell", for: indexPath)
+        let model = filteredModels[indexPath.row]
+
+        var content = cell.defaultContentConfiguration()
+        content.text = SwiftDataManager.shared.makeSummary(for: model)
+        content.secondaryText = String(describing: model)
+        content.secondaryTextProperties.numberOfLines = 2
+        content.image = UIImage(systemName: "doc.text.magnifyingglass")
+
+        cell.contentConfiguration = content
+        cell.accessoryType = .disclosureIndicator
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        let model = filteredModels[indexPath.row]
+        let controller = SwiftDataModelDetailViewController(
+            registration: registration,
+            entityName: entityName,
+            model: model
+        )
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        filteredModels.isEmpty ? nil : "Instances (\(filteredModels.count))"
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        88
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    ) -> UISwipeActionsConfiguration? {
+        guard !DebugSwift.Resources.shared.swiftDataReadOnly else { return nil }
+
+        let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, completion in
+            self?.deleteModel(at: indexPath, completion: completion)
+        }
+        deleteAction.image = UIImage(systemName: "trash")
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+}
+
+@available(iOS 17.0, *)
+extension SwiftDataEntityViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        applyFilter()
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataModelDetailViewController: BaseTableController {
+    private let registration: SwiftDataContextRegistration
+    private let entityName: String
+    private let model: any PersistentModel
+    private var properties: [SwiftDataPropertyItem] = []
+
+    init(
+        registration: SwiftDataContextRegistration,
+        entityName: String,
+        model: any PersistentModel
+    ) {
+        self.registration = registration
+        self.entityName = entityName
+        self.model = model
+        super.init()
+        title = entityName
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "SwiftDataPropertyCell")
+        loadProperties()
+    }
+
+    private func loadProperties() {
+        properties = SwiftDataManager.shared.getProperties(
+            for: model,
+            entityName: entityName,
+            in: registration
+        )
+        tableView.reloadData()
+    }
+
+    private func editable(_ property: SwiftDataPropertyItem) -> Bool {
+        !DebugSwift.Resources.shared.swiftDataReadOnly &&
+            property.isAttribute &&
+            !property.isRelationship &&
+            property.rawValue != nil &&
+            model is NSObject
+    }
+
+    private func presentEditAlert(for property: SwiftDataPropertyItem) {
+        guard editable(property) else { return }
+
+        let alert = UIAlertController(
+            title: "Edit \(property.name)",
+            message: "Current: \(property.valueDescription)",
+            preferredStyle: .alert
+        )
+
+        alert.addTextField { field in
+            field.text = property.valueDescription == "nil" ? "" : property.valueDescription
+            field.placeholder = "New value"
+        }
+
+        alert.addAction(UIAlertAction(title: "Save", style: .default) { [weak self] _ in
+            guard let self else { return }
+            let value = alert.textFields?.first?.text ?? ""
+            do {
+                try SwiftDataManager.shared.updateProperty(
+                    model: self.model,
+                    entityName: self.entityName,
+                    propertyName: property.name,
+                    newValueText: value,
+                    in: self.registration
+                )
+                self.loadProperties()
+            } catch {
+                self.showError(error)
+            }
+        })
+
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    private func showError(_ error: Error) {
+        let alert = UIAlertController(
+            title: "Update Failed",
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+@available(iOS 17.0, *)
+extension SwiftDataModelDetailViewController {
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        2
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == 0 {
+            return 1
+        }
+        return properties.count
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        section == 0 ? "Model" : "Properties (\(properties.count))"
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "SwiftDataPropertyCell", for: indexPath)
+        var content = cell.defaultContentConfiguration()
+
+        if indexPath.section == 0 {
+            content.text = String(describing: model)
+            content.secondaryText = "Tap an editable property below to modify and save."
+            content.secondaryTextProperties.numberOfLines = 2
+            content.image = UIImage(systemName: "shippingbox.circle")
+            cell.accessoryType = .none
+        } else {
+            let property = properties[indexPath.row]
+            var metadata: [String] = [property.typeName]
+            if property.isRelationship { metadata.append("relationship") }
+            if property.isOptional { metadata.append("optional") }
+            if property.isTransient { metadata.append("transient") }
+            if property.isUnique { metadata.append("unique") }
+
+            content.text = "\(property.name): \(property.valueDescription)"
+            content.secondaryText = metadata.joined(separator: " • ")
+            content.secondaryTextProperties.numberOfLines = 2
+            content.image = UIImage(systemName: property.isRelationship ? "link" : "slider.horizontal.3")
+            cell.accessoryType = editable(property) ? .detailButton : .none
+        }
+
+        cell.contentConfiguration = content
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard indexPath.section == 1 else { return }
+        presentEditAlert(for: properties[indexPath.row])
+    }
+
+    override func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
+        guard indexPath.section == 1 else { return }
+        presentEditAlert(for: properties[indexPath.row])
+    }
+}
+
+#endif

--- a/DebugSwift/Sources/Features/App/SwiftData/SwiftDataManager.swift
+++ b/DebugSwift/Sources/Features/App/SwiftData/SwiftDataManager.swift
@@ -1,0 +1,305 @@
+//
+//  SwiftDataManager.swift
+//  DebugSwift
+//
+//  SwiftData runtime browsing and editing helpers
+//
+
+import Foundation
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataManager {
+    static let shared = SwiftDataManager()
+
+    private init() {}
+
+    private var contexts: [SwiftDataContextRegistration] = []
+    var readOnlyMode = false
+
+    func configure(contexts: [SwiftDataContextRegistration]) {
+        self.contexts = contexts
+    }
+
+    func getAvailableContexts() -> [SwiftDataContextRegistration] {
+        contexts.sorted { $0.name < $1.name }
+    }
+
+    func getDefaultContext() -> SwiftDataContextRegistration? {
+        contexts.sorted { $0.name < $1.name }.first
+    }
+
+    func getEntities(for registration: SwiftDataContextRegistration) -> [SwiftDataEntity] {
+        let entityNames = registration.container.schema.entitiesByName.keys.sorted()
+        return entityNames.map { entityName in
+            let modelRegistration = modelRegistration(
+                forEntityName: entityName,
+                in: registration
+            )
+            let count = (try? objectCount(for: entityName, in: registration)) ?? 0
+            return SwiftDataEntity(
+                name: entityName,
+                displayName: modelRegistration?.displayName ?? entityName,
+                objectCount: count,
+                isBrowsable: modelRegistration != nil
+            )
+        }
+    }
+
+    func objectCount(for entityName: String, in registration: SwiftDataContextRegistration) throws -> Int {
+        guard let modelRegistration = modelRegistration(
+            forEntityName: entityName,
+            in: registration
+        ) else {
+            return 0
+        }
+        let context = registration.container.mainContext
+        return try modelRegistration.fetch(context).count
+    }
+
+    func fetchModels(
+        entityName: String,
+        in registration: SwiftDataContextRegistration
+    ) throws -> [any PersistentModel] {
+        guard let modelRegistration = modelRegistration(
+            forEntityName: entityName,
+            in: registration
+        ) else {
+            return []
+        }
+        return try modelRegistration.fetch(registration.container.mainContext)
+    }
+
+    func createModel(
+        entityName: String,
+        in registration: SwiftDataContextRegistration
+    ) throws {
+        guard let modelRegistration = modelRegistration(
+            forEntityName: entityName,
+            in: registration
+        ) else {
+            return
+        }
+
+        guard let model = modelRegistration.create?() else {
+            return
+        }
+
+        let context = registration.container.mainContext
+        context.insert(model)
+        try context.save()
+    }
+
+    func deleteModel(
+        _ model: any PersistentModel,
+        entityName: String,
+        in registration: SwiftDataContextRegistration
+    ) throws {
+        guard let modelRegistration = modelRegistration(
+            forEntityName: entityName,
+            in: registration
+        ) else {
+            throw SwiftDataBrowserError.invalidModelType
+        }
+        let context = registration.container.mainContext
+        try modelRegistration.delete(context, model)
+        try context.save()
+    }
+
+    func getProperties(
+        for model: any PersistentModel,
+        entityName: String,
+        in registration: SwiftDataContextRegistration
+    ) -> [SwiftDataPropertyItem] {
+        guard let entity = registration.container.schema.entitiesByName[entityName] else {
+            return []
+        }
+
+        let reflectedValues: [String: Any] = Mirror(reflecting: model).children.reduce(into: [:]) { partialResult, child in
+            guard let name = child.label else { return }
+            partialResult[name] = child.value
+        }
+
+        let properties = entity.storedProperties.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+
+        return properties.map { property in
+            let value = reflectedValues[property.name]
+            return SwiftDataPropertyItem(
+                name: property.name,
+                valueDescription: formatValue(value),
+                isRelationship: property.isRelationship,
+                isAttribute: property.isAttribute,
+                isTransient: property.isTransient,
+                isOptional: property.isOptional,
+                isUnique: property.isUnique,
+                typeName: String(describing: property.valueType),
+                rawValue: value
+            )
+        }
+    }
+
+    func updateProperty(
+        model: any PersistentModel,
+        entityName: String,
+        propertyName: String,
+        newValueText: String,
+        in registration: SwiftDataContextRegistration
+    ) throws {
+        guard !DebugSwift.Resources.shared.swiftDataReadOnly else {
+            return
+        }
+
+        guard let object = model as? NSObject else {
+            throw SwiftDataBrowserError.propertyUpdateFailed
+        }
+
+        let properties = getProperties(for: model, entityName: entityName, in: registration)
+        guard let property = properties.first(where: { $0.name == propertyName }),
+              let existingValue = property.rawValue else {
+            throw SwiftDataBrowserError.propertyUpdateFailed
+        }
+
+        guard let parsedValue = parseValue(newValueText, basedOn: existingValue) else {
+            throw SwiftDataBrowserError.unsupportedEditType
+        }
+
+        object.setValue(parsedValue, forKey: propertyName)
+        try registration.container.mainContext.save()
+    }
+
+    func exportAsJSON(
+        entityName: String,
+        in registration: SwiftDataContextRegistration
+    ) throws -> String {
+        let models = try fetchModels(entityName: entityName, in: registration)
+
+        let dictionaries = models.map { model -> [String: String] in
+            Dictionary(
+                uniqueKeysWithValues: Mirror(reflecting: model).children.compactMap { child in
+                    guard let label = child.label else { return nil }
+                    return (label, formatValue(child.value))
+                }
+            )
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: dictionaries, options: [.prettyPrinted])
+        return String(data: data, encoding: .utf8) ?? "[]"
+    }
+
+    func makeSummary(for model: any PersistentModel) -> String {
+        let values = Mirror(reflecting: model).children.compactMap { child -> String? in
+            guard let label = child.label else { return nil }
+            let value = formatValue(child.value)
+            guard !value.isEmpty else { return nil }
+            return "\(label): \(value)"
+        }
+        return values.prefix(2).joined(separator: " | ")
+    }
+
+    private func modelRegistration(
+        forEntityName entityName: String,
+        in registration: SwiftDataContextRegistration
+    ) -> SwiftDataModelRegistration? {
+        let normalizedEntityName = normalizeEntityName(entityName)
+        return registration.models.first { model in
+            normalizeEntityName(model.entityName) == normalizedEntityName
+        }
+    }
+
+    private func normalizeEntityName(_ name: String) -> String {
+        name.split(separator: ".").last.map(String.init) ?? name
+    }
+
+    private func parseValue(_ text: String, basedOn existingValue: Any) -> Any? {
+        if existingValue is String {
+            return text
+        }
+
+        if existingValue is Int {
+            return Int(text)
+        }
+
+        if existingValue is Int16 {
+            return Int16(text)
+        }
+
+        if existingValue is Int32 {
+            return Int32(text)
+        }
+
+        if existingValue is Int64 {
+            return Int64(text)
+        }
+
+        if existingValue is Double {
+            return Double(text)
+        }
+
+        if existingValue is Float {
+            return Float(text)
+        }
+
+        if existingValue is Bool {
+            let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if normalized == "true" || normalized == "1" {
+                return true
+            }
+            if normalized == "false" || normalized == "0" {
+                return false
+            }
+            return nil
+        }
+
+        if existingValue is Date {
+            return ISO8601DateFormatter().date(from: text)
+        }
+
+        return nil
+    }
+
+    private func formatValue(_ value: Any?) -> String {
+        guard let value else { return "nil" }
+
+        if let date = value as? Date {
+            return ISO8601DateFormatter().string(from: date)
+        }
+
+        if let data = value as? Data {
+            return "\(data.count) bytes"
+        }
+
+        let raw = String(describing: value)
+        if raw.count > 200 {
+            return String(raw.prefix(200)) + "..."
+        }
+        return raw
+    }
+}
+
+@available(iOS 17.0, *)
+struct SwiftDataEntity {
+    let name: String
+    let displayName: String
+    let objectCount: Int
+    let isBrowsable: Bool
+}
+
+@available(iOS 17.0, *)
+struct SwiftDataPropertyItem {
+    let name: String
+    let valueDescription: String
+    let isRelationship: Bool
+    let isAttribute: Bool
+    let isTransient: Bool
+    let isOptional: Bool
+    let isUnique: Bool
+    let typeName: String
+    let rawValue: Any?
+}
+
+#endif

--- a/DebugSwift/Sources/Features/Resources/Resources.Controller.swift
+++ b/DebugSwift/Sources/Features/Resources/Resources.Controller.swift
@@ -15,6 +15,7 @@ final class ResourcesViewController: BaseController, MainFeatureType {
         case keychain
         case persistentData
         case coreData
+        case swiftData
         case httpCookies
         case database
 
@@ -30,6 +31,8 @@ final class ResourcesViewController: BaseController, MainFeatureType {
                 "Persistent Data"
             case .coreData:
                 "Core Data"
+            case .swiftData:
+                "SwiftData Browser"
             case .httpCookies:
                 "HTTP Cookies"
             case .database:
@@ -54,6 +57,7 @@ final class ResourcesViewController: BaseController, MainFeatureType {
         .persistentData,
         .httpCookies,
         .coreData,
+        .swiftData,
         .database
     ]
 
@@ -131,6 +135,18 @@ extension ResourcesViewController: UITableViewDataSource, UITableViewDelegate {
             controller = ResourcesTabbedController()
         case .coreData:
             controller = CoreDataBrowserViewController()
+        case .swiftData:
+            if #available(iOS 17.0, *) {
+                controller = SwiftDataBrowserViewController()
+            } else {
+                let alert = UIAlertController(
+                    title: "SwiftData Unavailable",
+                    message: "SwiftData Browser requires iOS 17.0 or newer.",
+                    preferredStyle: .alert
+                )
+                alert.addAction(UIAlertAction(title: "OK", style: .default))
+                present(alert, animated: true)
+            }
 
         case .httpCookies:
             let viewModel = ResourcesHTTPCookiesViewModel()

--- a/DebugSwift/Sources/Settings/DebugSwift.Network.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.Network.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 import CoreData
+#if canImport(SwiftData)
+import SwiftData
+#endif
 
 extension DebugSwift {
     public class Network: @unchecked Sendable {
@@ -431,6 +434,32 @@ extension DebugSwift {
         
         /// Enable read-only mode for Core Data browser (default: false)
         public var coreDataReadOnly: Bool = false
+
+#if canImport(SwiftData)
+        /// SwiftData containers and model registrations for debugging
+        @available(iOS 17.0, *)
+        @MainActor
+        public var swiftDataContexts: [SwiftDataContextRegistration] {
+            get {
+                SwiftDataManager.shared.getAvailableContexts()
+            }
+            set {
+                SwiftDataManager.shared.configure(contexts: newValue)
+            }
+        }
+
+        /// Enable read-only mode for SwiftData browser (default: false)
+        @available(iOS 17.0, *)
+        @MainActor
+        public var swiftDataReadOnly: Bool {
+            get {
+                SwiftDataManager.shared.readOnlyMode
+            }
+            set {
+                SwiftDataManager.shared.readOnlyMode = newValue
+            }
+        }
+#endif
         
         /// Configure Core Data with a persistent container
         /// - Parameter container: The NSPersistentContainer to debug
@@ -449,5 +478,21 @@ extension DebugSwift {
         public func configureCoreData(contexts: [String: NSManagedObjectContext]) {
             coreDataContexts = contexts
         }
+
+#if canImport(SwiftData)
+        /// Configure SwiftData with one or more containers and model registrations
+        @available(iOS 17.0, *)
+        @MainActor
+        public func configureSwiftData(contexts: [SwiftDataContextRegistration]) {
+            swiftDataContexts = contexts
+        }
+
+        /// Add a single SwiftData container registration
+        @available(iOS 17.0, *)
+        @MainActor
+        public func addSwiftDataContext(_ context: SwiftDataContextRegistration) {
+            swiftDataContexts.append(context)
+        }
+#endif
     }
 }

--- a/DebugSwift/Sources/Settings/DebugSwift.SwiftData.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.SwiftData.swift
@@ -1,0 +1,86 @@
+//
+//  DebugSwift.SwiftData.swift
+//  DebugSwift
+//
+//  Public configuration for SwiftData browser
+//
+
+import Foundation
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17.0, *)
+public struct SwiftDataContextRegistration {
+    public let name: String
+    public let container: ModelContainer
+    public let models: [SwiftDataModelRegistration]
+
+    public init(
+        name: String,
+        container: ModelContainer,
+        models: [SwiftDataModelRegistration]
+    ) {
+        self.name = name
+        self.container = container
+        self.models = models
+    }
+}
+
+@available(iOS 17.0, *)
+public struct SwiftDataModelRegistration {
+    public let displayName: String
+    let entityName: String
+    let fetch: (@MainActor @Sendable (ModelContext) throws -> [any PersistentModel])
+    let create: (@MainActor @Sendable () -> (any PersistentModel))?
+    let delete: (@MainActor @Sendable (ModelContext, any PersistentModel) throws -> Void)
+
+    public init<T: PersistentModel>(
+        _ type: T.Type,
+        displayName: String? = nil,
+        create: (@MainActor @Sendable () -> T)? = nil
+    ) {
+        self.displayName = displayName ?? String(describing: type)
+        entityName = String(describing: type)
+
+        fetch = { context in
+            let descriptor = FetchDescriptor<T>()
+            return try context.fetch(descriptor).map { $0 as any PersistentModel }
+        }
+
+        if let create {
+            self.create = {
+                create() as any PersistentModel
+            }
+        } else {
+            self.create = nil
+        }
+
+        delete = { context, model in
+            guard let typedModel = model as? T else {
+                throw SwiftDataBrowserError.invalidModelType
+            }
+            context.delete(typedModel)
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+public enum SwiftDataBrowserError: LocalizedError {
+    case invalidModelType
+    case unsupportedEditType
+    case propertyUpdateFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidModelType:
+            return "Invalid model type for this operation."
+        case .unsupportedEditType:
+            return "Unsupported value type for editing."
+        case .propertyUpdateFailed:
+            return "Failed to update property."
+        }
+    }
+}
+
+#endif

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2EA3B66C2B2E8054001B59FE /* DebugSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 2EA3B66B2B2E8054001B59FE /* DebugSwift */; };
+		125DF3962F9196C100217119 /* DebugSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 125DF3952F9196C100217119 /* DebugSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,7 +47,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2EA3B66C2B2E8054001B59FE /* DebugSwift in Frameworks */,
+				125DF3962F9196C100217119 /* DebugSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,7 +101,7 @@
 			);
 			name = Example;
 			packageProductDependencies = (
-				2EA3B66B2B2E8054001B59FE /* DebugSwift */,
+				125DF3952F9196C100217119 /* DebugSwift */,
 			);
 			productName = Example;
 			productReference = 2EA3B6592B2E7F71001B59FE /* Example.app */;
@@ -160,7 +160,7 @@
 			);
 			mainGroup = 2EA3B6502B2E7F71001B59FE;
 			packageReferences = (
-				2EA3B66A2B2E8054001B59FE /* XCRemoteSwiftPackageReference "DebugSwift" */,
+				125DF3942F9196C100217119 /* XCLocalSwiftPackageReference "../../DebugSwift" */,
 			);
 			productRefGroup = 2EA3B65A2B2E7F71001B59FE /* Products */;
 			projectDirPath = "";
@@ -375,21 +375,16 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		2EA3B66A2B2E8054001B59FE /* XCRemoteSwiftPackageReference "DebugSwift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/DebugSwift/DebugSwift";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		125DF3942F9196C100217119 /* XCLocalSwiftPackageReference "../../DebugSwift" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../DebugSwift;
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		2EA3B66B2B2E8054001B59FE /* DebugSwift */ = {
+		125DF3952F9196C100217119 /* DebugSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2EA3B66A2B2E8054001B59FE /* XCRemoteSwiftPackageReference "DebugSwift" */;
 			productName = DebugSwift;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -54,6 +54,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         
         // MARK: Core Data Example Setup
         setupCoreDataExample()
+
+        // MARK: SwiftData Example Setup
+        setupSwiftDataExample()
         
         // MARK: Custom Actions Demo - Including Network History Clear
         setupCustomActions()
@@ -76,6 +79,13 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         if count == 0 {
             CoreDataExample.shared.createSampleData()
         }
+    }
+
+    private func setupSwiftDataExample() {
+        guard #available(iOS 17.0, *) else { return }
+
+        SwiftDataExample.shared.setupDebugSwift()
+        SwiftDataExample.shared.createSampleDataIfNeeded()
     }
     
     // MARK: - Deep Link Handling

--- a/Example/Example/SwiftData/SwiftDataExample.swift
+++ b/Example/Example/SwiftData/SwiftDataExample.swift
@@ -1,0 +1,83 @@
+//
+//  SwiftDataExample.swift
+//  Example
+//
+//  SwiftData example setup for DebugSwift testing
+//
+
+import Foundation
+import DebugSwift
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17.0, *)
+@Model
+final class SwiftDataPerson {
+    var name: String
+    var age: Int
+    var createdAt: Date
+
+    init(name: String, age: Int, createdAt: Date = Date()) {
+        self.name = name
+        self.age = age
+        self.createdAt = createdAt
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataExample {
+    static let shared = SwiftDataExample()
+
+    private init() {}
+
+    lazy var modelContainer: ModelContainer = {
+        do {
+            return try ModelContainer(for: SwiftDataPerson.self)
+        } catch {
+            fatalError("Unable to create SwiftData model container: \(error)")
+        }
+    }()
+
+    func setupDebugSwift() {
+        let models: [SwiftDataModelRegistration] = [
+            .init(SwiftDataPerson.self, displayName: "SwiftData Person") {
+                SwiftDataPerson(
+                    name: "New Person",
+                    age: Int.random(in: 18...65)
+                )
+            }
+        ]
+
+        DebugSwift.Resources.shared.configureSwiftData(contexts: [
+            .init(name: "Main", container: modelContainer, models: models)
+        ])
+    }
+
+    func createSampleDataIfNeeded() {
+        let context = modelContainer.mainContext
+        let descriptor = FetchDescriptor<SwiftDataPerson>()
+
+        do {
+            let existing = try context.fetch(descriptor)
+            guard existing.isEmpty else { return }
+
+            for i in 1...5 {
+                let person = SwiftDataPerson(
+                    name: "SwiftData Person \(i)",
+                    age: 20 + i,
+                    createdAt: Date().addingTimeInterval(TimeInterval(-i * 3_600))
+                )
+                context.insert(person)
+            }
+
+            try context.save()
+            print("✅ Sample SwiftData created successfully")
+        } catch {
+            print("❌ Failed to setup SwiftData sample data: \(error)")
+        }
+    }
+}
+
+#endif

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ DebugSwift
 - **Keychain:** Inspect keychain entries
 - **Database Browser:** SQLite and Realm database inspection
 - **Push Notifications:** Simulate push notifications with templates and test scenarios
+- **SwiftData Browser (iOS 17+):** Inspect registered SwiftData containers, browse models, inspect properties/relationships, edit values, and export JSON
 
 ## Installation & Setup
 
@@ -406,6 +407,26 @@ debugSwift.setup(
 debugSwift.setup(
     enableBetaFeatures: [.swiftUIRenderTracking] // Enable experimental SwiftUI render tracking
 )
+```
+
+### SwiftData Browser (iOS 17+)
+
+```swift
+import SwiftData
+
+// Define your model registrations
+let swiftDataModels: [SwiftDataModelRegistration] = [
+    .init(Trip.self),
+    .init(Accommodation.self)
+]
+
+// Register one or more containers
+DebugSwift.Resources.shared.configureSwiftData(contexts: [
+    .init(name: "Main", container: appModelContainer, models: swiftDataModels)
+])
+
+// Optional: lock browser editing
+DebugSwift.Resources.shared.swiftDataReadOnly = true
 ```
 
 ### App Group Configuration


### PR DESCRIPTION


## Summary

• Added a new SwiftData Browser in DebugSwift (App tab) to inspect and debug SwiftData at runtime.
• Introduced public SwiftData configuration API under Debug​Swift​.​Resources so host apps can register one or more Model​Containers and model types.
• Implemented model/entity browsing, instance listing, property inspection, search/filter, JSON export, delete, and basic runtime editing for supported attribute types.
• Added iOS 17+ availability handling for SwiftData surfaces and updated README with setup instructions.

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Configure SwiftData in sample app code using:
Debug​Swift​.​Resources​.shared​.configure​Swift​Data(contexts: [.init(name: "​Main", container: app​Model​Container, models: [...])])
2. Launch app, open DebugSwift, go to App > SwiftData Browser, verify containers/models appear and can be searched.
3. Open a model:
   • inspect instances and properties,
   • edit a supported attribute (String/Int/Double/Bool/Date),
   • delete an item,
   • export JSON,
   • verify persisted changes in app behavior/data.

## Screenshots / recordings (if applicable)
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-16 at 15 35 37" src="https://github.com/user-attachments/assets/97ed94b0-7c94-4748-b8cd-88e94faee909" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-16 at 15 35 46" src="https://github.com/user-attachments/assets/b02e66c5-277a-401f-b08b-5a06b21a8aeb" />


## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
