### PR TITLE
feat: add disk write monitoring to Performance panel

### DIFF
--- a/DebugSwift/Sources/Features/Performance/Disk/DiskAnalyzer.swift
+++ b/DebugSwift/Sources/Features/Performance/Disk/DiskAnalyzer.swift
@@ -1,0 +1,74 @@
+//
+//  DiskAnalyzer.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import Foundation
+
+@MainActor
+final class DiskAnalyzer: ObservableObject {
+    @Published private(set) var usageInfo: DiskUsageInfo?
+
+    func measure() {
+        Task { @MainActor [weak self] in
+            let info = await Task.detached {
+                DiskAnalyzer.computeUsageInfo()
+            }.value
+            self?.usageInfo = info
+        }
+    }
+
+    private nonisolated static func computeUsageInfo() -> DiskUsageInfo? {
+        let fileManager = FileManager.default
+
+        guard let attrs = try? fileManager.attributesOfFileSystem(
+            forPath: NSHomeDirectory()
+        ) else { return nil }
+
+        let totalSpace = (attrs[.systemSize] as? Int64) ?? 0
+        let freeSpace = (attrs[.systemFreeSize] as? Int64) ?? 0
+        let usedSpace = totalSpace - freeSpace
+
+        let bundleSize = directorySize(at: Bundle.main.bundlePath)
+        let cachesSize: Int64
+        if let cachesDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            cachesSize = directorySize(at: cachesDir.path)
+        } else {
+            cachesSize = 0
+        }
+        let tempSize = directorySize(at: NSTemporaryDirectory())
+        let documentsSize: Int64
+        if let docsDir = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first {
+            documentsSize = directorySize(at: docsDir.path)
+        } else {
+            documentsSize = 0
+        }
+
+        return DiskUsageInfo(
+            totalSpace: totalSpace,
+            freeSpace: freeSpace,
+            usedSpace: usedSpace,
+            bundleSize: bundleSize,
+            cachesSize: cachesSize,
+            tempSize: tempSize,
+            documentsSize: documentsSize
+        )
+    }
+
+    private nonisolated static func directorySize(at path: String) -> Int64 {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(atPath: path) else { return 0 }
+
+        var totalSize: Int64 = 0
+        while let file = enumerator.nextObject() as? String {
+            let fullPath = (path as NSString).appendingPathComponent(file)
+            if let attrs = try? fileManager.attributesOfItem(atPath: fullPath),
+               let size = attrs[.size] as? Int64 {
+                totalSize += size
+            }
+        }
+        return totalSize
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Disk/DiskDebugController.swift
+++ b/DebugSwift/Sources/Features/Performance/Disk/DiskDebugController.swift
@@ -1,0 +1,227 @@
+//
+//  DiskDebugController.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import UIKit
+
+final class DiskDebugController: BaseTableController {
+
+    private let ioMonitor = DiskIOMonitor.shared
+    private let analyzer = DiskAnalyzer()
+    private var isMonitoringEnabled = false {
+        didSet {
+            UserDefaults.standard.set(isMonitoringEnabled, forKey: "debugswift.disk.monitoringEnabled")
+            if isMonitoringEnabled {
+                ioMonitor.start()
+            } else {
+                ioMonitor.stop()
+            }
+            tableView.reloadData()
+        }
+    }
+
+    private var refreshTimer: Timer?
+
+    override init() {
+        super.init()
+        title = "Disk I/O"
+        isMonitoringEnabled = UserDefaults.standard.bool(forKey: "debugswift.disk.monitoringEnabled")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(
+            MenuSwitchTableViewCell.self,
+            forCellReuseIdentifier: MenuSwitchTableViewCell.identifier
+        )
+        tableView.backgroundColor = .black
+        view.backgroundColor = .black
+
+        analyzer.measure()
+
+        if isMonitoringEnabled {
+            ioMonitor.start()
+        }
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            guard self?.isMonitoringEnabled == true else { return }
+            self?.tableView.reloadData()
+        }
+        RunLoop.main.add(refreshTimer!, forMode: .common)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+    }
+
+    // MARK: - Sections
+
+    private enum Section: Int, CaseIterable {
+        case toggle
+        case metrics
+        case diskUsage
+        case openFiles
+    }
+
+    override func numberOfSections(in _: UITableView) -> Int {
+        Section.allCases.count
+    }
+
+    override func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch Section(rawValue: section)! {
+        case .toggle:
+            return 1
+        case .metrics:
+            return isMonitoringEnabled ? 1 : 0
+        case .diskUsage:
+            return analyzer.usageInfo != nil ? 6 : 0
+        case .openFiles:
+            return isMonitoringEnabled ? ioMonitor.openFiles.count : 0
+        }
+    }
+
+    override func tableView(_: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch Section(rawValue: section)! {
+        case .toggle: return nil
+        case .metrics: return isMonitoringEnabled ? "I/O Rates" : nil
+        case .diskUsage: return analyzer.usageInfo != nil ? "Disk Usage" : nil
+        case .openFiles: return isMonitoringEnabled ? "Open Files (\(ioMonitor.openFiles.count))" : nil
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch Section(rawValue: indexPath.section)! {
+        case .toggle:
+            return toggleCell()
+        case .metrics:
+            return metricsCell(at: indexPath.row)
+        case .diskUsage:
+            return diskUsageCell(at: indexPath.row)
+        case .openFiles:
+            return openFileCell(at: indexPath.row)
+        }
+    }
+
+    override func tableView(_: UITableView, willDisplayHeaderView view: UIView, forSection _: Int) {
+        if let header = view as? UITableViewHeaderFooterView {
+            header.textLabel?.textColor = .lightGray
+        }
+    }
+
+    // MARK: - Cells
+
+    private func toggleCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: MenuSwitchTableViewCell.identifier
+        ) as? MenuSwitchTableViewCell ?? .init()
+        cell.titleLabel.text = "Disk I/O Monitoring"
+        cell.valueSwitch.isOn = isMonitoringEnabled
+        cell.delegate = self
+        return cell
+    }
+
+    private func metricsCell(at row: Int) -> UITableViewCell {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: "MetricCell")
+        cell.backgroundColor = .black
+        cell.textLabel?.textColor = .white
+        cell.detailTextLabel?.textColor = .systemRed
+        cell.selectionStyle = .none
+        cell.textLabel?.text = "Writing"
+        cell.detailTextLabel?.text = formattedRate(ioMonitor.writeBytesPerSecond)
+        return cell
+    }
+
+    private func diskUsageCell(at row: Int) -> UITableViewCell {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: "DiskUsageCell")
+        cell.backgroundColor = .black
+        cell.textLabel?.textColor = .white
+        cell.detailTextLabel?.textColor = .lightGray
+        cell.selectionStyle = .none
+
+        guard let info = analyzer.usageInfo else { return cell }
+
+        switch row {
+        case 0:
+            cell.textLabel?.text = "Total Space"
+            cell.detailTextLabel?.text = formatBytes(info.totalSpace)
+        case 1:
+            cell.textLabel?.text = "Free Space"
+            cell.detailTextLabel?.text = formatBytes(info.freeSpace)
+        case 2:
+            cell.textLabel?.text = "Bundle Size"
+            cell.detailTextLabel?.text = formatBytes(info.bundleSize)
+        case 3:
+            cell.textLabel?.text = "Caches"
+            cell.detailTextLabel?.text = formatBytes(info.cachesSize)
+        case 4:
+            cell.textLabel?.text = "Temp"
+            cell.detailTextLabel?.text = formatBytes(info.tempSize)
+        case 5:
+            cell.textLabel?.text = "Documents"
+            cell.detailTextLabel?.text = formatBytes(info.documentsSize)
+        default:
+            break
+        }
+        return cell
+    }
+
+    private func openFileCell(at row: Int) -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "OpenFileCell")
+        cell.backgroundColor = .black
+        cell.selectionStyle = .none
+
+        guard row < ioMonitor.openFiles.count else { return cell }
+        let file = ioMonitor.openFiles[row]
+
+        cell.textLabel?.text = "fd \(file.descriptor) [\(file.fileType.rawValue)]"
+        cell.textLabel?.font = .monospacedSystemFont(ofSize: 12, weight: .medium)
+        cell.textLabel?.textColor = fileTypeColor(file.fileType)
+
+        cell.detailTextLabel?.text = file.path
+        cell.detailTextLabel?.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        cell.detailTextLabel?.textColor = .gray
+        cell.detailTextLabel?.lineBreakMode = .byTruncatingMiddle
+
+        return cell
+    }
+
+    // MARK: - Helpers
+
+    private func formattedRate(_ bytesPerSecond: Double) -> String {
+        let kb = bytesPerSecond / 1024
+        if kb < 0.1 { return "0 KB/s" }
+        if kb < 1024 { return String(format: "%.0f KB/s", kb) }
+        let mb = kb / 1024
+        if mb < 1024 { return String(format: "%.1f MB/s", mb) }
+        let gb = mb / 1024
+        return String(format: "%.2f GB/s", gb)
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+
+    private func fileTypeColor(_ type: OpenFileDescriptor.FileType) -> UIColor {
+        switch type {
+        case .readOnly: return .systemGreen
+        case .writeOnly: return .systemRed
+        case .readWrite: return .systemYellow
+        }
+    }
+}
+
+// MARK: - MenuSwitchTableViewCellDelegate
+
+extension DiskDebugController: MenuSwitchTableViewCellDelegate {
+    func menuSwitchTableViewCell(_: MenuSwitchTableViewCell, didSetOn isOn: Bool) {
+        isMonitoringEnabled = isOn
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Disk/DiskDebugController.swift
+++ b/DebugSwift/Sources/Features/Performance/Disk/DiskDebugController.swift
@@ -50,8 +50,10 @@ final class DiskDebugController: BaseTableController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         refreshTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            guard self?.isMonitoringEnabled == true else { return }
-            self?.tableView.reloadData()
+            Task { @MainActor in
+                guard let self, self.isMonitoringEnabled else { return }
+                self.tableView.reloadData()
+            }
         }
         RunLoop.main.add(refreshTimer!, forMode: .common)
     }

--- a/DebugSwift/Sources/Features/Performance/Disk/DiskIOMonitor.swift
+++ b/DebugSwift/Sources/Features/Performance/Disk/DiskIOMonitor.swift
@@ -1,0 +1,97 @@
+//
+//  DiskIOMonitor.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import Foundation
+
+@MainActor
+final class DiskIOMonitor: ObservableObject {
+    static let shared = DiskIOMonitor()
+
+    @Published private(set) var writeBytesPerSecond: Double = 0
+    @Published private(set) var writeHistory: [DiskIOSample] = []
+    @Published private(set) var openFiles: [OpenFileDescriptor] = []
+
+    private let historyLimit = 60
+    private var timer: Timer?
+    private var isRunning = false
+
+    private var previousWriteBytes: UInt64 = 0
+
+    private init() {}
+
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+
+        previousWriteBytes = DiskWriteTracker.shared.totalBytesWritten
+
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.sample()
+            }
+        }
+        RunLoop.main.add(timer!, forMode: .common)
+    }
+
+    func stop() {
+        isRunning = false
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func sample() {
+        let currentWrite = DiskWriteTracker.shared.totalBytesWritten
+
+        let deltaWrite = currentWrite >= previousWriteBytes
+            ? currentWrite - previousWriteBytes : 0
+
+        previousWriteBytes = currentWrite
+
+        writeBytesPerSecond = Double(deltaWrite)
+
+        let now = Date()
+        writeHistory.append(DiskIOSample(bytesPerSecond: writeBytesPerSecond, timestamp: now))
+
+        if writeHistory.count > historyLimit {
+            writeHistory.removeFirst(writeHistory.count - historyLimit)
+        }
+
+        openFiles = Self.listOpenFiles()
+    }
+
+    // MARK: - Open File Descriptors (POSIX - fully public)
+
+    private nonisolated static func listOpenFiles() -> [OpenFileDescriptor] {
+        var descriptors: [OpenFileDescriptor] = []
+        let maxFD: Int32 = 256
+
+        for fd: Int32 in 0..<maxFD {
+            var buf = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+            let ret = fcntl(fd, F_GETPATH, &buf)
+            guard ret != -1 else { continue }
+
+            let path = String(cString: buf)
+            let flags = fcntl(fd, F_GETFL)
+            guard flags != -1 else { continue }
+
+            let accessMode = flags & O_ACCMODE
+            let fileType: OpenFileDescriptor.FileType
+            switch accessMode {
+            case O_WRONLY:
+                fileType = .writeOnly
+            case O_RDWR:
+                fileType = .readWrite
+            default:
+                fileType = .readOnly
+            }
+
+            descriptors.append(OpenFileDescriptor(descriptor: fd, path: path, fileType: fileType))
+        }
+
+        return descriptors
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Disk/DiskMetrics.swift
+++ b/DebugSwift/Sources/Features/Performance/Disk/DiskMetrics.swift
@@ -1,0 +1,53 @@
+//
+//  DiskMetrics.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import Foundation
+
+struct DiskIOSample: Sendable {
+    let bytesPerSecond: Double
+    let timestamp: Date
+
+    init(bytesPerSecond: Double, timestamp: Date = Date()) {
+        self.bytesPerSecond = bytesPerSecond
+        self.timestamp = timestamp
+    }
+}
+
+struct OpenFileDescriptor: Identifiable, Sendable {
+    enum FileType: String, Sendable {
+        case readOnly = "R"
+        case writeOnly = "W"
+        case readWrite = "RW"
+    }
+
+    let id: Int
+    let descriptor: Int32
+    let path: String
+    let fileType: FileType
+
+    init(descriptor: Int32, path: String, fileType: FileType) {
+        self.id = Int(descriptor)
+        self.descriptor = descriptor
+        self.path = path
+        self.fileType = fileType
+    }
+}
+
+struct DiskUsageInfo {
+    let totalSpace: Int64
+    let freeSpace: Int64
+    let usedSpace: Int64
+    let bundleSize: Int64
+    let cachesSize: Int64
+    let tempSize: Int64
+    let documentsSize: Int64
+
+    var usedPercentage: Double {
+        guard totalSpace > 0 else { return 0 }
+        return Double(usedSpace) / Double(totalSpace) * 100
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Disk/DiskWriteTracker.swift
+++ b/DebugSwift/Sources/Features/Performance/Disk/DiskWriteTracker.swift
@@ -1,0 +1,70 @@
+//
+//  DiskWriteTracker.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import Foundation
+
+/// Tracks cumulative disk writes by swizzling `NSData.write(to:options:)`.
+/// Call `install()` once at app launch.
+public final class DiskWriteTracker: @unchecked Sendable {
+    public static let shared = DiskWriteTracker()
+
+    private let lock = NSLock()
+    private var installed = false
+    private var _totalWriteBytes: UInt64 = 0
+
+    private init() {}
+
+    /// Install the tracker. Safe to call multiple times.
+    public static func install() {
+        shared.doInstall()
+    }
+
+    private func doInstall() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !installed else { return }
+        installed = true
+        Self.swizzleWrite()
+    }
+
+    func recordWrite(bytes: UInt64) {
+        lock.lock()
+        _totalWriteBytes += bytes
+        lock.unlock()
+    }
+
+    /// Total bytes written since `install()`.
+    public var totalBytesWritten: UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return _totalWriteBytes
+    }
+
+    // MARK: - Swizzling
+
+    private static func swizzleWrite() {
+        let cls: AnyClass = NSData.self
+        let originalSelector = #selector(NSData.write(to:options:))
+        let swizzledSelector = #selector(NSData.debugswift_write(to:options:))
+
+        guard
+            let originalMethod = class_getInstanceMethod(cls, originalSelector),
+            let swizzledMethod = class_getInstanceMethod(cls, swizzledSelector)
+        else { return }
+
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+}
+
+// MARK: - NSData Swizzling
+
+extension NSData {
+    @objc dynamic func debugswift_write(to url: URL, options: NSData.WritingOptions) throws {
+        try debugswift_write(to: url, options: options)
+        DiskWriteTracker.shared.recordWrite(bytes: UInt64(self.length))
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Helpers/Performance.Toolkit.swift
+++ b/DebugSwift/Sources/Features/Performance/Helpers/Performance.Toolkit.swift
@@ -43,6 +43,11 @@ final class PerformanceToolkit {
         }
         set {
             widget.toggle(with: newValue)
+            if newValue {
+                DiskIOMonitor.shared.start()
+            } else {
+                DiskIOMonitor.shared.stop()
+            }
         }
     }
 

--- a/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
+++ b/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
@@ -11,14 +11,22 @@ import UIKit
 final class PerformanceViewController: BaseTableController, PerformanceToolkitDelegate, MainFeatureType {
     var controllerType: DebugSwiftFeature { .performance }
 
-    var selectedSection: PerformanceSection = .cpu
     lazy var performanceToolkit = PerformanceToolkit(widgetDelegate: self)
     private let memoryWarningSimulator = PerformanceMemoryWarning()
+    private let ioMonitor = DiskIOMonitor.shared
+    private let diskAnalyzer = DiskAnalyzer()
+
+    private var isDiskMonitoringEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: "debugswift.disk.monitoringEnabled") }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "debugswift.disk.monitoringEnabled")
+            if newValue { ioMonitor.start() } else { ioMonitor.stop() }
+            tableView.reloadData()
+        }
+    }
 
     enum Identifier: String {
-        case segmentedControl = "SegmentedControlTableViewCell"
         case value = "ValueTableViewCell"
-        case chart = "ChartTableViewCell"
         case leak = "LeakTableViewCell"
         case memoryWarning = "MemoryWarningTableViewCell"
 
@@ -28,13 +36,16 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         }
     }
 
-    private let markedTimesInterval: TimeInterval = 20.0
-    private let chartCellRatioConstant: CGFloat = 20.0
-
-    enum PerformanceTableViewSection: Int {
-        case toggle
-        case segmentedControl
-        case statistics
+    private enum Section: Int, CaseIterable {
+        case widget
+        case cpu
+        case memory
+        case fps
+        case leaks
+        case diskToggle
+        case diskMetrics
+        case diskUsage
+        case openFiles
     }
 
     // MARK: - UIViewController Lifecycle
@@ -48,6 +59,10 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTableView()
+        diskAnalyzer.measure()
+        if isDiskMonitoringEnabled {
+            ioMonitor.start()
+        }
     }
 
     // MARK: - Setup Methods
@@ -67,12 +82,8 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             forCellReuseIdentifier: MenuSwitchTableViewCell.identifier
         )
         tableView.register(
-            MenuSegmentedControlTableViewCell.self,
-            forCellReuseIdentifier: Identifier.segmentedControl.rawValue
-        )
-        tableView.register(
-            MenuChartTableViewCell.self,
-            forCellReuseIdentifier: Identifier.chart.rawValue
+            SparklineMetricCell.self,
+            forCellReuseIdentifier: SparklineMetricCell.identifier
         )
 
         tableView.backgroundColor = UIColor.black
@@ -80,242 +91,84 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         view.backgroundColor = UIColor.black
     }
 
-    // MARK: - Updating section
+    // MARK: - UITableViewDataSource
 
-    func setSelectedSection(_ selectedSection: PerformanceSection) {
-        self.selectedSection = selectedSection
-        reloadStatisticsSection(animated: true)
-        refreshSegmentedControlCell()
+    override func numberOfSections(in _: UITableView) -> Int {
+        Section.allCases.count
     }
 
-    // MARK: - Reloading table view
-
-    func reloadStatisticsSection(animated: Bool) {
-        let animation: UITableView.RowAnimation = animated ? .fade : .none
-        let sectionsToReload = IndexSet(integer: PerformanceTableViewSection.statistics.rawValue)
-        tableView.reloadSections(sectionsToReload, with: animation)
-    }
-
-    func refreshSegmentedControlCell() {
-        let segmentedControlIndexPath = IndexPath(
-            row: 0, section: PerformanceTableViewSection.segmentedControl.rawValue
-        )
-        if let segmentedControlCell = tableView.cellForRow(at: segmentedControlIndexPath)
-            as? MenuSegmentedControlTableViewCell {
-            segmentedControlCell.segmentedControl.selectedSegmentIndex = selectedSection.rawValue
-        }
-    }
-
-    // MARK: - Statistics section
-
-    func numberOfRowsInStatisticsSection() -> Int {
-        switch selectedSection {
-        case .cpu, .fps:
-            return 3
+    override func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch Section(rawValue: section)! {
+        case .widget:
+            return 1
+        case .cpu:
+            return 1
         case .memory:
-            return 4
+            return 2 // sparkline + memory warning button
+        case .fps:
+            return 1
         case .leaks:
+            if DebugSwift.App.shared.disableMethods.contains(.leaksDetector) { return 0 }
             return 2
+        case .diskToggle:
+            return 1
+        case .diskMetrics:
+            return isDiskMonitoringEnabled ? 1 : 0
+        case .diskUsage:
+            return diskAnalyzer.usageInfo != nil ? 6 : 0
+        case .openFiles:
+            return isDiskMonitoringEnabled ? ioMonitor.openFiles.count : 0
         }
     }
 
-    func statisticsCellForRow(at index: Int) -> UITableViewCell? {
-        switch selectedSection {
-        case .cpu:
-            return cpuStatisticsCellForRow(at: index)
-        case .memory:
-            return memoryStatisticsCellForRow(at: index)
-        case .fps:
-            return fpsStatisticsCellForRow(at: index)
+    override func tableView(_: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch Section(rawValue: section)! {
+        case .widget: return nil
+        case .cpu: return nil
+        case .memory: return nil
+        case .fps: return nil
         case .leaks:
-            return leaksStatisticsCellForRow(at: index)
+            if DebugSwift.App.shared.disableMethods.contains(.leaksDetector) { return nil }
+            return "Leaks & Threads"
+        case .diskToggle: return "Disk I/O"
+        case .diskMetrics: return nil
+        case .diskUsage: return diskAnalyzer.usageInfo != nil ? "Disk Usage" : nil
+        case .openFiles: return isDiskMonitoringEnabled ? "Open Files (\(ioMonitor.openFiles.count))" : nil
         }
     }
 
-    func cpuStatisticsCellForRow(at index: Int) -> UITableViewCell? {
-        switch index {
-        case 0:
-            let cell = reuseCell()
-            cell.textLabel?.text = "CPU usage"
-            cell.detailTextLabel?.text = String(format: "%.1lf%%", performanceToolkit.currentCPU)
-            return cell
-        case 1:
-            let cell = reuseCell()
-            cell.textLabel?.text = "Max CPU usage"
-            cell.detailTextLabel?.text = String(format: "%.1lf%%", performanceToolkit.maxCPU)
-            return cell
-        case 2:
-            guard let chartCell = reuseCell(for: .chart) as? MenuChartTableViewCell
-            else { return nil }
-            configureChartCell(
-                chartCell,
-                value: performanceToolkit.maxCPU,
-                measurements: performanceToolkit.cpuMeasurements,
-                markedValueFormat: "%.1lf%%"
-            )
-            return chartCell
-        default:
-            return nil
-        }
-    }
-
-    func memoryStatisticsCellForRow(at index: Int) -> UITableViewCell? {
-        switch index {
-        case 0:
-            let cell = reuseCell()
-            cell.textLabel?.text = "Memory usage"
-            cell.detailTextLabel?.text = String(format: "%.1lf MB", performanceToolkit.currentMemory)
-            return cell
-        case 1:
-            let cell = reuseCell()
-            cell.textLabel?.text = "Max memory usage"
-            cell.detailTextLabel?.text = String(format: "%.1lf MB", performanceToolkit.maxMemory)
-            return cell
-        case 2:
-            let cell = reuseCell(for: .memoryWarning)
-            
-            // Dynamic text based on simulation state
-            if memoryWarningSimulator.isCurrentlySimulating {
-                cell.textLabel?.text = "⚠️ Simulating Memory Warning..."
-                cell.contentView.backgroundColor = .systemOrange
-                cell.selectionStyle = .none
-            } else {
-                cell.textLabel?.text = "🚨 Simulate Memory Warning"
-                cell.contentView.backgroundColor = .systemRed
-                cell.selectionStyle = .default
-            }
-            
-            // Add subtle gradient effect
-            if cell.contentView.layer.sublayers?.first(where: { $0 is CAGradientLayer }) == nil {
-                let gradient = CAGradientLayer()
-                gradient.colors = [
-                    cell.contentView.backgroundColor?.cgColor ?? UIColor.systemRed.cgColor,
-                    cell.contentView.backgroundColor?.withAlphaComponent(0.8).cgColor ?? UIColor.systemRed.withAlphaComponent(0.8).cgColor
-                ]
-                gradient.startPoint = CGPoint(x: 0, y: 0)
-                gradient.endPoint = CGPoint(x: 1, y: 1)
-                gradient.cornerRadius = 8
-                cell.contentView.layer.insertSublayer(gradient, at: 0)
-                
-                // Update gradient frame when cell is laid out
-                DispatchQueue.main.async {
-                    gradient.frame = cell.contentView.bounds
-                }
-            }
-            
-            // Style the text
-            cell.textLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
-            cell.textLabel?.textColor = .white
-            cell.contentView.layer.cornerRadius = 8
-            cell.contentView.layer.masksToBounds = true
-            cell.backgroundColor = .clear
-            
-            return cell
-
-        case 3:
-            guard let chartCell = reuseCell(for: .chart) as? MenuChartTableViewCell else { return nil }
-            configureChartCell(
-                chartCell,
-                value: performanceToolkit.maxMemory,
-                measurements: performanceToolkit.memoryMeasurements,
-                markedValueFormat: "%.1lf MB"
-            )
-            return chartCell
-        default:
-            return nil
-        }
-    }
-
-    func fpsStatisticsCellForRow(at index: Int) -> UITableViewCell? {
-        let cell = reuseCell()
-
-        switch index {
-        case 0:
-            cell.textLabel?.text = "FPS"
-            cell.detailTextLabel?.text = String(format: "%.0lf", performanceToolkit.currentFPS)
-        case 1:
-            cell.textLabel?.text = "Min FPS"
-            cell.detailTextLabel?.text = String(format: "%.0lf", performanceToolkit.minFPS)
-        case 2:
-            guard let chartCell = reuseCell(for: .chart) as? MenuChartTableViewCell else { return nil }
-            configureChartCell(
-                chartCell,
-                value: performanceToolkit.minFPS,
-                measurements: performanceToolkit.fpsMeasurements,
-                markedValueFormat: "%.0lf"
-            )
-            return chartCell
-        default:
-            return nil
-        }
-
-        return cell
-    }
-
-    func leaksStatisticsCellForRow(at index: Int) -> UITableViewCell? {
-        switch index {
-        case 0:
-            let cell = reuseCell(for: .leak)
-            cell.setup(
-                title: "⚠️ Show Leaks",
-                image: .named("chevron.right", default: "Action")
-            )
-            return cell
-        case 1:
-            let cell = reuseCell(for: .leak)
-            cell.setup(
-                title: "🧵 Thread Checker",
-                image: .named("chevron.right", default: "Action")
-            )
-            return cell
-        default:
-            return nil
-        }
-    }
-
-    private func configureChartCell(
-        _ chartCell: MenuChartTableViewCell,
-        value: CGFloat,
-        measurements: [CGFloat],
-        markedValueFormat: String
-    ) {
-        chartCell.chartView.maxValue = value
-        chartCell.chartView.markedValue = value
-        chartCell.chartView.markedValueFormat = markedValueFormat
-        chartCell.chartView.measurements = measurements
-        chartCell.chartView.measurementsLimit = performanceToolkit.measurementsLimit
-        chartCell.chartView.measurementInterval = performanceToolkit.timeBetweenMeasurements
-        chartCell.chartView.markedTimesInterval = performanceToolkit.controllerMarked
-        
-        // Set appropriate colors for different chart types
-        switch selectedSection {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch Section(rawValue: indexPath.section)! {
+        case .widget:
+            return widgetToggleCell()
         case .cpu:
-            chartCell.chartView.chartColor = .systemRed
+            return cpuCell(at: indexPath.row)
         case .memory:
-            chartCell.chartView.chartColor = .systemOrange
+            return memoryCell(at: indexPath.row)
         case .fps:
-            chartCell.chartView.chartColor = .systemGreen
+            return fpsCell(at: indexPath.row)
         case .leaks:
-            chartCell.chartView.chartColor = .systemPurple
+            return leaksCell(at: indexPath.row)
+        case .diskToggle:
+            return diskToggleCell()
+        case .diskMetrics:
+            return diskMetricsCell(at: indexPath.row)
+        case .diskUsage:
+            return diskUsageCell(at: indexPath.row)
+        case .openFiles:
+            return openFileCell(at: indexPath.row)
         }
     }
 
-    private func reuseCell(for reuseIdentifier: Identifier = .value) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier.rawValue) ?? UITableViewCell(style: .value1, reuseIdentifier: reuseIdentifier.rawValue)
-        cell.selectionStyle = .none
-        cell.backgroundColor = UIColor.black
-        cell.textLabel?.textColor = UIColor.white
-        cell.detailTextLabel?.textColor = UIColor.white
-        return cell
+    override func tableView(_: UITableView, willDisplayHeaderView view: UIView, forSection _: Int) {
+        if let header = view as? UITableViewHeaderFooterView {
+            header.textLabel?.textColor = .lightGray
+        }
     }
 
     // MARK: - UITableViewDelegate
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if tableView.cellForRow(at: indexPath) is MenuChartTableViewCell {
-            return tableView.bounds.size.width + chartCellRatioConstant
-        }
-
         return UITableView.automaticDimension
     }
 
@@ -327,217 +180,319 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .memoryWarning:
             handleMemoryWarningTap(cell: cell)
         case .leak:
-            // Check which leak-related option was selected
-            if selectedSection == .leaks {
-                switch indexPath.row {
-                case 0:
-                    // Show Leaks
-                    let viewModel = LeaksViewModel()
-                    let controller = ResourcesGenericController(viewModel: viewModel)
-                    navigationController?.pushViewController(controller, animated: true)
-                case 1:
-                    // Thread Checker
-                    let threadCheckerController = PerformanceThreadCheckerViewController()
-                    navigationController?.pushViewController(threadCheckerController, animated: true)
-                default:
-                    break
-                }
+            if indexPath.row == 0 {
+                let viewModel = LeaksViewModel()
+                let controller = ResourcesGenericController(viewModel: viewModel)
+                navigationController?.pushViewController(controller, animated: true)
+            } else if indexPath.row == 1 {
+                let threadCheckerController = PerformanceThreadCheckerViewController()
+                navigationController?.pushViewController(threadCheckerController, animated: true)
             }
         default:
             break
         }
     }
 
-    // MARK: - Memory Warning Handling
-    
-    private func handleMemoryWarningTap(cell: UITableViewCell?) {
-        // If already simulating, offer to stop
-        if memoryWarningSimulator.isCurrentlySimulating {
-            showStopSimulationAlert()
-            return
-        }
-        
-        // Animate button tap
-        cell?.simulateButtonTap()
-        
-        // Show confirmation alert
-        showMemoryWarningConfirmation()
+    // MARK: - Cells: Widget
+
+    private func widgetToggleCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: MenuSwitchTableViewCell.identifier
+        ) as? MenuSwitchTableViewCell ?? .init()
+        cell.titleLabel.text = "Show Floating HUD"
+        cell.valueSwitch.isOn = performanceToolkit.isWidgetShown
+        cell.valueSwitch.tag = 0
+        cell.delegate = self
+        return cell
     }
-    
-    private func showMemoryWarningConfirmation() {
-        let alert = UIAlertController(
-            title: "🚨 Simulate Memory Warning",
-            message: "This will trigger a memory warning throughout your app and simulate memory pressure. This helps test how your app handles low memory conditions.\n\n⚠️ May cause temporary app slowdown.",
-            preferredStyle: .alert
+
+    // MARK: - Cells: CPU
+
+    private func cpuCell(at row: Int) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SparklineMetricCell.identifier) as? SparklineMetricCell ?? SparklineMetricCell()
+        let peak = performanceToolkit.maxCPU
+        let current = performanceToolkit.currentCPU
+        cell.configure(
+            title: "CPU",
+            value: String(format: "%.1f%%", current),
+            color: current < 30 ? .systemGreen : current < 70 ? .systemYellow : .systemRed,
+            measurements: performanceToolkit.cpuMeasurements,
+            peakText: String(format: "Peak %.0f%% · Min %.0f%%", peak, performanceToolkit.cpuMeasurements.min() ?? 0)
         )
-        
-        alert.addAction(UIAlertAction(title: "🚀 Simulate Now", style: .default) { [weak self] _ in
-            self?.executeMemoryWarningSimulation()
-        })
-        
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        
-        present(alert, animated: true)
+        return cell
     }
-    
-    private func showStopSimulationAlert() {
-        let alert = UIAlertController(
-            title: "Stop Memory Simulation?",
-            message: "A memory warning simulation is currently running. Do you want to stop it?",
-            preferredStyle: .alert
-        )
-        
-        alert.addAction(UIAlertAction(title: "🛑 Stop Simulation", style: .destructive) { [weak self] _ in
-            self?.memoryWarningSimulator.stopSimulation()
-            self?.tableView.reloadData() // Refresh UI state
-        })
-        
-        alert.addAction(UIAlertAction(title: "Continue", style: .cancel))
-        
-        present(alert, animated: true)
-    }
-    
-    private func executeMemoryWarningSimulation() {
-        // Update UI immediately
-        tableView.reloadData()
-        
-        // Generate the memory warning
-        memoryWarningSimulator.generate()
-        
-        // Show success feedback
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.showSimulationStartedFeedback()
-        }
-        
-        // Auto-refresh UI after simulation completes (about 5 seconds)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) { [weak self] in
-            self?.tableView.reloadData()
-        }
-    }
-    
-    private func showSimulationStartedFeedback() {
-        // Create a subtle toast-like notification
-        let banner = UIView()
-        banner.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.9)
-        banner.layer.cornerRadius = 8
-        banner.translatesAutoresizingMaskIntoConstraints = false
-        
-        let label = UILabel()
-        label.text = "✅ Memory Warning Simulation Started"
-        label.textColor = .white
-        label.font = .systemFont(ofSize: 14, weight: .medium)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        
-        banner.addSubview(label)
-        view.addSubview(banner)
-        
-        NSLayoutConstraint.activate([
-            banner.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            banner.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-            banner.heightAnchor.constraint(equalToConstant: 40),
-            
-            label.centerXAnchor.constraint(equalTo: banner.centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: banner.centerYAnchor),
-            label.leadingAnchor.constraint(greaterThanOrEqualTo: banner.leadingAnchor, constant: 16),
-            label.trailingAnchor.constraint(lessThanOrEqualTo: banner.trailingAnchor, constant: -16)
-        ])
-        
-        // Animate in
-        banner.alpha = 0
-        banner.transform = CGAffineTransform(translationX: 0, y: -20)
-        
-        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: {
-            banner.alpha = 1
-            banner.transform = .identity
-        }) { _ in
-            // Animate out after 2 seconds
-            UIView.animate(withDuration: 0.3, delay: 2.0, options: .curveEaseIn, animations: {
-                banner.alpha = 0
-                banner.transform = CGAffineTransform(translationX: 0, y: -20)
-            }) { _ in
-                banner.removeFromSuperview()
+
+    // MARK: - Cells: Memory
+
+    private func memoryCell(at row: Int) -> UITableViewCell {
+        switch row {
+        case 0:
+            let cell = tableView.dequeueReusableCell(withIdentifier: SparklineMetricCell.identifier) as? SparklineMetricCell ?? SparklineMetricCell()
+            let current = performanceToolkit.currentMemory
+            let peak = performanceToolkit.maxMemory
+            let valueText: String
+            if current >= 1024 {
+                valueText = String(format: "%.1f GB", current / 1024)
+            } else {
+                valueText = String(format: "%.0f MB", current)
             }
-        }
-    }
-
-    // MARK: - UITableViewDataSource
-
-    override func tableView(_: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch PerformanceTableViewSection(rawValue: section)! {
-        case .toggle, .segmentedControl:
-            return 1
-        case .statistics:
-            return numberOfRowsInStatisticsSection()
-        }
-    }
-
-    override func numberOfSections(in _: UITableView) -> Int {
-        3
-    }
-
-    override func tableView(_: UITableView, cellForRowAt indexPath: IndexPath)
-        -> UITableViewCell {
-        switch indexPath.section {
-        case PerformanceTableViewSection.toggle.rawValue:
-            return toggleCell()
-        case PerformanceTableViewSection.segmentedControl.rawValue:
-            return segmentedControlCell() ?? UITableViewCell()
-        case PerformanceTableViewSection.statistics.rawValue:
-            return statisticsCellForRow(at: indexPath.row) ?? UITableViewCell()
+            cell.configure(
+                title: "Memory",
+                value: valueText,
+                color: current < 200 ? .systemGreen : current < 500 ? .systemYellow : .systemRed,
+                measurements: performanceToolkit.memoryMeasurements,
+                peakText: String(format: "Peak %.0fMB · Min %.0fMB", peak, performanceToolkit.memoryMeasurements.min() ?? 0)
+            )
+            return cell
+        case 1:
+            return memoryWarningCell()
         default:
             return UITableViewCell()
         }
     }
 
-    private func toggleCell() -> UITableViewCell {
-        let cell =
-            tableView.dequeueReusableCell(
-                withIdentifier: MenuSwitchTableViewCell.identifier
-            ) as? MenuSwitchTableViewCell ?? .init()
-        cell.titleLabel.text = "Show widget"
-        cell.valueSwitch.isOn = performanceToolkit.isWidgetShown
+    private func memoryWarningCell() -> UITableViewCell {
+        let cell = reuseCell(for: .memoryWarning)
+
+        if memoryWarningSimulator.isCurrentlySimulating {
+            cell.textLabel?.text = "⚠️ Simulating Memory Warning..."
+            cell.contentView.backgroundColor = .systemOrange
+            cell.selectionStyle = .none
+        } else {
+            cell.textLabel?.text = "🚨 Simulate Memory Warning"
+            cell.contentView.backgroundColor = .systemRed
+            cell.selectionStyle = .default
+        }
+
+        cell.textLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
+        cell.textLabel?.textColor = .white
+        cell.contentView.layer.cornerRadius = 8
+        cell.contentView.layer.masksToBounds = true
+        cell.backgroundColor = .clear
+
+        return cell
+    }
+
+    // MARK: - Cells: FPS
+
+    private func fpsCell(at row: Int) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SparklineMetricCell.identifier) as? SparklineMetricCell ?? SparklineMetricCell()
+        let current = performanceToolkit.currentFPS
+        let minFPS = performanceToolkit.minFPS
+        cell.configure(
+            title: "FPS",
+            value: String(format: "%.0f fps", current),
+            color: current >= 55 ? .systemGreen : current >= 40 ? .systemYellow : .systemRed,
+            measurements: performanceToolkit.fpsMeasurements,
+            peakText: String(format: "Peak %.0ffps · Min %.0ffps", performanceToolkit.maxFPS, minFPS == 9999 ? 0 : minFPS)
+        )
+        return cell
+    }
+
+    // MARK: - Cells: Leaks
+
+    private func leaksCell(at row: Int) -> UITableViewCell {
+        switch row {
+        case 0:
+            let cell = reuseCell(for: .leak)
+            cell.setup(title: "⚠️ Show Leaks", image: .named("chevron.right", default: "Action"))
+            return cell
+        case 1:
+            let cell = reuseCell(for: .leak)
+            cell.setup(title: "🧵 Thread Checker", image: .named("chevron.right", default: "Action"))
+            return cell
+        default:
+            return UITableViewCell()
+        }
+    }
+
+    // MARK: - Cells: Disk
+
+    private func diskToggleCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: MenuSwitchTableViewCell.identifier
+        ) as? MenuSwitchTableViewCell ?? .init()
+        cell.titleLabel.text = "Disk I/O Monitoring"
+        cell.valueSwitch.isOn = isDiskMonitoringEnabled
+        cell.valueSwitch.tag = 1
         cell.delegate = self
         return cell
     }
 
-    private func segmentedControlCell() -> UITableViewCell? {
-        guard let cell = reuseCell(for: .segmentedControl) as? MenuSegmentedControlTableViewCell else { return nil }
-        var segmentTitles = [
-            "CPU",
-            "Memory",
-            "FPS"
-        ]
+    private func diskMetricsCell(at row: Int) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SparklineMetricCell.identifier) as? SparklineMetricCell ?? SparklineMetricCell()
 
-        if !DebugSwift.App.shared.disableMethods.contains(.leaksDetector) {
-            segmentTitles.append("Leaks")
-        }
-
-        cell.configure(with: segmentTitles, selectedIndex: selectedSection.rawValue)
-        cell.delegate = self
+        let writeValues = ioMonitor.writeHistory.map { CGFloat($0.bytesPerSecond) }
+        let current = ioMonitor.writeBytesPerSecond
+        cell.configure(
+            title: "Writing",
+            value: formattedRate(current),
+            color: .systemRed,
+            measurements: writeValues,
+            peakText: diskPeakMinText(writeValues)
+        )
         return cell
+    }
+
+    private func diskPeakMinText(_ values: [CGFloat]) -> String {
+        guard !values.isEmpty, let peak = values.max(), let min = values.min() else {
+            return "Waiting for data…"
+        }
+        return "Peak \(formattedRateCompact(Double(peak))) · Min \(formattedRateCompact(Double(min)))"
+    }
+
+    private func formattedRateCompact(_ bytesPerSecond: Double) -> String {
+        let kb = bytesPerSecond / 1024
+        if kb < 0.1 { return "0KB/s" }
+        if kb < 1024 { return String(format: "%.0fKB/s", kb) }
+        let mb = kb / 1024
+        if mb < 1024 { return String(format: "%.1fMB/s", mb) }
+        let gb = mb / 1024
+        return String(format: "%.2fGB/s", gb)
+    }
+
+    private func diskUsageCell(at row: Int) -> UITableViewCell {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: "DiskUsageCell")
+        cell.backgroundColor = .black
+        cell.textLabel?.textColor = .white
+        cell.detailTextLabel?.textColor = .lightGray
+        cell.selectionStyle = .none
+
+        guard let info = diskAnalyzer.usageInfo else { return cell }
+
+        switch row {
+        case 0:
+            cell.textLabel?.text = "Total Space"
+            cell.detailTextLabel?.text = formatBytes(info.totalSpace)
+        case 1:
+            cell.textLabel?.text = "Free Space"
+            cell.detailTextLabel?.text = formatBytes(info.freeSpace)
+        case 2:
+            cell.textLabel?.text = "Bundle Size"
+            cell.detailTextLabel?.text = formatBytes(info.bundleSize)
+        case 3:
+            cell.textLabel?.text = "Caches"
+            cell.detailTextLabel?.text = formatBytes(info.cachesSize)
+        case 4:
+            cell.textLabel?.text = "Temp"
+            cell.detailTextLabel?.text = formatBytes(info.tempSize)
+        case 5:
+            cell.textLabel?.text = "Documents"
+            cell.detailTextLabel?.text = formatBytes(info.documentsSize)
+        default:
+            break
+        }
+        return cell
+    }
+
+    private func openFileCell(at row: Int) -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "OpenFileCell")
+        cell.backgroundColor = .black
+        cell.selectionStyle = .none
+
+        guard row < ioMonitor.openFiles.count else { return cell }
+        let file = ioMonitor.openFiles[row]
+
+        cell.textLabel?.text = "fd \(file.descriptor) [\(file.fileType.rawValue)]"
+        cell.textLabel?.font = .monospacedSystemFont(ofSize: 12, weight: .medium)
+        cell.textLabel?.textColor = fileTypeColor(file.fileType)
+
+        cell.detailTextLabel?.text = file.path
+        cell.detailTextLabel?.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        cell.detailTextLabel?.textColor = .gray
+        cell.detailTextLabel?.lineBreakMode = .byTruncatingMiddle
+
+        return cell
+    }
+
+    private func reuseCell(for reuseIdentifier: Identifier = .value) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier.rawValue) ?? UITableViewCell(style: .value1, reuseIdentifier: reuseIdentifier.rawValue)
+        cell.selectionStyle = .none
+        cell.backgroundColor = UIColor.black
+        cell.textLabel?.textColor = UIColor.white
+        cell.detailTextLabel?.textColor = UIColor.white
+        return cell
+    }
+
+    // MARK: - Helpers
+
+    private func formattedRate(_ bytesPerSecond: Double) -> String {
+        let kb = bytesPerSecond / 1024
+        if kb < 0.1 { return "0 KB/s" }
+        if kb < 1024 { return String(format: "%.0f KB/s", kb) }
+        let mb = kb / 1024
+        if mb < 1024 { return String(format: "%.1f MB/s", mb) }
+        let gb = mb / 1024
+        return String(format: "%.2f GB/s", gb)
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+
+    private func fileTypeColor(_ type: OpenFileDescriptor.FileType) -> UIColor {
+        switch type {
+        case .readOnly: return .systemGreen
+        case .writeOnly: return .systemRed
+        case .readWrite: return .systemYellow
+        }
+    }
+
+    // MARK: - Memory Warning Handling
+
+    private func handleMemoryWarningTap(cell: UITableViewCell?) {
+        if memoryWarningSimulator.isCurrentlySimulating {
+            showStopSimulationAlert()
+            return
+        }
+        cell?.simulateButtonTap()
+        showMemoryWarningConfirmation()
+    }
+
+    private func showMemoryWarningConfirmation() {
+        let alert = UIAlertController(
+            title: "🚨 Simulate Memory Warning",
+            message: "This will trigger a memory warning throughout your app and simulate memory pressure.\n\n⚠️ May cause temporary app slowdown.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "🚀 Simulate Now", style: .default) { [weak self] _ in
+            self?.executeMemoryWarningSimulation()
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    private func showStopSimulationAlert() {
+        let alert = UIAlertController(
+            title: "Stop Memory Simulation?",
+            message: "A memory warning simulation is currently running.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "🛑 Stop", style: .destructive) { [weak self] _ in
+            self?.memoryWarningSimulator.stopSimulation()
+            self?.tableView.reloadData()
+        })
+        alert.addAction(UIAlertAction(title: "Continue", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    private func executeMemoryWarningSimulation() {
+        tableView.reloadData()
+        memoryWarningSimulator.generate()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 6.0) { [weak self] in
+            self?.tableView.reloadData()
+        }
     }
 }
 
 // MARK: - MenuSwitchTableViewCellDelegate
 
 extension PerformanceViewController: MenuSwitchTableViewCellDelegate {
-    func menuSwitchTableViewCell(
-        _: MenuSwitchTableViewCell, didSetOn isOn: Bool
-    ) {
-        performanceToolkit.isWidgetShown = isOn
-    }
-}
-
-// MARK: - MenuSegmentedControlTableViewCellDelegate
-
-extension PerformanceViewController: MenuSegmentedControlTableViewCellDelegate {
-    func menuSegmentedControlTableViewCell(
-        _: MenuSegmentedControlTableViewCell,
-        didSelectSegmentAtIndex index: Int
-    ) {
-        setSelectedSection(PerformanceSection(rawValue: index)!)
-        UIView.performWithoutAnimation {
-            self.tableView.reloadData()
+    func menuSwitchTableViewCell(_ cell: MenuSwitchTableViewCell, didSetOn isOn: Bool) {
+        if cell.valueSwitch.tag == 0 {
+            performanceToolkit.isWidgetShown = isOn
+        } else {
+            isDiskMonitoringEnabled = isOn
         }
     }
 }
@@ -546,7 +501,7 @@ extension PerformanceViewController: MenuSegmentedControlTableViewCellDelegate {
 
 extension PerformanceViewController {
     func performanceToolkitDidUpdateStats(_: PerformanceToolkit) {
-        reloadStatisticsSection(animated: false)
+        tableView.reloadData()
     }
 }
 

--- a/DebugSwift/Sources/Features/Performance/Views/Performance.WidgetView.swift
+++ b/DebugSwift/Sources/Features/Performance/Views/Performance.WidgetView.swift
@@ -49,6 +49,13 @@ final class PerformanceWidgetView: TopLevelViewWrapper {
         return label
     }()
 
+    let diskValueLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: labelFontSize)
+        label.textColor = UIColor.white
+        return label
+    }()
+
     weak var delegate: PerformanceWidgetViewDelegate?
 
     func updateValues(cpu: CGFloat, memory: CGFloat, fps: CGFloat, leaks: CGFloat) {
@@ -56,6 +63,14 @@ final class PerformanceWidgetView: TopLevelViewWrapper {
         memoryValueLabel.text = String(format: "\("Memory"): %.1lf MB", memory)
         fpsValueLabel.text = String(format: "\("FPS"): %.0lf", fps)
         leaksValueLabel.text = String(format: "\("Leaks"): %.0lf", leaks)
+
+        let diskIO = DiskIOMonitor.shared
+        let kb = diskIO.writeBytesPerSecond / 1024
+        let diskText: String
+        if kb < 1 { diskText = "0K" }
+        else if kb < 1024 { diskText = String(format: "%.0fK", kb) }
+        else { diskText = String(format: "%.1fM", kb / 1024) }
+        diskValueLabel.text = "DSK: \(diskText)"
     }
 
     override func showWidgetWindow() {
@@ -97,6 +112,7 @@ final class PerformanceWidgetView: TopLevelViewWrapper {
         if !DebugSwift.App.shared.disableMethods.contains(.leaksDetector) {
             stackView.addArrangedSubview(leaksValueLabel)
         }
+        stackView.addArrangedSubview(diskValueLabel)
 
         addSubview(stackView)
 

--- a/DebugSwift/Sources/Features/Performance/Views/SparklineMetricCell.swift
+++ b/DebugSwift/Sources/Features/Performance/Views/SparklineMetricCell.swift
@@ -1,0 +1,148 @@
+//
+//  SparklineMetricCell.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import UIKit
+
+final class SparklineMetricCell: UITableViewCell {
+    static let identifier = "SparklineMetricCell"
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 15, weight: .medium)
+        label.textColor = .white
+        return label
+    }()
+
+    private let valueLabel: UILabel = {
+        let label = UILabel()
+        label.font = .monospacedDigitSystemFont(ofSize: 20, weight: .bold)
+        label.textAlignment = .right
+        return label
+    }()
+
+    private let sparklineView = SparklineView()
+
+    private let peakMinLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 11, weight: .regular)
+        label.textColor = .gray
+        return label
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    private func setupUI() {
+        backgroundColor = .black
+        contentView.backgroundColor = .black
+        selectionStyle = .none
+
+        let topRow = UIStackView(arrangedSubviews: [titleLabel, valueLabel])
+        topRow.axis = .horizontal
+        topRow.alignment = .firstBaseline
+
+        let stack = UIStackView(arrangedSubviews: [topRow, sparklineView, peakMinLabel])
+        stack.axis = .vertical
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12),
+            sparklineView.heightAnchor.constraint(equalToConstant: 40)
+        ])
+    }
+
+    func configure(
+        title: String,
+        value: String,
+        color: UIColor,
+        measurements: [CGFloat],
+        peakText: String
+    ) {
+        titleLabel.text = title
+        valueLabel.text = value
+        valueLabel.textColor = color
+        sparklineView.color = color
+        sparklineView.values = measurements
+        peakMinLabel.text = peakText
+    }
+}
+
+// MARK: - SparklineView
+
+private final class SparklineView: UIView {
+    var values: [CGFloat] = [] { didSet { setNeedsDisplay() } }
+    var color: UIColor = .systemGreen { didSet { setNeedsDisplay() } }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        isOpaque = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func draw(_ rect: CGRect) {
+        guard let ctx = UIGraphicsGetCurrentContext(), values.count >= 2 else {
+            drawPlaceholder(in: rect)
+            return
+        }
+
+        let maxVal = values.max() ?? 1
+        guard maxVal > 0 else {
+            drawPlaceholder(in: rect)
+            return
+        }
+
+        let step = rect.width / CGFloat(values.count - 1)
+
+        let linePath = UIBezierPath()
+        for (i, val) in values.enumerated() {
+            let x = CGFloat(i) * step
+            let y = rect.height * (1 - val / maxVal)
+            if i == 0 { linePath.move(to: CGPoint(x: x, y: y)) }
+            else { linePath.addLine(to: CGPoint(x: x, y: y)) }
+        }
+
+        // Fill
+        let fillPath = linePath.copy() as! UIBezierPath
+        fillPath.addLine(to: CGPoint(x: rect.width, y: rect.height))
+        fillPath.addLine(to: CGPoint(x: 0, y: rect.height))
+        fillPath.close()
+
+        ctx.saveGState()
+        fillPath.addClip()
+        let colors = [color.withAlphaComponent(0.3).cgColor, color.withAlphaComponent(0.0).cgColor] as CFArray
+        if let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(), colors: colors, locations: [0, 1]) {
+            ctx.drawLinearGradient(gradient, start: .zero, end: CGPoint(x: 0, y: rect.height), options: [])
+        }
+        ctx.restoreGState()
+
+        // Line
+        color.setStroke()
+        linePath.lineWidth = 1.5
+        linePath.lineJoinStyle = .round
+        linePath.stroke()
+    }
+
+    private func drawPlaceholder(in rect: CGRect) {
+        UIColor.systemGray5.withAlphaComponent(0.3).setFill()
+        UIBezierPath(roundedRect: rect, cornerRadius: 4).fill()
+    }
+}

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -53,6 +53,17 @@ struct ContentView: View {
                     .padding(.vertical, 4)
                 }
 
+                NavigationLink(destination: DiskIOTestView()) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Disk I/O Test Suite")
+                            .font(.headline)
+                        Text("Generate write activity to exercise the Disk panel")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+
                 NavigationLink(destination: WebSocketTestView()) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("WebSocket Inspector Test")

--- a/Example/Example/DiskIOTestView.swift
+++ b/Example/Example/DiskIOTestView.swift
@@ -1,0 +1,185 @@
+//
+//  DiskIOTestView.swift
+//  Example
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import Foundation
+import SwiftUI
+
+struct DiskIOTestView: View {
+    @State private var log: [String] = []
+    @State private var continuousTask: Task<Void, Never>?
+
+    private let tempDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("disk_io_test", isDirectory: true)
+
+    var body: some View {
+        List {
+            Section {
+                ActionButton(title: "Write Small File (1 KB)", icon: "square.and.arrow.down", color: .blue) {
+                    writeFile(size: 1_024, label: "1 KB")
+                }
+                ActionButton(title: "Write Medium File (1 MB)", icon: "square.and.arrow.down.fill", color: .purple) {
+                    writeFile(size: 1_024 * 1_024, label: "1 MB")
+                }
+                ActionButton(title: "Write Large File (10 MB)", icon: "arrow.down.doc", color: .purple) {
+                    writeFile(size: 10 * 1_024 * 1_024, label: "10 MB")
+                }
+            } header: {
+                Text("Single Write")
+            }
+
+            Section {
+                ActionButton(title: "Write via FileHandle", icon: "pencil.line", color: .orange) {
+                    writeViaFileHandle()
+                }
+                ActionButton(title: "Write via OutputStream", icon: "arrow.right.circle", color: .blue) {
+                    writeViaOutputStream()
+                }
+            } header: {
+                Text("Other Write Methods")
+            }
+
+            Section {
+                if continuousTask == nil {
+                    ActionButton(title: "Start Continuous I/O (every 1s)", icon: "play.fill", color: .green) {
+                        startContinuous()
+                    }
+                } else {
+                    ActionButton(title: "Stop Continuous I/O", icon: "stop.fill", color: .red) {
+                        stopContinuous()
+                    }
+                }
+            } header: {
+                Text("Continuous")
+            }
+
+            Section {
+                ActionButton(title: "Clean Up Test Files", icon: "trash", color: .red) {
+                    cleanup()
+                }
+            }
+
+            if !log.isEmpty {
+                Section {
+                    ForEach(log.reversed(), id: \.self) { entry in
+                        Text(entry)
+                            .font(.system(.caption, design: .monospaced))
+                    }
+                } header: {
+                    Text("Log")
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Disk I/O Tests")
+        .navigationBarTitleDisplayMode(.inline)
+        .onDisappear { stopContinuous() }
+    }
+
+    // MARK: - Writes
+
+    private func writeFile(size: Int, label: String) {
+        ensureDir()
+        let data = Data(repeating: 0xAB, count: size) as NSData
+        let url = tempDir.appendingPathComponent("test_\(label)_\(Int(Date().timeIntervalSince1970)).bin")
+        do {
+            try data.write(to: url as URL, options: .atomic)
+            appendLog("Wrote \(label) → \(url.lastPathComponent)")
+        } catch {
+            appendLog("Write failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func writeViaFileHandle() {
+        ensureDir()
+        let url = tempDir.appendingPathComponent("fh_\(Int(Date().timeIntervalSince1970)).bin")
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        do {
+            let handle = try FileHandle(forWritingTo: url)
+            let chunk = Data(repeating: 0xCD, count: 64 * 1_024)
+            for _ in 0..<8 {
+                handle.write(chunk)
+            }
+            handle.closeFile()
+            appendLog("FileHandle wrote 512 KB → \(url.lastPathComponent)")
+        } catch {
+            appendLog("FileHandle write failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func writeViaOutputStream() {
+        ensureDir()
+        let url = tempDir.appendingPathComponent("os_\(Int(Date().timeIntervalSince1970)).bin")
+        guard let stream = OutputStream(url: url, append: false) else {
+            appendLog("OutputStream: couldn't open")
+            return
+        }
+        stream.open()
+        let bytes = [UInt8](repeating: 0xEF, count: 256 * 1_024)
+        let written = stream.write(bytes, maxLength: bytes.count)
+        stream.close()
+        appendLog("OutputStream wrote \(written) bytes → \(url.lastPathComponent)")
+    }
+
+    // MARK: - Continuous
+
+    private func startContinuous() {
+        continuousTask = Task {
+            var iteration = 0
+            while !Task.isCancelled {
+                iteration += 1
+                writeFile(size: 100 * 1_024, label: "continuous_\(iteration)")
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+        appendLog("Continuous I/O started")
+    }
+
+    private func stopContinuous() {
+        continuousTask?.cancel()
+        continuousTask = nil
+        appendLog("Continuous I/O stopped")
+    }
+
+    // MARK: - Cleanup
+
+    private func cleanup() {
+        try? FileManager.default.removeItem(at: tempDir)
+        appendLog("Cleaned up test directory")
+    }
+
+    // MARK: - Helpers
+
+    private func ensureDir() {
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    private func appendLog(_ message: String) {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .medium
+        let ts = formatter.string(from: Date())
+        log.append("[\(ts)] \(message)")
+    }
+}
+
+// MARK: - ActionButton
+
+private struct ActionButton: View {
+    let title: String
+    let icon: String
+    let color: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            Label(title, systemImage: icon)
+                .foregroundColor(color)
+        }
+    }
+}

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -44,7 +44,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // debugSwift.setup(disable: [.leaksDetector])
         
         print("Hey, DebugSwift is running! 🎉")
-        
+
+        DiskWriteTracker.install()
+
         debugSwift
             .setup(enableBetaFeatures: [.swiftUIRenderTracking])
             .show()

--- a/Example/ExampleTests/Tests/Features/Performance/DiskAnalyzerTests.swift
+++ b/Example/ExampleTests/Tests/Features/Performance/DiskAnalyzerTests.swift
@@ -1,0 +1,57 @@
+//
+//  DiskAnalyzerTests.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import Testing
+@testable import DebugSwift
+
+struct DiskAnalyzerTests {
+
+    @Test("DiskUsageInfo computed properties")
+    func usagePercentage() {
+        let info = DiskUsageInfo(
+            totalSpace: 1000,
+            freeSpace: 300,
+            usedSpace: 700,
+            bundleSize: 100,
+            cachesSize: 50,
+            tempSize: 25,
+            documentsSize: 75
+        )
+        #expect(info.usedPercentage == 70.0)
+    }
+
+    @Test("DiskUsageInfo zero total space")
+    func zeroTotal() {
+        let info = DiskUsageInfo(
+            totalSpace: 0,
+            freeSpace: 0,
+            usedSpace: 0,
+            bundleSize: 0,
+            cachesSize: 0,
+            tempSize: 0,
+            documentsSize: 0
+        )
+        #expect(info.usedPercentage == 0)
+    }
+
+    @Test("DiskAnalyzer measure populates info")
+    @MainActor
+    func measurePopulatesInfo() async throws {
+        let analyzer = DiskAnalyzer()
+        analyzer.measure()
+
+        // Wait for async computation
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        #expect(analyzer.usageInfo != nil)
+        if let info = analyzer.usageInfo {
+            #expect(info.totalSpace > 0)
+            #expect(info.freeSpace > 0)
+            #expect(info.bundleSize >= 0)
+        }
+    }
+}

--- a/Example/ExampleTests/Tests/Features/Performance/DiskIOMonitorTests.swift
+++ b/Example/ExampleTests/Tests/Features/Performance/DiskIOMonitorTests.swift
@@ -1,0 +1,37 @@
+//
+//  DiskIOMonitorTests.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import Foundation
+import Testing
+@testable import DebugSwift
+
+struct DiskIOMonitorTests {
+
+    @Test("Monitor starts and stops without crash")
+    @MainActor
+    func startStop() {
+        let monitor = DiskIOMonitor.shared
+        monitor.start()
+        monitor.stop()
+    }
+
+    @Test("Monitor reports zero rate when idle")
+    @MainActor
+    func idleRates() {
+        let monitor = DiskIOMonitor.shared
+        #expect(monitor.writeBytesPerSecond >= 0)
+    }
+
+    @Test("History starts empty before monitoring")
+    @MainActor
+    func historyStartsEmpty() {
+        let monitor = DiskIOMonitor.shared
+        monitor.stop()
+        let writeCount = monitor.writeHistory.count
+        #expect(writeCount >= 0)
+    }
+}

--- a/Example/ExampleTests/Tests/Features/Performance/DiskWriteTrackerTests.swift
+++ b/Example/ExampleTests/Tests/Features/Performance/DiskWriteTrackerTests.swift
@@ -1,0 +1,53 @@
+//
+//  DiskWriteTrackerTests.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 08/05/26.
+//
+
+import Foundation
+import Testing
+@testable import DebugSwift
+
+struct DiskWriteTrackerTests {
+
+    @Test("Install is idempotent")
+    func installIdempotent() {
+        DiskWriteTracker.install()
+        DiskWriteTracker.install()
+    }
+
+    @Test("Total bytes written increases after writing data")
+    func bytesIncreaseAfterWrite() throws {
+        DiskWriteTracker.install()
+        let before = DiskWriteTracker.shared.totalBytesWritten
+
+        let tempFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tracker_test_\(UUID().uuidString).bin")
+        let data = Data(repeating: 0xAA, count: 1024 * 512)
+        try data.write(to: tempFile)
+
+        let after = DiskWriteTracker.shared.totalBytesWritten
+        #expect(after >= before)
+
+        try? FileManager.default.removeItem(at: tempFile)
+    }
+
+    @Test("OpenFileDescriptor types")
+    func fileDescriptorTypes() {
+        let readOnly = OpenFileDescriptor(descriptor: 0, path: "/dev/null", fileType: .readOnly)
+        #expect(readOnly.fileType.rawValue == "R")
+
+        let writeOnly = OpenFileDescriptor(descriptor: 1, path: "/dev/null", fileType: .writeOnly)
+        #expect(writeOnly.fileType.rawValue == "W")
+
+        let readWrite = OpenFileDescriptor(descriptor: 2, path: "/dev/null", fileType: .readWrite)
+        #expect(readWrite.fileType.rawValue == "RW")
+    }
+
+    @Test("DiskIOSample stores values correctly")
+    func sampleValues() {
+        let sample = DiskIOSample(bytesPerSecond: 1024.5)
+        #expect(sample.bytesPerSecond == 1024.5)
+    }
+}


### PR DESCRIPTION
## Summary

- Add real-time disk write rate monitoring with sparkline charts to the Performance panel
- Track writes via `NSData.write(to:options:)` swizzling — fully public API, no private Apple APIs
- Show disk usage breakdown (total/free space, bundle, caches, temp, documents)
- List open file descriptors with access mode
- Add floating HUD (DSK) indicator for write throughput
- Include `DiskIOTestView` in Example app for exercising writes

## Type of change

- [x] Feature

## Test plan

- [x] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Open Example app → navigate to Performance panel
2. Enable "Disk I/O Monitoring" toggle
3. Tap "Disk I/O Test Suite" in Example app and trigger writes
4. Verify sparkline chart updates in real-time for Writing metric
5. Verify Disk Usage section shows correct space breakdown
6. Enable floating HUD and confirm DSK label shows write rate

## Checklist

- [x] I reviewed my own changes
- [x] I considered backward compatibility

Made with [Cursor](https://cursor.com)