### PR TITLE
chore: fix a typo of `Definition` in the danger file

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -169,7 +169,7 @@ fileprivate extension Danger.File {
         hasSuffix(".swift") || hasSuffix(".h") || hasSuffix(".m")
     }
 
-    var isSwiftPackageDefintion: Bool {
+    var isSwiftPackageDefinition: Bool {
         hasPrefix("Package") && hasSuffix(".swift")
     }
 


### PR DESCRIPTION
The variable appears unused, and I couldn't find any references to it. Please double-check its compatibility and ensure that CI doesn't break.

Thansk