### PR TITLE
chore: fix a typo of `Performance` in the helpers directory

### DIFF
--- a/DebugSwift/Sources/Features/Performance/Helpers/Performance.FPSCalculator.swift
+++ b/DebugSwift/Sources/Features/Performance/Helpers/Performance.FPSCalculator.swift
@@ -1,5 +1,5 @@
 //
-//  Performace.FPSCalculator.swift
+//  Performance.FPSCalculator.swift
 //  DebugSwift
 //
 //  Created by Matheus Gois on 15/12/23.


### PR DESCRIPTION
The file name was misspelled as `Performace` in both the file name and the header comment. I have fixed them both at once.

- [X] I reviewed my own changes
- [X] I updated docs when needed
- [X] I considered backward compatibility
