### PR TITLE
fix: correct constraint anchors in buildLabel to prevent NSGenericException crash

### DIFF
--- a/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
+++ b/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
@@ -176,8 +176,8 @@ extension FloatBallView {
         label.text = .init(0)
         ballView.addSubview(label)
         NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor)
+            label.centerXAnchor.constraint(equalTo: ballView.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: ballView.centerYAnchor)
         ])
         return label
     }


### PR DESCRIPTION
## Summary
`buildLabel()` inside `FloatBallView` was adding the label as a subview of `ballView`, 
but the Auto Layout constraints were referencing `self` (FloatBallView) as the anchor. 
Since `label` and `self` had no common ancestor at the time of constraint activation, 
this caused an `NSGenericException` crash:

"Unable to activate constraint with anchors because they have no common ancestor."

Fixed by changing the constraint anchors from `centerXAnchor`/`centerYAnchor` of `self` 
to `ballView.centerXAnchor`/`ballView.centerYAnchor`, which is the actual parent of the label.

## Type of change
- [x] Fix

## Test plan
- [x] Manual testing completed

### Manual test steps
1. Add DebugSwift to an iOS app
2. Launch the app — FloatBallView appears without crashing
3. Navigate between screens — no NSGenericException thrown

## Checklist
- [x] I reviewed my own changes
- [x] I considered backward compatibility