### PR TITLE
feat(network-injection): add fully offline mock API (no network requests being sent to server)

### DIFF
--- a/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
+++ b/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
@@ -49,7 +49,7 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
         guard let sectionType = Section(rawValue: section) else { return 0 }
         switch sectionType {
         case .options:
-            return 4
+            return 5
         case .rules:
             return max(rewriteConfig.rules.count, 1)
         }
@@ -120,6 +120,12 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
             toggle.addTarget(self, action: #selector(allRulesToggleChanged(_:)), for: .valueChanged)
             cell.accessoryView = toggle
         case 3:
+            cell.textLabel?.text = "Short-circuit Mode"
+            let toggle = UISwitch()
+            toggle.isOn = NetworkInjectionManager.shared.isRewriteShortCircuitEnabled()
+            toggle.addTarget(self, action: #selector(shortCircuitToggleChanged(_:)), for: .valueChanged)
+            cell.accessoryView = toggle
+        case 4:
             cell.textLabel?.text = "Import / Export CSV"
             cell.accessoryType = .disclosureIndicator
         default:
@@ -157,7 +163,27 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
 
     private func handleOptionSelection(row: Int) {
         switch row {
+        case 0:
+            showInfoAlert(
+                title: "Enable Response Modifier",
+                message: "Turns response modifier on or off globally. When off, no rewrite rules are applied."
+            )
+        case 1:
+            showInfoAlert(
+                title: "Auto-enable Every Run",
+                message: "If enabled, response modifier will automatically be active each time the app starts."
+            )
+        case 2:
+            showInfoAlert(
+                title: "Enable All Rules",
+                message: "Quickly enable or disable all existing rules at once."
+            )
         case 3:
+            showInfoAlert(
+                title: "Short-circuit Matched Rules",
+                message: "When enabled, matched rules return mocked responses immediately from local data. This works offline and skips the real network request for matched rules."
+            )
+        case 4:
             showImportExportMenu()
         default:
             break
@@ -176,6 +202,16 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
 
     @objc private func autoEnableToggleChanged(_ sender: UISwitch) {
         NetworkInjectionManager.shared.setRewriteAutoEnableOnRun(sender.isOn)
+    }
+    
+    @objc private func shortCircuitToggleChanged(_ sender: UISwitch) {
+        NetworkInjectionManager.shared.setRewriteShortCircuitEnabled(sender.isOn)
+    }
+    
+    private func showInfoAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 
     @objc private func ruleToggleChanged(_ sender: UISwitch) {

--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -144,6 +144,10 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         
         // Resolve rewrite rule once per request (first-match-wins order)
         matchedRewriteRule = NetworkInjectionManager.shared.matchingRewriteRule(for: request)
+        if let matchedRewriteRule, NetworkInjectionManager.shared.isRewriteShortCircuitEnabled() {
+            injectRewrittenResponse(using: matchedRewriteRule, for: request)
+            return
+        }
         
         threadOperator = ThreadOperator()
         startTime = Date()
@@ -250,6 +254,54 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
                 cachePolicy: cachePolicy
             )
             Self.report(data, matchedResponseModifier: false)
+        }
+    }
+    
+    private func injectRewrittenResponse(using rule: ResponseBodyRewriteRule, for request: URLRequest) {
+        guard let url = request.url else { return }
+        
+        let rewrittenData = rule.responseBody.data(using: .utf8) ?? Data()
+        let statusCode = rule.responseStatusCode ?? 200
+        
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )
+        
+        if let response {
+            self.response = response
+            self.data = rewrittenData
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: rewrittenData)
+        }
+        
+        client?.urlProtocolDidFinishLoading(self)
+        
+        let method = request.httpMethod
+        let requestId = request.requestId
+        let cachePolicy = getCachePolicy(value: request.cachePolicy.rawValue)
+        let requestHeaderFields = request.allHTTPHeaderFields
+        let now = Date()
+        
+        Task { @MainActor in
+            let data = NetworkReportData(
+                url: url,
+                method: method,
+                requestData: nil,
+                responseData: rewrittenData,
+                statusCode: "\(statusCode)",
+                mineType: "application/json",
+                startTime: now,
+                endTime: now,
+                error: nil,
+                requestHeaderFields: requestHeaderFields,
+                responseHeaderFields: ["Content-Type": "application/json"],
+                requestId: requestId,
+                cachePolicy: cachePolicy
+            )
+            Self.report(data, matchedResponseModifier: true)
         }
     }
     
@@ -461,14 +513,6 @@ extension CustomHTTPProtocol: URLSessionDataDelegate {
             Debug.print(#function)
             
             if self.matchedRewriteRule != nil {
-                if self.cachePolicy == .allowed {
-                    self.data.append(data)
-                } else if self.data.isEmpty {
-                    self.data = data
-                } else {
-                    self.data.append(data)
-                }
-                
                 self.didReceiveData = true
                 return
             }

--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -67,6 +67,8 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
     private var prevUrl: URL?
     private var prevStartTime: Date?
     private var matchedRewriteRule: ResponseBodyRewriteRule?
+    private let reportQueue = DispatchQueue(label: "com.debugswift.http-protocol.report")
+    private var didReport = false
 
     private var threadOperator: ThreadOperator?
     
@@ -186,6 +188,8 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         }
         """.data(using: .utf8) ?? Data()
         
+        guard markReportedIfNeeded() else { return }
+
         // Notify client of response
         if let response = httpResponse {
             self.response = response
@@ -225,6 +229,7 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
     }
     
     private func injectNetworkError(_ error: Error) {
+        guard markReportedIfNeeded() else { return }
         self.error = error
         client?.urlProtocol(self, didFailWithError: error)
         
@@ -270,6 +275,8 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             headerFields: ["Content-Type": "application/json"]
         )
         
+        guard markReportedIfNeeded() else { return }
+
         if let response {
             self.response = response
             self.data = rewrittenData
@@ -353,6 +360,8 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         let cachePolicy = getCachePolicy(value: request.cachePolicy.rawValue)
         let matchedResponseModifier = matchedRewriteRule != nil
 
+        guard markReportedIfNeeded() else { return }
+
         Task { @MainActor in
             guard NetworkHelper.shared.isNetworkEnable else {
                 return
@@ -374,6 +383,14 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
                 cachePolicy: cachePolicy
             )
             Self.report(reportData, matchedResponseModifier: matchedResponseModifier)
+        }
+    }
+
+    private func markReportedIfNeeded() -> Bool {
+        reportQueue.sync {
+            guard !didReport else { return false }
+            didReport = true
+            return true
         }
     }
     

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
@@ -246,6 +246,11 @@ public struct NetworkFailureConfig: Sendable {
 
 /// A single response body rewrite rule.
 public struct ResponseBodyRewriteRule: Sendable, Equatable, Codable {
+    public enum MatchType: String, Sendable, Equatable, Codable {
+        case exact
+        case wildcard
+    }
+
     /// URL pattern to match (supports wildcard `*` and `?`)
     public var urlPattern: String
     
@@ -257,17 +262,23 @@ public struct ResponseBodyRewriteRule: Sendable, Equatable, Codable {
 
     /// Whether this rule is active
     public var isEnabled: Bool
+
+    /// Matcher mode used for fast-path lookup.
+    /// Backward-compatible: missing value from older persisted data defaults to `.exact`.
+    public var matchType: MatchType
     
     public init(
         urlPattern: String,
         responseBody: String,
         responseStatusCode: Int? = nil,
-        isEnabled: Bool = true
+        isEnabled: Bool = true,
+        matchType: MatchType = .exact
     ) {
         self.urlPattern = urlPattern
         self.responseBody = responseBody
         self.responseStatusCode = responseStatusCode
         self.isEnabled = isEnabled
+        self.matchType = matchType
     }
 }
 

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
@@ -14,6 +14,7 @@ final class NetworkInjectionManager: @unchecked Sendable {
     private enum PersistenceKeys {
         static let rewriteRules = "DebugSwift.NetworkInjection.RewriteRules"
         static let rewriteAutoEnableOnRun = "DebugSwift.NetworkInjection.RewriteAutoEnableOnRun"
+        static let rewriteShortCircuitEnabled = "DebugSwift.NetworkInjection.RewriteShortCircuitEnabled"
     }
     
     private let queue = DispatchQueue(label: "com.debugswift.injection", attributes: .concurrent)
@@ -106,6 +107,17 @@ final class NetworkInjectionManager: @unchecked Sendable {
 
     func shouldAutoEnableRewriteOnRun() -> Bool {
         UserDefaults.standard.bool(forKey: PersistenceKeys.rewriteAutoEnableOnRun)
+    }
+    
+    func setRewriteShortCircuitEnabled(_ isEnabled: Bool) {
+        UserDefaults.standard.set(isEnabled, forKey: PersistenceKeys.rewriteShortCircuitEnabled)
+    }
+    
+    func isRewriteShortCircuitEnabled() -> Bool {
+        if UserDefaults.standard.object(forKey: PersistenceKeys.rewriteShortCircuitEnabled) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: PersistenceKeys.rewriteShortCircuitEnabled)
     }
     
     private func loadPersistedRewriteRules() -> [ResponseBodyRewriteRule] {

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
@@ -21,10 +21,16 @@ final class NetworkInjectionManager: @unchecked Sendable {
     private var _delayConfig: RequestDelayConfig = RequestDelayConfig()
     private var _failureConfig: NetworkFailureConfig = NetworkFailureConfig()
     private var _rewriteConfig: ResponseBodyRewriteConfig = ResponseBodyRewriteConfig()
+    private var _rewriteRulesSnapshot: [ResponseBodyRewriteRule] = []
     
     private init() {
         _rewriteConfig.isEnabled = shouldAutoEnableRewriteOnRun()
-        _rewriteConfig.rules = loadPersistedRewriteRules()
+        _rewriteConfig.rules = loadPersistedRewriteRules().map { rule in
+            var normalizedRule = rule
+            normalizedRule.matchType = rule.urlPattern.contains("*") || rule.urlPattern.contains("?") ? .wildcard : .exact
+            return normalizedRule
+        }
+        _rewriteRulesSnapshot = _rewriteConfig.rules
     }
     
     // MARK: - Delay Injection
@@ -84,9 +90,16 @@ final class NetworkInjectionManager: @unchecked Sendable {
     func setRewriteConfig(_ config: ResponseBodyRewriteConfig) {
         queue.sync(flags: .barrier) {
             let previousRules = _rewriteConfig.rules
-            _rewriteConfig = config
-            if previousRules != config.rules {
-                persistRewriteRules(config.rules)
+            var normalizedConfig = config
+            normalizedConfig.rules = config.rules.map { rule in
+                var normalizedRule = rule
+                normalizedRule.matchType = rule.urlPattern.contains("*") || rule.urlPattern.contains("?") ? .wildcard : .exact
+                return normalizedRule
+            }
+            _rewriteConfig = normalizedConfig
+            _rewriteRulesSnapshot = normalizedConfig.rules
+            if previousRules != normalizedConfig.rules {
+                persistRewriteRules(normalizedConfig.rules)
             }
         }
         Debug.print("✏️ Rewrite config updated: enabled=\(config.isEnabled), rules=\(config.rules.count)")
@@ -97,8 +110,31 @@ final class NetworkInjectionManager: @unchecked Sendable {
     }
     
     func matchingRewriteRule(for request: URLRequest) -> ResponseBodyRewriteRule? {
-        let config = getRewriteConfig()
-        return config.matchingRule(for: request)
+        guard let url = request.url else { return nil }
+        let (isEnabled, rules): (Bool, [ResponseBodyRewriteRule]) = queue.sync {
+            (_rewriteConfig.isEnabled, _rewriteRulesSnapshot)
+        }
+        guard isEnabled else { return nil }
+
+        let requestURLLowercased = url.absoluteString.lowercased()
+        for rule in rules where rule.isEnabled {
+            switch rule.matchType {
+            case .exact:
+                if requestURLLowercased == rule.urlPattern.lowercased() {
+                    return rule
+                }
+            case .wildcard:
+                if url.matches(
+                    wildcardPattern: rule.urlPattern,
+                    strategy: .full,
+                    queryStrategy: .exact
+                ) {
+                    return rule
+                }
+            }
+        }
+
+        return nil
     }
 
     func setRewriteAutoEnableOnRun(_ isEnabled: Bool) {


### PR DESCRIPTION
## Summary

Closes #356 - Network response modification now fully works, **even when offline or the server returns no response at all** using short-circuit mechanism.

- Improve rewrite matching performance using **snapshot-based matching** and adjusted rule handling.
- **No request are sent over the network** in short-circuit mode (very useful for preventing data disruptions in the server)
- Update injection flow to better support configuration and matching behavior in network module.

## Type of change

- [ ] Fix
- [x] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Open Network detail and configure response modifier/injection settings.
2. Trigger request scenarios with matching and non-matching rules (including HTTP method variants).
3. Verify injected response is applied correctly and matching remains stable/performs as expected.

## Screenshots / recordings (if applicable)

<img width="640" height="1217" alt="QuickTime movie" src="https://github.com/user-attachments/assets/57b26041-cdac-467b-a4b6-2305d28e9e08" />

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility