### PR TITLE
chore: fix a typo in `activated` throughout the code

### DIFF
--- a/DebugSwift/Sources/Features/App/Console/ConsoleViewModel.swift
+++ b/DebugSwift/Sources/Features/App/Console/ConsoleViewModel.swift
@@ -14,7 +14,7 @@ final class AppConsoleViewModel: NSObject, ResourcesGenericListViewModel {
 
     // MARK: - ViewModel
 
-    var isSearchActived = false
+    var isSearchActivated = false
 
     var reloadData: (() -> Void)?
 
@@ -23,11 +23,11 @@ final class AppConsoleViewModel: NSObject, ResourcesGenericListViewModel {
     }
 
     func numberOfItems() -> Int {
-        isSearchActived ? filteredInfo.count : data.count
+        isSearchActivated ? filteredInfo.count : data.count
     }
 
     func dataSourceForItem(atIndex index: Int) -> ViewData {
-        let info = isSearchActived ? filteredInfo[index] : data[index]
+        let info = isSearchActivated ? filteredInfo[index] : data[index]
         return .init(title: info)
     }
 
@@ -37,7 +37,7 @@ final class AppConsoleViewModel: NSObject, ResourcesGenericListViewModel {
     }
 
     func handleDeleteItemAction(atIndex index: Int) {
-        if isSearchActived {
+        if isSearchActivated {
             let info = filteredInfo.remove(at: index)
             ConsoleOutput.shared.removeAllPrintAndNSLogOutput(info)
         } else {

--- a/DebugSwift/Sources/Features/App/CustomAction/App.CustomAction.ViewModel.swift
+++ b/DebugSwift/Sources/Features/App/CustomAction/App.CustomAction.ViewModel.swift
@@ -20,7 +20,7 @@ final class AppCustomActionViewModel: NSObject, ResourcesGenericListViewModel {
 
     // MARK: - ViewModel
 
-    var isSearchActived = false
+    var isSearchActivated = false
     var isDeleteEnable: Bool { false }
     var isCustomActionEnable: Bool { true }
 
@@ -29,11 +29,11 @@ final class AppCustomActionViewModel: NSObject, ResourcesGenericListViewModel {
     func viewTitle() -> String { data.title }
 
     func numberOfItems() -> Int {
-        isSearchActived ? filtered.count : data.actions.count
+        isSearchActivated ? filtered.count : data.actions.count
     }
 
     func dataSourceForItem(atIndex index: Int) -> ViewData {
-        let info = isSearchActived ? filtered[index] : data.actions[index]
+        let info = isSearchActivated ? filtered[index] : data.actions[index]
         return .init(title: info.title)
     }
 
@@ -56,7 +56,7 @@ final class AppCustomActionViewModel: NSObject, ResourcesGenericListViewModel {
     // MARK: - Action
 
     func didTapItem(index: Int) {
-        if isSearchActived {
+        if isSearchActivated {
             filtered[index].action?()
         } else {
             data.actions[index].action?()

--- a/DebugSwift/Sources/Features/App/CustomInfo/App.CustomInfo.ViewModel.swift
+++ b/DebugSwift/Sources/Features/App/CustomInfo/App.CustomInfo.ViewModel.swift
@@ -20,7 +20,7 @@ final class AppCustomInfoViewModel: NSObject, ResourcesGenericListViewModel {
 
     // MARK: - ViewModel
 
-    var isSearchActived = false
+    var isSearchActivated = false
 
     var reloadData: (() -> Void)?
 
@@ -31,11 +31,11 @@ final class AppCustomInfoViewModel: NSObject, ResourcesGenericListViewModel {
     }
 
     func numberOfItems() -> Int {
-        isSearchActived ? filteredInfo.count : data.infos.count
+        isSearchActivated ? filteredInfo.count : data.infos.count
     }
 
     func dataSourceForItem(atIndex index: Int) -> ViewData {
-        let info = isSearchActived ? filteredInfo[index] : data.infos[index]
+        let info = isSearchActivated ? filteredInfo[index] : data.infos[index]
         return .init(title: info.title, value: info.subtitle)
     }
 

--- a/DebugSwift/Sources/Features/Performance/Leak/LeaksViewModel.swift
+++ b/DebugSwift/Sources/Features/Performance/Leak/LeaksViewModel.swift
@@ -16,7 +16,7 @@ final class LeaksViewModel: NSObject, ResourcesGenericListViewModel {
 
     // MARK: - ViewModel
 
-    var isSearchActived = false
+    var isSearchActivated = false
     var reloadData: (() -> Void)?
 
     var isDeleteEnable: Bool { true }
@@ -26,11 +26,11 @@ final class LeaksViewModel: NSObject, ResourcesGenericListViewModel {
     func viewTitle() -> String { "\(data.count) " + "Leaks" }
 
     func numberOfItems() -> Int {
-        isSearchActived ? filteredInfo.count : data.count
+        isSearchActivated ? filteredInfo.count : data.count
     }
 
     func dataSourceForItem(atIndex index: Int) -> ResourcesGenericController.CellViewData {
-        let leak = isSearchActived ? filteredInfo[index] : data[index]
+        let leak = isSearchActivated ? filteredInfo[index] : data[index]
 
         return .init(
             title: "\(leak.symbol)\(leak.details)",
@@ -44,7 +44,7 @@ final class LeaksViewModel: NSObject, ResourcesGenericListViewModel {
     }
 
     func handleDeleteItemAction(atIndex index: Int) {
-        if isSearchActived {
+        if isSearchActivated {
             let leak = filteredInfo.remove(at: index)
             PerformanceLeakDetector.shared.leaks.removeAll(where: { $0.id == leak.id })
         } else {
@@ -76,7 +76,7 @@ final class LeaksViewModel: NSObject, ResourcesGenericListViewModel {
     func didTapItem(index: Int) {
         let leak: PerformanceLeakDetector.LeakModel
 
-        if isSearchActived {
+        if isSearchActivated {
             leak = filteredInfo[index]
         } else {
             leak = data[index]

--- a/DebugSwift/Sources/Features/Resources/GenericList/Resources.Generic.Controller.swift
+++ b/DebugSwift/Sources/Features/Resources/GenericList/Resources.Generic.Controller.swift
@@ -586,7 +586,7 @@ extension ResourcesGenericController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         let searchText = searchController.searchBar.text ?? ""
         viewModel.filterContentForSearchText(searchText)
-        viewModel.isSearchActived = !searchText.isEmpty
+        viewModel.isSearchActivated = !searchText.isEmpty
         tableView.reloadData()
     }
 }
@@ -594,7 +594,7 @@ extension ResourcesGenericController: UISearchResultsUpdating {
 protocol ResourcesGenericListViewModel: AnyObject {
     typealias ViewData = ResourcesGenericController.CellViewData
 
-    var isSearchActived: Bool { get set }
+    var isSearchActivated: Bool { get set }
 
     var isDeleteEnable: Bool { get }
 

--- a/DebugSwift/Sources/Features/Resources/HTTPCookies/Resources.HTTPCookies.ViewModel.swift
+++ b/DebugSwift/Sources/Features/Resources/HTTPCookies/Resources.HTTPCookies.ViewModel.swift
@@ -33,7 +33,7 @@ final class ResourcesHTTPCookiesViewModel: NSObject, ResourcesGenericListViewMod
 
     // MARK: - ViewModel
 
-    var isSearchActived: Bool = false
+    var isSearchActivated: Bool = false
 
     var reloadData: (() -> Void)?
 
@@ -42,11 +42,11 @@ final class ResourcesHTTPCookiesViewModel: NSObject, ResourcesGenericListViewMod
     }
 
     func numberOfItems() -> Int {
-        isSearchActived ? filteredKeys.count : keys.count
+        isSearchActivated ? filteredKeys.count : keys.count
     }
 
     func dataSourceForItem(atIndex index: Int) -> ViewData {
-        let key = isSearchActived ? filteredKeys[index] : keys[index]
+        let key = isSearchActivated ? filteredKeys[index] : keys[index]
         let value: String = {
             if let cookie = storage.cookies?.first(where: { $0.domain == key.domain && $0.name == key.name }) {
                 return "\(cookie)"
@@ -57,12 +57,12 @@ final class ResourcesHTTPCookiesViewModel: NSObject, ResourcesGenericListViewMod
     }
 
     func handleClearAction() {
-        let keys = isSearchActived ? filteredKeys : self.keys
+        let keys = isSearchActivated ? filteredKeys : self.keys
         removeItems(forKeys: keys)
     }
 
     func handleDeleteItemAction(atIndex index: Int) {
-        let key = isSearchActived ? filteredKeys[index] : keys[index]
+        let key = isSearchActivated ? filteredKeys[index] : keys[index]
         removeItems(forKeys: [key])
     }
 

--- a/DebugSwift/Sources/Features/Resources/Keychain/Resources.Keychain.ViewModel.swift
+++ b/DebugSwift/Sources/Features/Resources/Keychain/Resources.Keychain.ViewModel.swift
@@ -33,7 +33,7 @@ final class ResourcesKeychainViewModel: NSObject, ResourcesGenericListViewModel 
 
     // MARK: - ViewModel
 
-    var isSearchActived = false
+    var isSearchActivated = false
 
     var reloadData: (() -> Void)?
 
@@ -46,11 +46,11 @@ final class ResourcesKeychainViewModel: NSObject, ResourcesGenericListViewModel 
     }
 
     func numberOfItems() -> Int {
-        isSearchActived ? filteredItems.count : keychainItems.count
+        isSearchActivated ? filteredItems.count : keychainItems.count
     }
 
     func dataSourceForItem(atIndex index: Int) -> ViewData {
-        let item = isSearchActived ? filteredItems[index] : keychainItems[index]
+        let item = isSearchActivated ? filteredItems[index] : keychainItems[index]
         let value = getKeychainValue(for: item) ?? ""
         return .init(title: item.key, value: value)
     }
@@ -73,11 +73,11 @@ final class ResourcesKeychainViewModel: NSObject, ResourcesGenericListViewModel 
     }
 
     func handleDeleteItemAction(atIndex index: Int) {
-        let item = isSearchActived ? filteredItems.remove(at: index) : keychainItems.remove(at: index)
+        let item = isSearchActivated ? filteredItems.remove(at: index) : keychainItems.remove(at: index)
         let serviceKeychain = Keychain(service: item.service)
         try? serviceKeychain.remove(item.key)
 
-        if isSearchActived {
+        if isSearchActivated {
             keychainItems.removeAll(where: { $0.service == item.service && $0.key == item.key })
         }
     }
@@ -93,7 +93,7 @@ final class ResourcesKeychainViewModel: NSObject, ResourcesGenericListViewModel 
     }
 
     func getEditItemData(atIndex index: Int) -> ResourcesGenericController.EditItemData {
-        let item = isSearchActived ? filteredItems[index] : keychainItems[index]
+        let item = isSearchActivated ? filteredItems[index] : keychainItems[index]
         let value = getKeychainValue(for: item) ?? ""
         
         return .init(
@@ -106,7 +106,7 @@ final class ResourcesKeychainViewModel: NSObject, ResourcesGenericListViewModel 
     }
 
     func updateItem(atIndex index: Int, key: String, value: String) {
-        let currentItem = isSearchActived ? filteredItems[index] : keychainItems[index]
+        let currentItem = isSearchActivated ? filteredItems[index] : keychainItems[index]
         let serviceKeychain = Keychain(service: currentItem.service)
         
         do {

--- a/DebugSwift/Sources/Features/Resources/UserDeafults/Resources.UserDefaults.ViewModel.swift
+++ b/DebugSwift/Sources/Features/Resources/UserDeafults/Resources.UserDefaults.ViewModel.swift
@@ -34,7 +34,7 @@ final class ResourcesUserDefaultsViewModel: NSObject, ResourcesGenericListViewMo
 
     // MARK: - ViewModel
 
-    var isSearchActived = false
+    var isSearchActivated = false
 
     var reloadData: (() -> Void)?
 
@@ -47,11 +47,11 @@ final class ResourcesUserDefaultsViewModel: NSObject, ResourcesGenericListViewMo
     }
 
     func numberOfItems() -> Int {
-        isSearchActived ? filteredKeys.count : keys.count
+        isSearchActivated ? filteredKeys.count : keys.count
     }
 
     func dataSourceForItem(atIndex index: Int) -> ViewData {
-        let key = isSearchActived ? filteredKeys[index] : keys[index]
+        let key = isSearchActivated ? filteredKeys[index] : keys[index]
         let value = "\(UserDefaults.standard.object(forKey: key) ?? "")"
         return .init(title: key, value: value)
     }
@@ -66,11 +66,11 @@ final class ResourcesUserDefaultsViewModel: NSObject, ResourcesGenericListViewMo
     }
 
     func handleDeleteItemAction(atIndex index: Int) {
-        let key = isSearchActived ? filteredKeys.remove(at: index) : keys.remove(at: index)
+        let key = isSearchActivated ? filteredKeys.remove(at: index) : keys.remove(at: index)
         UserDefaults.standard.removeObject(forKey: key)
         UserDefaults.standard.synchronize()
 
-        if isSearchActived {
+        if isSearchActivated {
             keys.removeAll(where: { $0 == key })
         }
     }
@@ -86,7 +86,7 @@ final class ResourcesUserDefaultsViewModel: NSObject, ResourcesGenericListViewMo
     }
 
     func getEditItemData(atIndex index: Int) -> ResourcesGenericController.EditItemData {
-        let key = isSearchActived ? filteredKeys[index] : keys[index]
+        let key = isSearchActivated ? filteredKeys[index] : keys[index]
         let value = UserDefaults.standard.object(forKey: key)
         let stringValue = String(describing: value ?? "")
         
@@ -101,7 +101,7 @@ final class ResourcesUserDefaultsViewModel: NSObject, ResourcesGenericListViewMo
 
     func updateItem(atIndex index: Int, key: String, value: String) {
         // Keys can't be changed in UserDefaults, so we just update the value
-        let currentKey = isSearchActived ? filteredKeys[index] : keys[index]
+        let currentKey = isSearchActivated ? filteredKeys[index] : keys[index]
         saveValue(value, forKey: currentKey)
         setupKeys()
     }

--- a/Example/ExampleTests/Tests/Features/App/CustomAction/AppCustomActionViewModelTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/CustomAction/AppCustomActionViewModelTests.swift
@@ -36,12 +36,12 @@ final class AppCustomActionViewModelTests: XCTestCase {
     // MARK: - numberOfItems
 
     func testNumberOfItems_searchInactive_returnsAllActions() {
-        sut.isSearchActived = false
+        sut.isSearchActivated = false
         XCTAssertEqual(sut.numberOfItems(), 3)
     }
 
     func testNumberOfItems_searchActive_returnsFilteredCount() {
-        sut.isSearchActived = true
+        sut.isSearchActivated = true
         sut.filterContentForSearchText("Alpha")
         XCTAssertEqual(sut.numberOfItems(), 1)
     }
@@ -49,13 +49,13 @@ final class AppCustomActionViewModelTests: XCTestCase {
     // MARK: - dataSourceForItem
 
     func testDataSourceForItem_searchInactive_returnsCorrectTitle() {
-        sut.isSearchActived = false
+        sut.isSearchActivated = false
         let viewData = sut.dataSourceForItem(atIndex: 1)
         XCTAssertEqual(viewData.title, "Beta")
     }
 
     func testDataSourceForItem_searchActive_returnsFilteredTitle() {
-        sut.isSearchActived = true
+        sut.isSearchActivated = true
         sut.filterContentForSearchText("Gamma")
         let viewData = sut.dataSourceForItem(atIndex: 0)
         XCTAssertEqual(viewData.title, "Gamma")
@@ -71,26 +71,26 @@ final class AppCustomActionViewModelTests: XCTestCase {
     // MARK: - filterContentForSearchText
 
     func testFilterContentForSearchText_emptyQuery_returnsAllActions() {
-        sut.isSearchActived = true
+        sut.isSearchActivated = true
         sut.filterContentForSearchText("")
         XCTAssertEqual(sut.numberOfItems(), 3)
     }
 
     func testFilterContentForSearchText_matchingQuery_returnsMatchingActions() {
-        sut.isSearchActived = true
+        sut.isSearchActivated = true
         sut.filterContentForSearchText("be")
         XCTAssertEqual(sut.numberOfItems(), 1)
         XCTAssertEqual(sut.dataSourceForItem(atIndex: 0).title, "Beta")
     }
 
     func testFilterContentForSearchText_noMatch_returnsEmpty() {
-        sut.isSearchActived = true
+        sut.isSearchActivated = true
         sut.filterContentForSearchText("XYZ")
         XCTAssertEqual(sut.numberOfItems(), 0)
     }
 
     func testFilterContentForSearchText_isCaseInsensitive() {
-        sut.isSearchActived = true
+        sut.isSearchActivated = true
         sut.filterContentForSearchText("alpha")
         XCTAssertEqual(sut.numberOfItems(), 1)
         XCTAssertEqual(sut.dataSourceForItem(atIndex: 0).title, "Alpha")
@@ -104,7 +104,7 @@ final class AppCustomActionViewModelTests: XCTestCase {
             .init(title: "Tap Me", action: { tapped = true })
         ]
         sut = AppCustomActionViewModel(data: CustomAction(title: "Actions", actions: actions))
-        sut.isSearchActived = false
+        sut.isSearchActivated = false
 
         sut.didTapItem(index: 0)
 
@@ -118,7 +118,7 @@ final class AppCustomActionViewModelTests: XCTestCase {
             .init(title: "Target", action: { tapped = true })
         ]
         sut = AppCustomActionViewModel(data: CustomAction(title: "Actions", actions: actions))
-        sut.isSearchActived = true
+        sut.isSearchActivated = true
         sut.filterContentForSearchText("Target")
 
         sut.didTapItem(index: 0)


### PR DESCRIPTION
Fixed a repeated typo in the word "Activated," which was misspelled as "Actived."

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
