### PR TITLE
feat: SwiftData Browser — Phase 1 MVP (Issue #311)

### DIFF
--- a/DebugSwift/Sources/Features/Resources/SwiftData/DebugSwift.SwiftDataBrowserViewController.swift
+++ b/DebugSwift/Sources/Features/Resources/SwiftData/DebugSwift.SwiftDataBrowserViewController.swift
@@ -1,0 +1,335 @@
+//
+//  DebugSwift.SwiftDataBrowserViewController.swift
+//  DebugSwift
+//
+//  Root browser — lists all registered SwiftData models grouped by container.
+//
+
+import UIKit
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataBrowserViewController: BaseController {
+
+    // MARK: - Properties
+
+    private var registrations: [SwiftDataContextRegistration] = []
+    private var filteredRegistrations: [SwiftDataContextRegistration] = []
+    private var selectedRegistration: SwiftDataContextRegistration?
+
+    private var searchController: UISearchController!
+
+    private lazy var contextSegmentedControl: UISegmentedControl = {
+        let control = UISegmentedControl()
+        control.translatesAutoresizingMaskIntoConstraints = false
+        control.addTarget(self, action: #selector(contextChanged), for: .valueChanged)
+        return control
+    }()
+
+    private lazy var tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .grouped)
+        table.translatesAutoresizingMaskIntoConstraints = false
+        table.delegate = self
+        table.dataSource = self
+        table.register(SwiftDataModelCell.self, forCellReuseIdentifier: "ModelCell")
+        return table
+    }()
+
+    private lazy var emptyStateLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .secondaryLabel
+        label.font = .systemFont(ofSize: 15, weight: .regular)
+        label.text = "No SwiftData containers configured.\n\nUse:\nDebugSwift.Resources.shared\n  .configureSwiftData(contexts:)"
+        return label
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        loadData()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        ImpactFeedback.generate()
+    }
+}
+
+// MARK: - Setup
+
+private extension SwiftDataBrowserViewController {
+
+    func setup() {
+        setupViews()
+        setupNavigation()
+        setupSearchController()
+    }
+
+    func setupViews() {
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    func setupNavigation() {
+        title = "SwiftData Browser"
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .refresh,
+            target: self,
+            action: #selector(refreshData)
+        )
+    }
+
+    func setupSearchController() {
+        searchController = UISearchController(searchResultsController: nil)
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = "Search models"
+        navigationItem.searchController = searchController
+        definesPresentationContext = true
+    }
+
+    func setupSegmentedControl() {
+        guard registrations.count > 1 else {
+            tableView.tableHeaderView = nil
+            return
+        }
+
+        contextSegmentedControl.removeAllSegments()
+        for (index, reg) in registrations.enumerated() {
+            contextSegmentedControl.insertSegment(withTitle: reg.name, at: index, animated: false)
+        }
+        contextSegmentedControl.selectedSegmentIndex = 0
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(contextSegmentedControl)
+
+        NSLayoutConstraint.activate([
+            contextSegmentedControl.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+            contextSegmentedControl.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            contextSegmentedControl.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            contextSegmentedControl.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -8),
+            container.heightAnchor.constraint(equalToConstant: 60)
+        ])
+
+        tableView.tableHeaderView = container
+    }
+
+    // MARK: - Actions
+
+    @objc func contextChanged() {
+        let index = contextSegmentedControl.selectedSegmentIndex
+        guard index >= 0, index < registrations.count else { return }
+        selectedRegistration = registrations[index]
+        applyFilter()
+    }
+
+    @objc func refreshData() {
+        loadData()
+    }
+
+    // MARK: - Data
+
+    func loadData() {
+        registrations = SwiftDataManager.shared.getAvailableContexts()
+        selectedRegistration = SwiftDataManager.shared.getDefaultContext()
+
+        if registrations.isEmpty {
+            showEmptyState()
+        } else {
+            hideEmptyState()
+            setupSegmentedControl()
+            applyFilter()
+        }
+    }
+
+    func applyFilter() {
+        guard let selected = selectedRegistration else {
+            filteredRegistrations = []
+            tableView.reloadData()
+            return
+        }
+
+        let searchText = searchController.searchBar.text ?? ""
+        if searchText.isEmpty {
+            filteredRegistrations = [selected]
+        } else {
+            let filtered = selected.models.filter {
+                $0.displayName.localizedCaseInsensitiveContains(searchText)
+            }
+            filteredRegistrations = filtered.isEmpty ? [] : [
+                SwiftDataContextRegistration(
+                    name: selected.name,
+                    container: selected.container,
+                    models: filtered
+                )
+            ]
+        }
+
+        tableView.reloadData()
+        updateEmptyState()
+    }
+
+    // MARK: - Empty State
+
+    func showEmptyState() {
+        tableView.backgroundView = emptyStateLabel
+        tableView.separatorStyle = .none
+    }
+
+    func hideEmptyState() {
+        tableView.backgroundView = nil
+        tableView.separatorStyle = .singleLine
+    }
+
+    func updateEmptyState() {
+        guard let selected = selectedRegistration else {
+            showEmptyState()
+            return
+        }
+        let visibleModels = filteredRegistrations.first?.models ?? []
+        if visibleModels.isEmpty {
+            emptyStateLabel.text = selected.models.isEmpty
+                ? "No models registered in this container."
+                : "No results for \"\(searchController.searchBar.text ?? "")\"."
+            showEmptyState()
+        } else {
+            hideEmptyState()
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension SwiftDataBrowserViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return filteredRegistrations.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return filteredRegistrations[section].models.count
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard filteredRegistrations.count > 1 else { return nil }
+        return filteredRegistrations[section].name
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ModelCell", for: indexPath) as! SwiftDataModelCell
+        let reg = filteredRegistrations[indexPath.section]
+        let model = reg.models[indexPath.row]
+        let context = ModelContext(reg.container)
+        let count = (try? SwiftDataManager.shared.fetchInstances(registration: model, context: context).count) ?? 0
+        cell.configure(name: model.displayName, count: count)
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension SwiftDataBrowserViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 70
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let reg = filteredRegistrations[indexPath.section]
+        let model = reg.models[indexPath.row]
+        let instancesVC = SwiftDataInstancesViewController(
+            modelRegistration: model,
+            container: reg.container
+        )
+        navigationController?.pushViewController(instancesVC, animated: true)
+    }
+}
+
+// MARK: - UISearchResultsUpdating
+
+extension SwiftDataBrowserViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        applyFilter()
+    }
+}
+
+// MARK: - Model Cell
+
+final class SwiftDataModelCell: UITableViewCell {
+
+    private let iconImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        iv.contentMode = .scaleAspectFit
+        iv.tintColor = .systemPurple
+        iv.image = UIImage(systemName: "tray.full.fill")
+        return iv
+    }()
+
+    private let nameLabel: UILabel = {
+        let l = UILabel()
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.font = .systemFont(ofSize: 16, weight: .medium)
+        return l
+    }()
+
+    private let countLabel: UILabel = {
+        let l = UILabel()
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.font = .systemFont(ofSize: 14)
+        l.textColor = .secondaryLabel
+        return l
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupViews() {
+        accessoryType = .disclosureIndicator
+        contentView.addSubview(iconImageView)
+        contentView.addSubview(nameLabel)
+        contentView.addSubview(countLabel)
+
+        NSLayoutConstraint.activate([
+            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 36),
+            iconImageView.heightAnchor.constraint(equalToConstant: 36),
+
+            nameLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 12),
+            nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 14),
+            nameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -40),
+
+            countLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
+            countLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 4),
+            countLabel.trailingAnchor.constraint(equalTo: nameLabel.trailingAnchor)
+        ])
+    }
+
+    func configure(name: String, count: Int) {
+        nameLabel.text = name
+        countLabel.text = "\(count) \(count == 1 ? "instance" : "instances")"
+    }
+}
+
+#endif

--- a/DebugSwift/Sources/Features/Resources/SwiftData/DebugSwift.SwiftDataInstanceDetailViewController.swift
+++ b/DebugSwift/Sources/Features/Resources/SwiftData/DebugSwift.SwiftDataInstanceDetailViewController.swift
@@ -1,0 +1,254 @@
+//
+//  DebugSwift.SwiftDataInstanceDetailViewController.swift
+//  DebugSwift
+//
+//  Detail view for a single SwiftData model instance — shows all properties.
+//
+
+import UIKit
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataInstanceDetailViewController: BaseController {
+
+    // MARK: - Properties
+
+    private let model: any PersistentModel
+    private let modelRegistration: SwiftDataModelRegistration
+    private let context: ModelContext
+
+    private var properties: [(label: String, value: String)] = []
+
+    private lazy var tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .insetGrouped)
+        table.translatesAutoresizingMaskIntoConstraints = false
+        table.delegate = self
+        table.dataSource = self
+        table.register(SwiftDataPropertyCell.self, forCellReuseIdentifier: "PropertyCell")
+        return table
+    }()
+
+    // MARK: - Init
+
+    init(
+        model: any PersistentModel,
+        modelRegistration: SwiftDataModelRegistration,
+        context: ModelContext
+    ) {
+        self.model = model
+        self.modelRegistration = modelRegistration
+        self.context = context
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        loadProperties()
+    }
+}
+
+// MARK: - Setup
+
+private extension SwiftDataInstanceDetailViewController {
+
+    func setup() {
+        setupViews()
+        setupNavigation()
+    }
+
+    func setupViews() {
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    func setupNavigation() {
+        title = modelRegistration.displayName
+
+        if !SwiftDataManager.shared.readOnlyMode {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                barButtonSystemItem: .action,
+                target: self,
+                action: #selector(shareProperties)
+            )
+        }
+    }
+
+    func loadProperties() {
+        properties = SwiftDataManager.shared.properties(of: model)
+        tableView.reloadData()
+    }
+
+    // MARK: - Actions
+
+    @objc func shareProperties() {
+        let text = properties.map { "\($0.label): \($0.value)" }.joined(separator: "\n")
+        let activityVC = UIActivityViewController(
+            activityItems: [text],
+            applicationActivities: nil
+        )
+        if let popover = activityVC.popoverPresentationController {
+            popover.barButtonItem = navigationItem.rightBarButtonItem
+        }
+        present(activityVC, animated: true)
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension SwiftDataInstanceDetailViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int { 2 }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch section {
+        case 0: return 2                  // Model name + persistent identifier
+        case 1: return properties.count   // All reflected properties
+        default: return 0
+        }
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch section {
+        case 0: return "Instance Information"
+        case 1: return "Properties (\(properties.count))"
+        default: return nil
+        }
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch indexPath.section {
+        case 0:
+            let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+            cell.selectionStyle = .none
+            if indexPath.row == 0 {
+                cell.textLabel?.text = "Model"
+                cell.detailTextLabel?.text = modelRegistration.displayName
+            } else {
+                cell.textLabel?.text = "Identifier"
+                let id = model.persistentModelID
+                cell.detailTextLabel?.text = "\(id)"
+                cell.detailTextLabel?.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+            }
+            return cell
+
+        case 1:
+            let cell = tableView.dequeueReusableCell(withIdentifier: "PropertyCell", for: indexPath) as! SwiftDataPropertyCell
+            let prop = properties[indexPath.row]
+            cell.configure(label: prop.label, value: prop.value)
+            return cell
+
+        default:
+            return UITableViewCell()
+        }
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension SwiftDataInstanceDetailViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        56
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        guard indexPath.section == 1 else { return }
+        let prop = properties[indexPath.row]
+
+        // Copy value on tap
+        UIPasteboard.general.string = prop.value
+        showCopiedToast(for: prop.label)
+    }
+
+    // MARK: - Helpers
+
+    func showCopiedToast(for label: String) {
+        let alert = UIAlertController(
+            title: nil,
+            message: "Copied \"\(label)\" to clipboard",
+            preferredStyle: .alert
+        )
+        present(alert, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak alert] in
+            alert?.dismiss(animated: true)
+        }
+    }
+}
+
+// MARK: - Property Cell
+
+final class SwiftDataPropertyCell: UITableViewCell {
+
+    private let nameLabel: UILabel = {
+        let l = UILabel()
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.font = .systemFont(ofSize: 14, weight: .medium)
+        l.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        l.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        return l
+    }()
+
+    private let valueLabel: UILabel = {
+        let l = UILabel()
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        l.textColor = .secondaryLabel
+        l.textAlignment = .right
+        l.numberOfLines = 0
+        l.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return l
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setupViews() {
+        selectionStyle = .default
+        contentView.addSubview(nameLabel)
+        contentView.addSubview(valueLabel)
+
+        NSLayoutConstraint.activate([
+            nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            nameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            nameLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -12),
+            nameLabel.widthAnchor.constraint(lessThanOrEqualTo: contentView.widthAnchor, multiplier: 0.38),
+
+            valueLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            valueLabel.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 8),
+            valueLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            valueLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12)
+        ])
+    }
+
+    func configure(label: String, value: String) {
+        nameLabel.text = label
+        valueLabel.text = value.isEmpty ? "(empty)" : value
+    }
+}
+
+#endif

--- a/DebugSwift/Sources/Features/Resources/SwiftData/DebugSwift.SwiftDataInstancesViewController.swift
+++ b/DebugSwift/Sources/Features/Resources/SwiftData/DebugSwift.SwiftDataInstancesViewController.swift
@@ -1,0 +1,324 @@
+//
+//  DebugSwift.SwiftDataInstancesViewController.swift
+//  DebugSwift
+//
+//  Lists all instances of a registered SwiftData model.
+//
+
+import UIKit
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataInstancesViewController: BaseController {
+
+    // MARK: - Properties
+
+    private let modelRegistration: SwiftDataModelRegistration
+    private let container: ModelContainer
+    private var context: ModelContext
+
+    private var instances: [any PersistentModel] = []
+    private var filteredInstances: [any PersistentModel] = []
+    private var allProperties: [(label: String, value: String)] = []
+
+    private var searchController: UISearchController!
+
+    private lazy var tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .grouped)
+        table.translatesAutoresizingMaskIntoConstraints = false
+        table.delegate = self
+        table.dataSource = self
+        table.register(SwiftDataInstanceCell.self, forCellReuseIdentifier: "InstanceCell")
+        return table
+    }()
+
+    private lazy var emptyStateLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .secondaryLabel
+        label.font = .systemFont(ofSize: 15, weight: .regular)
+        return label
+    }()
+
+    // MARK: - Init
+
+    init(modelRegistration: SwiftDataModelRegistration, container: ModelContainer) {
+        self.modelRegistration = modelRegistration
+        self.container = container
+        self.context = ModelContext(container)
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        loadInstances()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        loadInstances()
+    }
+}
+
+// MARK: - Setup
+
+private extension SwiftDataInstancesViewController {
+
+    func setup() {
+        setupViews()
+        setupNavigation()
+        setupSearchController()
+    }
+
+    func setupViews() {
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    func setupNavigation() {
+        title = modelRegistration.displayName
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .refresh,
+            target: self,
+            action: #selector(refreshData)
+        )
+    }
+
+    func setupSearchController() {
+        searchController = UISearchController(searchResultsController: nil)
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = "Search instances"
+        navigationItem.searchController = searchController
+        definesPresentationContext = true
+    }
+
+    @objc func refreshData() {
+        // Rebuild context for fresh data
+        context = ModelContext(container)
+        loadInstances()
+    }
+
+    // MARK: - Data
+
+    func loadInstances() {
+        do {
+            instances = try SwiftDataManager.shared.fetchInstances(
+                registration: modelRegistration,
+                context: context
+            )
+        } catch {
+            instances = []
+            showError(error)
+        }
+        applyFilter()
+    }
+
+    func applyFilter() {
+        let searchText = searchController.searchBar.text ?? ""
+        if searchText.isEmpty {
+            filteredInstances = instances
+        } else {
+            filteredInstances = instances.filter { model in
+                let props = SwiftDataManager.shared.properties(of: model)
+                return props.contains { prop in
+                    prop.label.localizedCaseInsensitiveContains(searchText) ||
+                    prop.value.localizedCaseInsensitiveContains(searchText)
+                }
+            }
+        }
+        tableView.reloadData()
+        updateEmptyState()
+    }
+
+    // MARK: - Empty State
+
+    func updateEmptyState() {
+        if filteredInstances.isEmpty {
+            emptyStateLabel.text = instances.isEmpty
+                ? "No instances found in this model."
+                : "No results for \"\(searchController.searchBar.text ?? "")\"."
+            tableView.backgroundView = emptyStateLabel
+            tableView.separatorStyle = .none
+        } else {
+            tableView.backgroundView = nil
+            tableView.separatorStyle = .singleLine
+        }
+    }
+
+    func showError(_ error: Error) {
+        let alert = UIAlertController(
+            title: "Error",
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension SwiftDataInstancesViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int { 1 }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        filteredInstances.count
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        filteredInstances.isEmpty ? nil : "Instances (\(filteredInstances.count))"
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "InstanceCell", for: indexPath) as! SwiftDataInstanceCell
+        let model = filteredInstances[indexPath.row]
+        let props = SwiftDataManager.shared.properties(of: model)
+        cell.configure(index: indexPath.row + 1, properties: props)
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension SwiftDataInstancesViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        80
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let model = filteredInstances[indexPath.row]
+        let detailVC = SwiftDataInstanceDetailViewController(
+            model: model,
+            modelRegistration: modelRegistration,
+            context: context
+        )
+        navigationController?.pushViewController(detailVC, animated: true)
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    ) -> UISwipeActionsConfiguration? {
+        guard !SwiftDataManager.shared.readOnlyMode else { return nil }
+
+        let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, completion in
+            self?.deleteInstance(at: indexPath, completion: completion)
+        }
+        deleteAction.image = UIImage(systemName: "trash")
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+
+    func deleteInstance(at indexPath: IndexPath, completion: @escaping (Bool) -> Void) {
+        let model = filteredInstances[indexPath.row]
+
+        let alert = UIAlertController(
+            title: "Delete Instance",
+            message: "Are you sure? This cannot be undone.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
+            guard let self else { completion(false); return }
+            do {
+                try SwiftDataManager.shared.deleteInstance(
+                    model,
+                    registration: self.modelRegistration,
+                    context: self.context
+                )
+                self.loadInstances()
+                completion(true)
+            } catch {
+                self.showError(error)
+                completion(false)
+            }
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in completion(false) })
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - UISearchResultsUpdating
+
+extension SwiftDataInstancesViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        applyFilter()
+    }
+}
+
+// MARK: - Instance Cell
+
+final class SwiftDataInstanceCell: UITableViewCell {
+
+    private let titleLabel: UILabel = {
+        let l = UILabel()
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.font = .systemFont(ofSize: 15, weight: .medium)
+        l.numberOfLines = 2
+        return l
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let l = UILabel()
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.font = .systemFont(ofSize: 13)
+        l.textColor = .secondaryLabel
+        l.numberOfLines = 3
+        return l
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setupViews() {
+        accessoryType = .disclosureIndicator
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(subtitleLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -40),
+
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+            subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            subtitleLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            subtitleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12)
+        ])
+    }
+
+    func configure(index: Int, properties: [(label: String, value: String)]) {
+        let preview = properties.prefix(3)
+        let lines = preview.map { "\($0.label): \($0.value)" }
+        titleLabel.text = lines.first ?? "Instance \(index)"
+        subtitleLabel.text = lines.dropFirst().joined(separator: "\n")
+    }
+}
+
+#endif

--- a/DebugSwift/Sources/Features/Resources/SwiftData/DebugSwift.SwiftDataManager.swift
+++ b/DebugSwift/Sources/Features/Resources/SwiftData/DebugSwift.SwiftDataManager.swift
@@ -1,0 +1,119 @@
+//
+//  DebugSwift.SwiftDataManager.swift
+//  DebugSwift
+//
+//  SwiftData stack management and model discovery for the browser
+//
+
+import Foundation
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataManager: @unchecked Sendable {
+    static let shared = SwiftDataManager()
+
+    private init() {}
+
+    // MARK: - State
+
+    private var registrations: [SwiftDataContextRegistration] = []
+    var readOnlyMode: Bool = false
+
+    // MARK: - Configuration
+
+    func configure(contexts: [SwiftDataContextRegistration]) {
+        self.registrations = contexts
+    }
+
+    // MARK: - Public Accessors
+
+    func getAvailableContexts() -> [SwiftDataContextRegistration] {
+        return registrations
+    }
+
+    func getDefaultContext() -> SwiftDataContextRegistration? {
+        return registrations.first
+    }
+
+    // MARK: - Fetch
+
+    func fetchInstances(
+        registration: SwiftDataModelRegistration,
+        context: ModelContext
+    ) throws -> [any PersistentModel] {
+        return try registration.fetch(context)
+    }
+
+    // MARK: - Delete
+
+    func deleteInstance(
+        _ model: any PersistentModel,
+        registration: SwiftDataModelRegistration,
+        context: ModelContext
+    ) throws {
+        try registration.delete(context, model)
+        try context.save()
+    }
+
+    // MARK: - Property Reflection
+
+    /// Returns a list of (label, value) tuples for all stored properties on a PersistentModel.
+    func properties(of model: any PersistentModel) -> [(label: String, value: String)] {
+        let mirror = Mirror(reflecting: model)
+        var result: [(String, String)] = []
+
+        for child in mirror.children {
+            guard let label = child.label else { continue }
+            // Skip SwiftData internals (_$backingData, etc.)
+            if label.hasPrefix("_$") { continue }
+            let cleaned = label.hasPrefix("_") ? String(label.dropFirst()) : label
+            result.append((cleaned, formatValue(child.value)))
+        }
+
+        return result.sorted { $0.0 < $1.0 }
+    }
+
+    // MARK: - Helpers
+
+    private func formatValue(_ value: Any) -> String {
+        if let optional = value as? any _OptionalProtocol {
+            guard let wrapped = optional.wrappedValue else { return "nil" }
+            return formatValue(wrapped)
+        }
+        switch value {
+        case let date as Date:
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .medium
+            return formatter.string(from: date)
+        case let data as Data:
+            return "\(data.count) bytes"
+        case let url as URL:
+            return url.absoluteString
+        case let uuid as UUID:
+            return uuid.uuidString
+        default:
+            let s = String(describing: value)
+            return s.count > 80 ? String(s.prefix(77)) + "..." : s
+        }
+    }
+}
+
+// MARK: - Internal Optional helper
+
+private protocol _OptionalProtocol {
+    var wrappedValue: Any? { get }
+}
+extension Optional: _OptionalProtocol {
+    var wrappedValue: Any? {
+        switch self {
+        case .none: return nil
+        case .some(let v): return v
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Implements **SwiftData Browser** as requested in #311 — a full runtime browser for SwiftData models, following the exact same architecture as the existing **Core Data Browser**.

### What's included (Phase 1 MVP)

| Component | Description |
|-----------|-------------|
| `SwiftDataManager` | Singleton managing context registrations, fetch, delete, and property reflection via `Mirror` |
| `SwiftDataBrowserViewController` | Root view — lists all registered `@Model` types with live instance counts, search, and multi-container segmented control |
| `SwiftDataInstancesViewController` | Drill-down — all instances of a model with property preview, search filter, and swipe-to-delete |
| `SwiftDataInstanceDetailViewController` | Full property inspector — all reflected properties, tap-to-copy, share via share sheet |

### How it works

The existing public API (`SwiftDataContextRegistration` / `SwiftDataModelRegistration` in `DebugSwift.SwiftData.swift` and the `configureSwiftData(contexts:)` method in `DebugSwift.Network.swift`) was already in place — this PR provides the **missing view layer** that makes those APIs functional.

**Usage** (no changes needed to existing API):
```swift
// In your app entry point
DebugSwift.Resources.shared.configureSwiftData(contexts: [
    SwiftDataContextRegistration(
        name: "Main",
        container: modelContainer,
        models: [
            SwiftDataModelRegistration(User.self),
            SwiftDataModelRegistration(Post.self)
        ]
    )
])
```

### Architecture

```
Resources Tab → SwiftData Browser
    SwiftDataBrowserViewController        ← lists models + counts
        └─ SwiftDataInstancesViewController   ← lists instances
               └─ SwiftDataInstanceDetailViewController  ← property inspector
```

All files follow the `DebugSwift.` file-naming convention. All SwiftData code is guarded with `#if canImport(SwiftData)` and `@available(iOS 17.0, *)`. The `Resources.Controller.swift` already had the `.swiftData` case wired up — this PR fills in the implementation.

### Read-only mode

Respects `DebugSwift.Resources.shared.swiftDataReadOnly`:
- Hides swipe-to-delete when `true`
- Hides the share/export button when `true`

## Test plan

- [ ] Register at least one `@Model` type and verify it appears in the browser
- [ ] Verify instance count matches actual stored data
- [ ] Tap into instances and verify all properties are displayed correctly
- [ ] Search filters work at both the model level and instance level
- [ ] Swipe-to-delete removes the instance from SwiftData
- [ ] Read-only mode hides destructive actions
- [ ] Multiple containers show segmented control at the top
- [ ] `#available(iOS 17.0, *)` guard shows the "unavailable" alert on iOS 16 and below
- [ ] No compile errors or warnings on iOS 16 target (canImport guard)

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)