### PR TITLE
fix: typos in the keychain service file

### DIFF
--- a/DebugSwift/Sources/Features/Resources/Keychain/KeychainService.swift
+++ b/DebugSwift/Sources/Features/Resources/Keychain/KeychainService.swift
@@ -1994,7 +1994,7 @@ enum Status: OSStatus, Error {
     case returnDataUnsupported = -34_008
     case returnAttributesUnsupported = -34_009
     case returnRefUnsupported = -34_010
-    case returnPersitentRefUnsupported = -34_011
+    case returnPersistentRefUnsupported = -34_011
     case valueRefUnsupported = -34_012
     case valuePersistentRefUnsupported = -34_013
     case returnMissingPointer = -34_014
@@ -2486,7 +2486,7 @@ extension Status: RawRepresentable, CustomStringConvertible {
             return "The caller passed in a kSecReturnAttributes key to a function which does not support it."
         case .returnRefUnsupported:
             return "The caller passed in a kSecReturnRef key to a function which does not support it."
-        case .returnPersitentRefUnsupported:
+        case .returnPersistentRefUnsupported:
             return "The caller passed in a kSecReturnPersistentRef key to a function which does not support it."
         case .valueRefUnsupported:
             return "The caller passed in a kSecValueRef key to a function which does not support it."

--- a/DebugSwift/Sources/Features/Resources/Keychain/KeychainService.swift
+++ b/DebugSwift/Sources/Features/Resources/Keychain/KeychainService.swift
@@ -2248,7 +2248,7 @@ enum Status: OSStatus, Error {
     case invalidAuthority = -67_824
     case verifyActionFailed = -67_825
     case invalidCertAuthority = -67_826
-    case invaldCRLAuthority = -67_827
+    case invalidCRLAuthority = -67_827
     case invalidCRLEncoding = -67_828
     case invalidCRLType = -67_829
     case invalidCRL = -67_830
@@ -2994,7 +2994,7 @@ extension Status: RawRepresentable, CustomStringConvertible {
             return "A verify action has failed."
         case .invalidCertAuthority:
             return "The certificate authority was not valid."
-        case .invaldCRLAuthority:
+        case .invalidCRLAuthority:
             return "The CRL authority was not valid."
         case .invalidCRLEncoding:
             return "The CRL encoding was not valid."

--- a/DebugSwift/Sources/Features/Resources/Keychain/KeychainService.swift
+++ b/DebugSwift/Sources/Features/Resources/Keychain/KeychainService.swift
@@ -88,7 +88,7 @@ enum Accessibility {
     /**
      Item data can only be accessed
      while the device is unlocked. This is recommended for items that only
-     need be accesible while the application is in the foreground. Items
+     need be accessible while the application is in the foreground. Items
      with this attribute will migrate to a new device when using encrypted
      backups.
      */
@@ -97,7 +97,7 @@ enum Accessibility {
     /**
      Item data can only be
      accessed once the device has been unlocked after a restart. This is
-     recommended for items that need to be accesible by background
+     recommended for items that need to be accessible by background
      applications. Items with this attribute will migrate to a new device
      when using encrypted backups.
      */
@@ -129,7 +129,7 @@ enum Accessibility {
     /**
      Item data can only
      be accessed while the device is unlocked. This is recommended for items
-     that only need be accesible while the application is in the foreground.
+     that only need be accessible while the application is in the foreground.
      Items with this attribute will never migrate to a new device, so after
      a backup is restored to a new device, these items will be missing.
      */


### PR DESCRIPTION
A bunch of typos fixed in the keychain service file. All were `internal` or in comments.

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
