### PR TITLE
Feat/response editor revamp

### DIFF
--- a/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
+++ b/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
@@ -106,7 +106,7 @@ final class NetworkViewControllerDetail: BaseTableController {
         })
         
         // Rewrite shortcut
-        alertController.addAction(UIAlertAction(title: "Create Rewrite Rule", style: .default) { [weak self] _ in
+        alertController.addAction(UIAlertAction(title: "Create Response Modifier", style: .default) { [weak self] _ in
             self?.showCreateRewriteRuleEditor()
         })
 
@@ -224,7 +224,7 @@ final class NetworkViewControllerDetail: BaseTableController {
         NetworkInjectionManager.shared.setRewriteConfig(config)
         showAlert(
             with: "Rewrite rule created for this request",
-            title: "Rewrite Rule Added",
+            title: "Response Modifier Added",
             rightButtonTitle: "OK"
         )
     }

--- a/DebugSwift/Sources/Features/Network/Details/NetworkInjectionSettingsController.swift
+++ b/DebugSwift/Sources/Features/Network/Details/NetworkInjectionSettingsController.swift
@@ -6,9 +6,7 @@
 //
 
 import UIKit
-import UniformTypeIdentifiers
-
-final class NetworkInjectionSettingsController: BaseTableController, UIDocumentPickerDelegate {
+final class NetworkInjectionSettingsController: BaseTableController {
     
     // MARK: - Sections
     
@@ -21,7 +19,7 @@ final class NetworkInjectionSettingsController: BaseTableController, UIDocumentP
             switch self {
             case .delay: return "REQUEST DELAY INJECTION"
             case .failure: return "NETWORK FAILURE INJECTION"
-            case .rewrite: return "RESPONSE BODY REWRITE"
+            case .rewrite: return "RESPONSE MODIFIER"
             }
         }
     }
@@ -94,7 +92,7 @@ final class NetworkInjectionSettingsController: BaseTableController, UIDocumentP
         case .failure:
             return failureConfig.isEnabled ? (failureConfig.failureType.isHTTPError ? 6 : 5) : 1
         case .rewrite:
-            return rewriteConfig.isEnabled ? 3 : 1
+            return 1
         }
     }
     
@@ -248,19 +246,12 @@ final class NetworkInjectionSettingsController: BaseTableController, UIDocumentP
         
         switch row {
         case 0:
-            cell.textLabel?.text = "Enable Rewrite"
-            let toggle = UISwitch()
-            toggle.isOn = rewriteConfig.isEnabled
-            toggle.addTarget(self, action: #selector(rewriteToggled(_:)), for: .valueChanged)
-            cell.accessoryView = toggle
-        case 1:
-            cell.textLabel?.text = "Rewrite Rules"
-            cell.detailTextLabel?.text = rewriteConfig.rules.isEmpty ? "None" : "\(rewriteConfig.rules.count)"
+            cell.textLabel?.text = "Response Modifier"
+            let rules = rewriteConfig.rules
+            let enabledRules = rules.filter(\.isEnabled).count
+            let state = rewriteConfig.isEnabled ? "On" : "Off"
+            cell.detailTextLabel?.text = "\(state) • \(enabledRules)/\(rules.count)"
             cell.accessoryType = .disclosureIndicator
-        case 2:
-            cell.textLabel?.text = "Rule Priority"
-            cell.detailTextLabel?.text = "First Match Wins"
-            cell.selectionStyle = .none
         default:
             break
         }
@@ -278,19 +269,6 @@ final class NetworkInjectionSettingsController: BaseTableController, UIDocumentP
     @objc private func failureToggled(_ sender: UISwitch) {
         failureConfig.isEnabled = sender.isOn
         tableView.reloadSections(IndexSet(integer: Section.failure.rawValue), with: .automatic)
-    }
-    
-    @objc private func rewriteToggled(_ sender: UISwitch) {
-        var config = rewriteConfig
-        config.isEnabled = sender.isOn
-        NetworkInjectionManager.shared.setRewriteConfig(config)
-        tableView.reloadSections(IndexSet(integer: Section.rewrite.rawValue), with: .automatic)
-    }
-    
-    private func updateRewriteRules(_ rules: [ResponseBodyRewriteRule]) {
-        var config = rewriteConfig
-        config.rules = rules
-        NetworkInjectionManager.shared.setRewriteConfig(config)
     }
     
     private func handleDelaySelection(row: Int) {
@@ -326,8 +304,9 @@ final class NetworkInjectionSettingsController: BaseTableController, UIDocumentP
     
     private func handleRewriteSelection(row: Int) {
         switch row {
-        case 1:
-            showRewriteRulesMenu()
+        case 0:
+            let vc = ResponseModifierSettingsController()
+            navigationController?.pushViewController(vc, animated: true)
         default:
             break
         }
@@ -527,225 +506,7 @@ final class NetworkInjectionSettingsController: BaseTableController, UIDocumentP
         present(alert, animated: true)
     }
     
-    private func showRewriteRulesMenu() {
-        let alert = UIAlertController(
-            title: "Rewrite Rules",
-            message: "Match URLs/patterns and modify the response. Use exact URLs when possible.",
-            preferredStyle: .actionSheet
-        )
-        
-        alert.addAction(UIAlertAction(title: "Add Rule", style: .default) { [weak self] _ in
-            self?.showRewriteRuleEditor()
-        })
-
-        alert.addAction(UIAlertAction(title: "Export CSV", style: .default) { [weak self] _ in
-            self?.exportRewriteRulesCSV()
-        })
-
-        alert.addAction(UIAlertAction(title: "Import CSV", style: .default) { [weak self] _ in
-            self?.importRewriteRulesCSV()
-        })
-        
-        if !rewriteConfig.rules.isEmpty {
-            alert.addAction(UIAlertAction(title: "Edit Rule", style: .default) { [weak self] _ in
-                self?.showRewriteRulePicker(mode: .edit)
-            })
-            
-            alert.addAction(UIAlertAction(title: "Delete Rule", style: .destructive) { [weak self] _ in
-                self?.showRewriteRulePicker(mode: .delete)
-            })
-            
-            alert.addAction(UIAlertAction(title: "Clear All Rules", style: .destructive) { [weak self] _ in
-                self?.updateRewriteRules([])
-                self?.tableView.reloadSections(IndexSet(integer: Section.rewrite.rawValue), with: .automatic)
-            })
-        }
-        
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        present(alert, animated: true)
-    }
     
-    private enum RewriteRulePickerMode {
-        case edit
-        case delete
-    }
-    
-    private func showRewriteRulePicker(mode: RewriteRulePickerMode) {
-        let title = mode == .edit ? "Edit Rule" : "Delete Rule"
-        let alert = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
-        
-        for (index, rule) in rewriteConfig.rules.enumerated() {
-            alert.addAction(UIAlertAction(title: "\(index + 1). \(rule.urlPattern)", style: .default) { [weak self] _ in
-                guard let self = self else { return }
-                switch mode {
-                case .edit:
-                    self.showRewriteRuleEditor(existingRule: rule, editIndex: index)
-                case .delete:
-                    var updatedRules = self.rewriteConfig.rules
-                    updatedRules.remove(at: index)
-                    self.updateRewriteRules(updatedRules)
-                    self.tableView.reloadSections(IndexSet(integer: Section.rewrite.rawValue), with: .automatic)
-                }
-            })
-        }
-        
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        present(alert, animated: true)
-    }
-    
-    private func showRewriteRuleEditor(existingRule: ResponseBodyRewriteRule? = nil, editIndex: Int? = nil) {
-        let backItem = UIBarButtonItem()
-        backItem.title = "Network Injection"
-        navigationItem.backBarButtonItem = backItem
-        if #available(iOS 14.0, *) {
-            navigationItem.backButtonDisplayMode = .default
-        }
-        let editor = RewriteRuleEditViewController(rule: existingRule) { [weak self] updatedRule in
-            guard let self = self else { return }
-            var updatedRules = self.rewriteConfig.rules
-            if let editIndex {
-                updatedRules[editIndex] = updatedRule
-            } else {
-                if let existingIndex = updatedRules.firstIndex(where: { $0.urlPattern == updatedRule.urlPattern }) {
-                    updatedRules[existingIndex] = updatedRule
-                } else {
-                    updatedRules.append(updatedRule)
-                }
-            }
-            self.updateRewriteRules(updatedRules)
-            self.tableView.reloadSections(IndexSet(integer: Section.rewrite.rawValue), with: .automatic)
-        }
-        navigationController?.pushViewController(editor, animated: true)
-    }
-
-    private func exportRewriteRulesCSV() {
-        let csv = RewriteRulesCSV.export(rules: rewriteConfig.rules)
-        guard let data = csv.data(using: .utf8) else {
-            return
-        }
-
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd_HHmmss"
-        let fileName = "rewrite_rules_\(formatter.string(from: Date())).csv"
-        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
-
-        do {
-            try data.write(to: fileURL, options: [.atomic])
-        } catch {
-            let alert = UIAlertController(
-                title: "Export Error",
-                message: error.localizedDescription,
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
-            return
-        }
-
-        let activityViewController = UIActivityViewController(
-            activityItems: [fileURL],
-            applicationActivities: nil
-        )
-        activityViewController.completionWithItemsHandler = { _, _, _, _ in
-            try? FileManager.default.removeItem(at: fileURL)
-        }
-
-        if let popover = activityViewController.popoverPresentationController {
-            popover.sourceView = view
-            popover.sourceRect = CGRect(
-                x: view.bounds.midX,
-                y: view.bounds.maxY - 1,
-                width: 1,
-                height: 1
-            )
-        }
-
-        present(activityViewController, animated: true)
-    }
-
-    private func importRewriteRulesCSV() {
-        if #available(iOS 14.0, *) {
-            let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.commaSeparatedText, .plainText])
-            picker.delegate = self
-            picker.allowsMultipleSelection = false
-            present(picker, animated: true)
-        } else {
-            let picker = UIDocumentPickerViewController(documentTypes: ["public.comma-separated-values-text", "public.plain-text"], in: .import)
-            picker.delegate = self
-            picker.allowsMultipleSelection = false
-            present(picker, animated: true)
-        }
-    }
-
-    private func applyImportedRewriteRules(_ importedRules: [ResponseBodyRewriteRule]) -> (created: Int, updated: Int) {
-        var mergedRules = rewriteConfig.rules
-        var created = 0
-        var updated = 0
-
-        for importedRule in importedRules {
-            if let existingIndex = mergedRules.firstIndex(where: { $0.urlPattern == importedRule.urlPattern }) {
-                mergedRules[existingIndex] = importedRule
-                updated += 1
-            } else {
-                mergedRules.append(importedRule)
-                created += 1
-            }
-        }
-
-        updateRewriteRules(mergedRules)
-        tableView.reloadSections(IndexSet(integer: Section.rewrite.rawValue), with: .automatic)
-        return (created, updated)
-    }
-
-    private func showCSVImportResult(created: Int, updated: Int) {
-        let alert = UIAlertController(
-            title: "Import Complete",
-            message: "Created \(created) rule(s), updated \(updated) rule(s).",
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
-        present(alert, animated: true)
-    }
-
-    private func showCSVImportError(_ error: Error) {
-        let alert = UIAlertController(
-            title: "Import Error",
-            message: error.localizedDescription,
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
-        present(alert, animated: true)
-    }
-
-    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
-        guard let fileURL = urls.first else { return }
-
-        let hasAccess = fileURL.startAccessingSecurityScopedResource()
-        defer {
-            if hasAccess {
-                fileURL.stopAccessingSecurityScopedResource()
-            }
-        }
-
-        do {
-            let data = try Data(contentsOf: fileURL)
-            guard let csvText = String(data: data, encoding: .utf8) else {
-                throw NSError(
-                    domain: "DebugSwift.NetworkInjection",
-                    code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "CSV file must be UTF-8 encoded."]
-                )
-            }
-
-            let importedRules = try RewriteRulesCSV.parse(csvText)
-            let result = applyImportedRewriteRules(importedRules)
-            showCSVImportResult(created: result.created, updated: result.updated)
-        } catch {
-            showCSVImportError(error)
-        }
-    }
-
-    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {}
 }
 
 // MARK: - FailureType Extension

--- a/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
+++ b/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
@@ -1,0 +1,357 @@
+//
+//  ResponseModifierSettingsController.swift
+//  DebugSwift
+//
+//  Created by Adjie Satryo Pamungkas on 13/04/26.
+//
+
+import UIKit
+import UniformTypeIdentifiers
+
+final class ResponseModifierSettingsController: BaseTableController, UIDocumentPickerDelegate {
+    private enum Section: Int, CaseIterable {
+        case options
+        case rules
+    }
+
+    private var rewriteConfig: ResponseBodyRewriteConfig {
+        NetworkInjectionManager.shared.getRewriteConfig()
+    }
+
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tableView.reloadData()
+    }
+
+    private func setupUI() {
+        title = "Response Modifier"
+        view.backgroundColor = .black
+        tableView.backgroundColor = .black
+        tableView.separatorColor = .darkGray
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .add,
+            target: self,
+            action: #selector(addRuleTapped)
+        )
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        Section.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard let sectionType = Section(rawValue: section) else { return 0 }
+        switch sectionType {
+        case .options:
+            return 4
+        case .rules:
+            return max(rewriteConfig.rules.count, 1)
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard let sectionType = Section(rawValue: section) else { return nil }
+        switch sectionType {
+        case .options: return "OPTIONS"
+        case .rules: return "API RULES"
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        guard let sectionType = Section(rawValue: section), sectionType == .options else { return nil }
+        return "Warning: Broad wildcard patterns (such as *) and many response modifier rules can reduce network matching performance."
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let section = Section(rawValue: indexPath.section) else {
+            return UITableViewCell()
+        }
+        switch section {
+        case .options:
+            return optionCell(for: indexPath.row)
+        case .rules:
+            return ruleCell(for: indexPath.row)
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let section = Section(rawValue: indexPath.section) else { return }
+        switch section {
+        case .options:
+            handleOptionSelection(row: indexPath.row)
+        case .rules:
+            guard !rewriteConfig.rules.isEmpty else { return }
+            showRewriteRuleEditor(existingRule: rewriteConfig.rules[indexPath.row], editIndex: indexPath.row)
+        }
+    }
+
+    private func optionCell(for row: Int) -> UITableViewCell {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: "Cell")
+        cell.backgroundColor = .black
+        cell.textLabel?.textColor = .white
+        cell.detailTextLabel?.textColor = .lightGray
+        let config = rewriteConfig
+
+        switch row {
+        case 0:
+            cell.textLabel?.text = "Enable Response Modifier"
+            let toggle = UISwitch()
+            toggle.isOn = config.isEnabled
+            toggle.addTarget(self, action: #selector(masterToggleChanged(_:)), for: .valueChanged)
+            cell.accessoryView = toggle
+        case 1:
+            cell.textLabel?.text = "Auto-enable Every Run"
+            let toggle = UISwitch()
+            toggle.isOn = NetworkInjectionManager.shared.shouldAutoEnableRewriteOnRun()
+            toggle.addTarget(self, action: #selector(autoEnableToggleChanged(_:)), for: .valueChanged)
+            cell.accessoryView = toggle
+        case 2:
+            cell.textLabel?.text = "Enable All Rules"
+            cell.detailTextLabel?.text = enabledRuleCountSummary()
+            let toggle = UISwitch()
+            toggle.isOn = areAllRulesEnabled()
+            toggle.addTarget(self, action: #selector(allRulesToggleChanged(_:)), for: .valueChanged)
+            cell.accessoryView = toggle
+        case 3:
+            cell.textLabel?.text = "Import / Export CSV"
+            cell.accessoryType = .disclosureIndicator
+        default:
+            break
+        }
+        return cell
+    }
+
+    private func ruleCell(for row: Int) -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "RuleCell")
+        cell.backgroundColor = .black
+        cell.textLabel?.textColor = .white
+        cell.detailTextLabel?.textColor = .lightGray
+
+        let rules = rewriteConfig.rules
+        guard !rules.isEmpty else {
+            cell.textLabel?.text = "No Response Modifier Rules"
+            cell.detailTextLabel?.text = "Tap + to add a rule"
+            cell.selectionStyle = .none
+            return cell
+        }
+        let rule = rules[row]
+        let displayPattern = rule.urlPattern
+        cell.textLabel?.text = displayPattern
+        cell.textLabel?.numberOfLines = 2
+        cell.textLabel?.lineBreakMode = .byTruncatingHead
+        cell.detailTextLabel?.text = nil
+        let toggle = UISwitch()
+        toggle.isOn = rule.isEnabled
+        toggle.tag = row
+        toggle.addTarget(self, action: #selector(ruleToggleChanged(_:)), for: .valueChanged)
+        cell.accessoryView = toggle
+        return cell
+    }
+
+    private func handleOptionSelection(row: Int) {
+        switch row {
+        case 3:
+            showImportExportMenu()
+        default:
+            break
+        }
+    }
+
+    @objc private func addRuleTapped() {
+        showRewriteRuleEditor()
+    }
+
+    @objc private func masterToggleChanged(_ sender: UISwitch) {
+        var config = rewriteConfig
+        config.isEnabled = sender.isOn
+        NetworkInjectionManager.shared.setRewriteConfig(config)
+    }
+
+    @objc private func autoEnableToggleChanged(_ sender: UISwitch) {
+        NetworkInjectionManager.shared.setRewriteAutoEnableOnRun(sender.isOn)
+    }
+
+    @objc private func ruleToggleChanged(_ sender: UISwitch) {
+        var config = rewriteConfig
+        guard config.rules.indices.contains(sender.tag) else { return }
+        config.rules[sender.tag].isEnabled = sender.isOn
+        NetworkInjectionManager.shared.setRewriteConfig(config)
+        tableView.reloadData()
+    }
+
+    private func updateRewriteRules(_ rules: [ResponseBodyRewriteRule]) {
+        var config = rewriteConfig
+        config.rules = rules
+        NetworkInjectionManager.shared.setRewriteConfig(config)
+    }
+
+    private func enabledRuleCountSummary() -> String {
+        let rules = rewriteConfig.rules
+        let enabledCount = rules.filter(\.isEnabled).count
+        return "\(enabledCount)/\(rules.count)"
+    }
+
+    private func areAllRulesEnabled() -> Bool {
+        let rules = rewriteConfig.rules
+        return !rules.isEmpty && rules.allSatisfy(\.isEnabled)
+    }
+
+    @objc private func allRulesToggleChanged(_ sender: UISwitch) {
+        setAllRulesEnabled(sender.isOn)
+    }
+
+    private func setAllRulesEnabled(_ isEnabled: Bool) {
+        let loading = UIAlertController(title: nil, message: "Updating rules...", preferredStyle: .alert)
+        present(loading, animated: true)
+
+        var config = rewriteConfig
+        config.rules = config.rules.map {
+            var rule = $0
+            rule.isEnabled = isEnabled
+            return rule
+        }
+        NetworkInjectionManager.shared.setRewriteConfig(config)
+        DispatchQueue.main.async { [weak self] in
+            loading.dismiss(animated: true) {
+                self?.tableView.reloadData()
+            }
+        }
+    }
+
+    private func showImportExportMenu() {
+        let alert = UIAlertController(title: "Response Modifier CSV", message: nil, preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: "Export CSV", style: .default) { [weak self] _ in
+            self?.exportRewriteRulesCSV()
+        })
+        alert.addAction(UIAlertAction(title: "Import CSV", style: .default) { [weak self] _ in
+            self?.importRewriteRulesCSV()
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    private func showRewriteRuleEditor(existingRule: ResponseBodyRewriteRule? = nil, editIndex: Int? = nil) {
+        let editor = RewriteRuleEditViewController(rule: existingRule) { [weak self] updatedRule in
+            guard let self = self else { return }
+            var updatedRules = self.rewriteConfig.rules
+            if let editIndex {
+                updatedRules[editIndex] = updatedRule
+            } else if let existingIndex = updatedRules.firstIndex(where: { $0.urlPattern == updatedRule.urlPattern }) {
+                updatedRules[existingIndex] = updatedRule
+            } else {
+                updatedRules.append(updatedRule)
+            }
+            self.updateRewriteRules(updatedRules)
+            self.tableView.reloadData()
+        }
+        navigationController?.pushViewController(editor, animated: true)
+    }
+
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard Section(rawValue: indexPath.section) == .rules, !rewriteConfig.rules.isEmpty else { return nil }
+        let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, completion in
+            guard let self = self else { return }
+            var updatedRules = self.rewriteConfig.rules
+            updatedRules.remove(at: indexPath.row)
+            self.updateRewriteRules(updatedRules)
+            self.tableView.reloadData()
+            completion(true)
+        }
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+
+    private func exportRewriteRulesCSV() {
+        let csv = RewriteRulesCSV.export(rules: rewriteConfig.rules)
+        guard let data = csv.data(using: .utf8) else { return }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd_HHmmss"
+        let fileName = "response_modifier_rules_\(formatter.string(from: Date())).csv"
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        do {
+            try data.write(to: fileURL, options: [.atomic])
+        } catch {
+            showMessageAlert(title: "Export Error", message: error.localizedDescription)
+            return
+        }
+
+        let activityVC = UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)
+        activityVC.completionWithItemsHandler = { _, _, _, _ in
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = view
+            popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.maxY - 1, width: 1, height: 1)
+        }
+        present(activityVC, animated: true)
+    }
+
+    private func importRewriteRulesCSV() {
+        if #available(iOS 14.0, *) {
+            let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.commaSeparatedText, .plainText])
+            picker.delegate = self
+            picker.allowsMultipleSelection = false
+            present(picker, animated: true)
+        } else {
+            let picker = UIDocumentPickerViewController(documentTypes: ["public.comma-separated-values-text", "public.plain-text"], in: .import)
+            picker.delegate = self
+            picker.allowsMultipleSelection = false
+            present(picker, animated: true)
+        }
+    }
+
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard let fileURL = urls.first else { return }
+        let hasAccess = fileURL.startAccessingSecurityScopedResource()
+        defer {
+            if hasAccess {
+                fileURL.stopAccessingSecurityScopedResource()
+            }
+        }
+        do {
+            let data = try Data(contentsOf: fileURL)
+            guard let csvText = String(data: data, encoding: .utf8) else {
+                throw NSError(domain: "DebugSwift.NetworkInjection", code: 1, userInfo: [NSLocalizedDescriptionKey: "CSV file must be UTF-8 encoded."])
+            }
+            let importedRules = try RewriteRulesCSV.parse(csvText)
+            let merged = applyImportedRewriteRules(importedRules)
+            showMessageAlert(title: "Import Complete", message: "Created \(merged.created) rule(s), updated \(merged.updated) rule(s).")
+        } catch {
+            showMessageAlert(title: "Import Error", message: error.localizedDescription)
+        }
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {}
+
+    private func applyImportedRewriteRules(_ importedRules: [ResponseBodyRewriteRule]) -> (created: Int, updated: Int) {
+        var mergedRules = rewriteConfig.rules
+        var created = 0
+        var updated = 0
+        for importedRule in importedRules {
+            if let existingIndex = mergedRules.firstIndex(where: { $0.urlPattern == importedRule.urlPattern }) {
+                mergedRules[existingIndex].responseBody = importedRule.responseBody
+                mergedRules[existingIndex].responseStatusCode = importedRule.responseStatusCode
+                updated += 1
+            } else {
+                mergedRules.append(importedRule)
+                created += 1
+            }
+        }
+        updateRewriteRules(mergedRules)
+        tableView.reloadData()
+        return (created, updated)
+    }
+
+    private func showMessageAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+
+}

--- a/DebugSwift/Sources/Features/Network/Details/RewriteRuleEditViewController.swift
+++ b/DebugSwift/Sources/Features/Network/Details/RewriteRuleEditViewController.swift
@@ -39,7 +39,7 @@ final class RewriteRuleEditViewController: BaseController {
         textView.layer.borderColor = UIColor.separator.cgColor
         return textView
     }()
-    
+
     private lazy var statusCodeField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
@@ -63,7 +63,7 @@ final class RewriteRuleEditViewController: BaseController {
     }
     
     private func setupUI() {
-        title = existingRule == nil ? "Add Rewrite Rule" : "Edit Rewrite Rule"
+        title = "Response Editor"
         view.backgroundColor = .black
         
         let patternLabel = UILabel()
@@ -113,7 +113,7 @@ final class RewriteRuleEditViewController: BaseController {
             bodyLabel.topAnchor.constraint(equalTo: statusCodeField.bottomAnchor, constant: 16),
             bodyLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
             bodyLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            
+
             bodyTextView.topAnchor.constraint(equalTo: bodyLabel.bottomAnchor, constant: 8),
             bodyTextView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
             bodyTextView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
@@ -140,7 +140,14 @@ final class RewriteRuleEditViewController: BaseController {
             target: self,
             action: #selector(showBodyEditorOptions)
         )
-        navigationItem.rightBarButtonItems = [saveButton, menuButton]
+        let bodyEditorButton = UIBarButtonItem(
+            image: UIImage(systemName: "square.and.pencil"),
+            style: .plain,
+            target: self,
+            action: #selector(openBodyEditorTapped)
+        )
+        bodyEditorButton.accessibilityLabel = "Body Editor"
+        navigationItem.rightBarButtonItems = [saveButton, bodyEditorButton, menuButton]
     }
     
     @objc private func showBodyEditorOptions() {
@@ -161,6 +168,10 @@ final class RewriteRuleEditViewController: BaseController {
         }
         
         present(alert, animated: true)
+    }
+
+    @objc private func openBodyEditorTapped() {
+        openKeyValueEditor()
     }
     
     private func openKeyValueEditor() {

--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -216,7 +216,7 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
                 requestId: requestId,
                 cachePolicy: cachePolicy
             )
-            Self.report(data)
+            Self.report(data, matchedResponseModifier: false)
         }
     }
     
@@ -249,7 +249,7 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
                 requestId: requestId,
                 cachePolicy: cachePolicy
             )
-            Self.report(data)
+            Self.report(data, matchedResponseModifier: false)
         }
     }
     
@@ -299,6 +299,7 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         let responseHeaderFields = headersToString(response?.allHeaderFields)
         let requestId = request.requestId
         let cachePolicy = getCachePolicy(value: request.cachePolicy.rawValue)
+        let matchedResponseModifier = matchedRewriteRule != nil
 
         Task { @MainActor in
             guard NetworkHelper.shared.isNetworkEnable else {
@@ -320,12 +321,12 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
                 requestId: requestId,
                 cachePolicy: cachePolicy
             )
-            Self.report(reportData)
+            Self.report(reportData, matchedResponseModifier: matchedResponseModifier)
         }
     }
     
     @MainActor
-    private static func report(_ data: NetworkReportData) {
+    private static func report(_ data: NetworkReportData, matchedResponseModifier: Bool = false) {
         var model = HttpModel()
         model.url = data.url
         model.method = data.method
@@ -385,7 +386,11 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         if HttpDatasource.shared.addHttpRequest(model) {
             NotificationCenter.default.post(
                 name: NSNotification.Name("reloadHttp_DebugSwift"),
-                object: model.isSuccess
+                object: nil,
+                userInfo: [
+                    "success": model.isSuccess,
+                    "matchedResponseModifier": matchedResponseModifier
+                ]
             )
         }
     }

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
@@ -254,15 +254,20 @@ public struct ResponseBodyRewriteRule: Sendable, Equatable, Codable {
     
     /// Optional HTTP status code override for rewritten response
     public var responseStatusCode: Int?
+
+    /// Whether this rule is active
+    public var isEnabled: Bool
     
     public init(
         urlPattern: String,
         responseBody: String,
-        responseStatusCode: Int? = nil
+        responseStatusCode: Int? = nil,
+        isEnabled: Bool = true
     ) {
         self.urlPattern = urlPattern
         self.responseBody = responseBody
         self.responseStatusCode = responseStatusCode
+        self.isEnabled = isEnabled
     }
 }
 
@@ -288,7 +293,8 @@ public struct ResponseBodyRewriteConfig: Sendable {
         guard let url = request.url else { return nil }
         
         return rules.first { rule in
-            url.matches(
+            guard rule.isEnabled else { return false }
+            return url.matches(
                 wildcardPattern: rule.urlPattern,
                 strategy: .full,
                 queryStrategy: .exact

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
@@ -13,6 +13,7 @@ final class NetworkInjectionManager: @unchecked Sendable {
     
     private enum PersistenceKeys {
         static let rewriteRules = "DebugSwift.NetworkInjection.RewriteRules"
+        static let rewriteAutoEnableOnRun = "DebugSwift.NetworkInjection.RewriteAutoEnableOnRun"
     }
     
     private let queue = DispatchQueue(label: "com.debugswift.injection", attributes: .concurrent)
@@ -21,7 +22,7 @@ final class NetworkInjectionManager: @unchecked Sendable {
     private var _rewriteConfig: ResponseBodyRewriteConfig = ResponseBodyRewriteConfig()
     
     private init() {
-        _rewriteConfig.isEnabled = false
+        _rewriteConfig.isEnabled = shouldAutoEnableRewriteOnRun()
         _rewriteConfig.rules = loadPersistedRewriteRules()
     }
     
@@ -97,6 +98,14 @@ final class NetworkInjectionManager: @unchecked Sendable {
     func matchingRewriteRule(for request: URLRequest) -> ResponseBodyRewriteRule? {
         let config = getRewriteConfig()
         return config.matchingRule(for: request)
+    }
+
+    func setRewriteAutoEnableOnRun(_ isEnabled: Bool) {
+        UserDefaults.standard.set(isEnabled, forKey: PersistenceKeys.rewriteAutoEnableOnRun)
+    }
+
+    func shouldAutoEnableRewriteOnRun() -> Bool {
+        UserDefaults.standard.bool(forKey: PersistenceKeys.rewriteAutoEnableOnRun)
     }
     
     private func loadPersistedRewriteRules() -> [ResponseBodyRewriteRule] {

--- a/DebugSwift/Sources/Features/Network/Main/Network.Controller.swift
+++ b/DebugSwift/Sources/Features/Network/Main/Network.Controller.swift
@@ -164,11 +164,13 @@ final class NetworkViewController: BaseController, MainFeatureType {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            let success = notification.object as? Bool ?? false
+            let success = (notification.userInfo?["success"] as? Bool) ?? (notification.object as? Bool) ?? false
+            let matchedResponseModifier = notification.userInfo?["matchedResponseModifier"] as? Bool ?? false
             MainActor.assumeIsolated {
                 self?.reloadHttp(
                     needScrollToEnd: (self?.viewModel.isReachEnd ?? true) && self?.view.window != nil,
-                    success: success
+                    success: success,
+                    matchedResponseModifier: matchedResponseModifier
                 )
                 self?.updateHTTPStatistics()
             }
@@ -197,13 +199,17 @@ final class NetworkViewController: BaseController, MainFeatureType {
         }
     }
 
-    func reloadHttp(needScrollToEnd: Bool = false, success: Bool = true) {
+    func reloadHttp(
+        needScrollToEnd: Bool = false,
+        success: Bool = true,
+        matchedResponseModifier: Bool = false
+    ) {
         guard viewModel.reloadDataFinish else { return }
         guard currentMode == .http || currentMode == .webview else { return }
 
         // Only animate if the float view is showing to avoid unnecessary work
         if FloatViewManager.shared.ballView.isShowing {
-            FloatViewManager.animate(success: success)
+            FloatViewManager.animate(success: success, matchedResponseModifier: matchedResponseModifier)
         }
         
         viewModel.applyFilter(for: currentMode)

--- a/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
+++ b/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
@@ -23,6 +23,7 @@ class FloatBallView: UIView {
     fileprivate var beginPoint: CGPoint?
 
     var changeStatusInNextTransaction = true
+    private var pendingAnimationWorkItem: DispatchWorkItem?
 
     lazy var label: UILabel = buildLabel()
     lazy var ballView: UIView = buildBallView()
@@ -89,21 +90,29 @@ class FloatBallView: UIView {
         }
     }
 
-    func animate(success: Bool) {
+    func animate(success: Bool, matchedResponseModifier: Bool = false) {
         guard isShowing else { return }
         
         // Debounce frequent animations
         cancelPendingAnimationRequests()
         
         updateText()
-        perform(#selector(performAnimation(_:)), with: success, afterDelay: 0.1)
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.performAnimation(success: success, matchedResponseModifier: matchedResponseModifier)
+        }
+        pendingAnimationWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
 
         if !success { ImpactFeedback.generate() }
     }
     
-    @objc private func performAnimation(_ success: NSNumber) {
+    private func performAnimation(success: Bool, matchedResponseModifier: Bool) {
         guard isShowing, superview != nil, window != nil else { return }
-        startAnimation(text: success.boolValue ? "🚀" : "❌")
+        if success {
+            startAnimation(text: matchedResponseModifier ? "💉" : "🚀")
+        } else {
+            startAnimation(text: "❌")
+        }
     }
     
     func animateWebSocket(connected: Bool) {
@@ -145,11 +154,8 @@ class FloatBallView: UIView {
     }
 
     private func cancelPendingAnimationRequests() {
-        NSObject.cancelPreviousPerformRequests(
-            withTarget: self,
-            selector: #selector(performAnimation(_:)),
-            object: nil
-        )
+        pendingAnimationWorkItem?.cancel()
+        pendingAnimationWorkItem = nil
     }
 }
 

--- a/DebugSwift/Sources/Helpers/Managers/FloatViewManager.swift
+++ b/DebugSwift/Sources/Helpers/Managers/FloatViewManager.swift
@@ -30,8 +30,8 @@ final class FloatViewManager: NSObject {
         shared.floatViewController = viewController
     }
 
-    static func animate(success: Bool) {
-        shared.ballView.animate(success: success)
+    static func animate(success: Bool, matchedResponseModifier: Bool = false) {
+        shared.ballView.animate(success: success, matchedResponseModifier: matchedResponseModifier)
     }
     
     static func animateWebSocket(connected: Bool) {
@@ -75,10 +75,11 @@ final class FloatViewManager: NSObject {
             object: nil,
             queue: .main
         ) { notification in
-            let success = notification.object as? Bool
+            let success = notification.userInfo?["success"] as? Bool
+            let matchedResponseModifier = notification.userInfo?["matchedResponseModifier"] as? Bool ?? false
             MainActor.assumeIsolated {
                 if let success = success {
-                    Self.animate(success: success)
+                    Self.animate(success: success, matchedResponseModifier: matchedResponseModifier)
                 }
             }
         }

--- a/Example/ExampleTests/Tests/Features/Network/DataSource/HttpDatasourceEncryptionTests.swift
+++ b/Example/ExampleTests/Tests/Features/Network/DataSource/HttpDatasourceEncryptionTests.swift
@@ -225,6 +225,66 @@ final class HttpDatasourceEncryptionTests: XCTestCase {
         // Then
         XCTAssertFalse(result)
     }
+
+    func testAddHttpRequest_withDuplicateRequestId_filtersDuplicate() {
+        // Given
+        let firstModel = makeHttpModel(url: "https://api.example.com/v1/orders")
+        firstModel.requestId = "request-1"
+        let duplicateModel = makeHttpModel(url: "https://api.example.com/v1/orders")
+        duplicateModel.requestId = "request-1"
+
+        // When
+        let firstResult = httpDataSource.addHttpRequest(firstModel)
+        let duplicateResult = httpDataSource.addHttpRequest(duplicateModel)
+
+        // Then
+        XCTAssertTrue(firstResult)
+        XCTAssertFalse(duplicateResult)
+        XCTAssertEqual(httpDataSource.httpModels.count, 1)
+    }
+
+    func testAddHttpRequest_afterRemovingRequestId_allowsSameRequestIdAgain() {
+        // Given
+        let firstModel = makeHttpModel(url: "https://api.example.com/v1/orders")
+        firstModel.requestId = "request-1"
+        let nextModel = makeHttpModel(url: "https://api.example.com/v1/orders")
+        nextModel.requestId = "request-1"
+
+        // When
+        XCTAssertTrue(httpDataSource.addHttpRequest(firstModel))
+        httpDataSource.remove(firstModel)
+        let result = httpDataSource.addHttpRequest(nextModel)
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertEqual(httpDataSource.httpModels.count, 1)
+        XCTAssertTrue(httpDataSource.httpModels.first === nextModel)
+    }
+
+    func testAddHttpRequest_whenStorageExceedsLimit_evictsOldestRequest() {
+        // Given
+        let firstModel = makeHttpModel(url: "https://api.example.com/v1/orders/0")
+        firstModel.requestId = "request-0"
+        XCTAssertTrue(httpDataSource.addHttpRequest(firstModel))
+
+        for index in 1..<10_000 {
+            let model = makeHttpModel(url: "https://api.example.com/v1/orders/\(index)")
+            model.requestId = "request-\(index)"
+            XCTAssertTrue(httpDataSource.addHttpRequest(model))
+        }
+
+        let nextModel = makeHttpModel(url: "https://api.example.com/v1/orders/10000")
+        nextModel.requestId = "request-10000"
+
+        // When
+        let result = httpDataSource.addHttpRequest(nextModel)
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertEqual(httpDataSource.httpModels.count, 10_000)
+        XCTAssertFalse(httpDataSource.httpModels.contains { $0 === firstModel })
+        XCTAssertTrue(httpDataSource.httpModels.last === nextModel)
+    }
     
     private func makeHttpModel(url: String) -> HttpModel {
         let model = HttpModel()

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ DebugSwift
 ---
 
 <img width="1970" alt="Image" src="https://github.com/user-attachments/assets/a569b038-9058-4260-ae7c-47f3376cf629" />
+<img width="1970" alt="Image" src="https://github.com/user-attachments/assets/35cbc0c4-4938-4b1f-bab2-69427aa66ffb" />
 <img width="1970" alt="Image" src="https://github.com/user-attachments/assets/334ccefa-5951-494f-8faa-5f016d39f946" />
 <img width="1970" alt="Image" src="https://github.com/user-attachments/assets/246cde3c-7a14-45de-ae01-e810c42d8e65" />
 <img width="1970" alt="Image" src="https://github.com/user-attachments/assets/fadde188-dcba-46d8-9460-762f9be98bd6" />
@@ -49,7 +50,7 @@ DebugSwift
 - **Request Limiting:** Set thresholds to monitor and control API usage
 - **Smart Content:** Automatic JSON formatting with syntax highlighting
 - **Encryption Support:** Automatic decryption of encrypted API responses with AES-256/128 and custom decryptors
-- **Response Modifier:** Use it to mock or alter API responses at runtime. Modify response body/status by URL pattern with per-rule toggles, CSV import/export, and startup auto-enable option
+- **Response Modifier:** Mock or modify any API responses in real time. Adjust the response body and status based on URL or patterns, enable or disable rules individually, import/export configurations via CSV, body editor, and generate rules from live network traffic.
 
 ### ⚡ Performance
 - **Real-time Metrics:** Monitor CPU, memory, and FPS in real-time

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ DebugSwift
 - **Request Limiting:** Set thresholds to monitor and control API usage
 - **Smart Content:** Automatic JSON formatting with syntax highlighting
 - **Encryption Support:** Automatic decryption of encrypted API responses with AES-256/128 and custom decryptors
+- **Response Modifier:** Use it to mock or alter API responses at runtime. Modify response body/status by URL pattern with per-rule toggles, CSV import/export, and startup auto-enable option
 
 ### ⚡ Performance
 - **Real-time Metrics:** Monitor CPU, memory, and FPS in real-time


### PR DESCRIPTION
## Summary

- Renamed user-facing Rewrite Rule terminology to **Response Modifier** 
- Reworked Response Modifier management into a dedicated Settings-style screen for better UX.
- Added per-rule activation support and control
- New persisted setting to auto-enable Response Modifier on every run.
- Added better controls for rule operations:
  - Per-item toggle.
  - Native iOS swipe-to-delete on list rows.
  - Global **Enable All Rules** toggle.
  - CSV import/export retained in dedicated screen.

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [x] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Open `Network Injection` settings and verify `Response Modifier` appears as a summary row.
2. Tap `Response Modifier` and verify dedicated screen opens.

## Screenshots / recordings (if applicable)

<img width="500" height="951" alt="QuickTime movie" src="https://github.com/user-attachments/assets/b548a7b7-32e6-49ae-a0b3-9c2dee1aa717" />

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility