### PR TITLE
feat(network-injection): add HttpMethod as a Response Modifier matching condition

### DIFF
--- a/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
+++ b/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
@@ -206,10 +206,12 @@ final class NetworkViewControllerDetail: BaseTableController {
         let initialURLPattern = model.url?.absoluteString ?? ""
         let initialResponseBody = (model.decryptedResponseData ?? model.responseData)?.formattedString() ?? ""
         let initialStatusCode = model.statusCode.flatMap { Int($0) }
+        let initialMethods = model.method.map { [$0.uppercased()] } ?? []
         let initialRule = ResponseBodyRewriteRule(
             urlPattern: initialURLPattern,
             responseBody: initialResponseBody,
-            responseStatusCode: initialStatusCode
+            responseStatusCode: initialStatusCode,
+            httpMethod: initialMethods.compactMap { HTTPMethod(rawValue: $0) }.first
         )
 
         let editor = RewriteRuleEditViewController(rule: initialRule) { [weak self] updatedRule in

--- a/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
+++ b/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
@@ -49,7 +49,7 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
         guard let sectionType = Section(rawValue: section) else { return 0 }
         switch sectionType {
         case .options:
-            return 4
+            return 5
         case .rules:
             return max(rewriteConfig.rules.count, 1)
         }
@@ -120,6 +120,12 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
             toggle.addTarget(self, action: #selector(allRulesToggleChanged(_:)), for: .valueChanged)
             cell.accessoryView = toggle
         case 3:
+            cell.textLabel?.text = "Short-circuit Mode"
+            let toggle = UISwitch()
+            toggle.isOn = NetworkInjectionManager.shared.isRewriteShortCircuitEnabled()
+            toggle.addTarget(self, action: #selector(shortCircuitToggleChanged(_:)), for: .valueChanged)
+            cell.accessoryView = toggle
+        case 4:
             cell.textLabel?.text = "Import / Export CSV"
             cell.accessoryType = .disclosureIndicator
         default:
@@ -157,7 +163,27 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
 
     private func handleOptionSelection(row: Int) {
         switch row {
+        case 0:
+            showInfoAlert(
+                title: "Enable Response Modifier",
+                message: "Turns response modifier on or off globally. When off, no rewrite rules are applied."
+            )
+        case 1:
+            showInfoAlert(
+                title: "Auto-enable Every Run",
+                message: "If enabled, response modifier will automatically be active each time the app starts."
+            )
+        case 2:
+            showInfoAlert(
+                title: "Enable All Rules",
+                message: "Quickly enable or disable all existing rules at once."
+            )
         case 3:
+            showInfoAlert(
+                title: "Short-circuit Matched Rules",
+                message: "When enabled, matched rules return mocked responses immediately from local data. This works offline and skips the real network request for matched rules."
+            )
+        case 4:
             showImportExportMenu()
         default:
             break
@@ -176,6 +202,16 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
 
     @objc private func autoEnableToggleChanged(_ sender: UISwitch) {
         NetworkInjectionManager.shared.setRewriteAutoEnableOnRun(sender.isOn)
+    }
+    
+    @objc private func shortCircuitToggleChanged(_ sender: UISwitch) {
+        NetworkInjectionManager.shared.setRewriteShortCircuitEnabled(sender.isOn)
+    }
+    
+    private func showInfoAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 
     @objc private func ruleToggleChanged(_ sender: UISwitch) {

--- a/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
+++ b/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
@@ -34,11 +34,18 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
         view.backgroundColor = .black
         tableView.backgroundColor = .black
         tableView.separatorColor = .darkGray
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
+        let addButton = UIBarButtonItem(
             barButtonSystemItem: .add,
             target: self,
             action: #selector(addRuleTapped)
         )
+        let menuButton = UIBarButtonItem(
+            image: UIImage(systemName: "ellipsis.circle"),
+            style: .plain,
+            target: self,
+            action: #selector(showMoreMenu)
+        )
+        navigationItem.rightBarButtonItems = [addButton, menuButton]
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -152,7 +159,7 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
         cell.textLabel?.text = displayPattern
         cell.textLabel?.numberOfLines = 2
         cell.textLabel?.lineBreakMode = .byTruncatingHead
-        cell.detailTextLabel?.text = nil
+        cell.detailTextLabel?.text = rule.httpMethod?.rawValue ?? "All Methods"
         let toggle = UISwitch()
         toggle.isOn = rule.isEnabled
         toggle.tag = row
@@ -192,6 +199,39 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
 
     @objc private func addRuleTapped() {
         showRewriteRuleEditor()
+    }
+
+    @objc private func showMoreMenu() {
+        let alert = UIAlertController(title: "More", message: nil, preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: "Reset All", style: .destructive) { [weak self] _ in
+            self?.confirmResetAll()
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        if let popover = alert.popoverPresentationController {
+            popover.barButtonItem = navigationItem.rightBarButtonItems?.last
+        }
+        present(alert, animated: true)
+    }
+
+    private func confirmResetAll() {
+        let alert = UIAlertController(
+            title: "Reset All Response Modifier Settings?",
+            message: "This will disable Response Modifier, disable Auto-enable, keep Short-circuit Mode enabled, and remove all rules.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "Reset All", style: .destructive) { [weak self] _ in
+            self?.performResetAll()
+        })
+        present(alert, animated: true)
+    }
+
+    private func performResetAll() {
+        let resetConfig = ResponseBodyRewriteConfig(isEnabled: false, rules: [])
+        NetworkInjectionManager.shared.setRewriteConfig(resetConfig)
+        NetworkInjectionManager.shared.setRewriteAutoEnableOnRun(false)
+        NetworkInjectionManager.shared.setRewriteShortCircuitEnabled(true)
+        tableView.reloadData()
     }
 
     @objc private func masterToggleChanged(_ sender: UISwitch) {
@@ -279,7 +319,7 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
             var updatedRules = self.rewriteConfig.rules
             if let editIndex {
                 updatedRules[editIndex] = updatedRule
-            } else if let existingIndex = updatedRules.firstIndex(where: { $0.urlPattern == updatedRule.urlPattern }) {
+            } else if let existingIndex = updatedRules.firstIndex(where: { $0.urlPattern == updatedRule.urlPattern && $0.httpMethod == updatedRule.httpMethod }) {
                 updatedRules[existingIndex] = updatedRule
             } else {
                 updatedRules.append(updatedRule)
@@ -370,9 +410,10 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
         var created = 0
         var updated = 0
         for importedRule in importedRules {
-            if let existingIndex = mergedRules.firstIndex(where: { $0.urlPattern == importedRule.urlPattern }) {
+            if let existingIndex = mergedRules.firstIndex(where: { $0.urlPattern == importedRule.urlPattern && $0.httpMethod == importedRule.httpMethod }) {
                 mergedRules[existingIndex].responseBody = importedRule.responseBody
                 mergedRules[existingIndex].responseStatusCode = importedRule.responseStatusCode
+                mergedRules[existingIndex].httpMethod = importedRule.httpMethod
                 updated += 1
             } else {
                 mergedRules.append(importedRule)

--- a/DebugSwift/Sources/Features/Network/Details/RewriteRuleEditViewController.swift
+++ b/DebugSwift/Sources/Features/Network/Details/RewriteRuleEditViewController.swift
@@ -51,6 +51,12 @@ final class RewriteRuleEditViewController: BaseController {
         return textField
     }()
     
+    private let supportedHTTPMethods = HTTPMethod.allCases
+    private var selectedHTTPMethod: HTTPMethod?
+    private weak var methodButton: UIButton!
+    private var initialDraftRule: ResponseBodyRewriteRule?
+    private var showPopup = false
+    
     init(rule: ResponseBodyRewriteRule?, onSave: @escaping (ResponseBodyRewriteRule) -> Void) {
         self.existingRule = rule
         self.onSave = onSave
@@ -60,69 +66,114 @@ final class RewriteRuleEditViewController: BaseController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+        setupNavigationInterception()
+        captureInitialState()
     }
     
     private func setupUI() {
         title = "Response Editor"
         view.backgroundColor = .black
         
-        let patternLabel = UILabel()
-        patternLabel.translatesAutoresizingMaskIntoConstraints = false
-        patternLabel.text = "URL or Pattern"
-        patternLabel.textColor = .white
-        patternLabel.font = .preferredFont(forTextStyle: .headline)
+        func makeSectionLabel(_ title: String) -> UILabel {
+            let label = UILabel()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            label.text = title
+            label.textColor = .white
+            label.font = .preferredFont(forTextStyle: .headline)
+            return label
+        }
         
-        let bodyLabel = UILabel()
-        bodyLabel.translatesAutoresizingMaskIntoConstraints = false
-        bodyLabel.text = "Response Body"
-        bodyLabel.textColor = .white
-        bodyLabel.font = .preferredFont(forTextStyle: .headline)
+        let methodButton = UIButton(type: .system)
+        methodButton.translatesAutoresizingMaskIntoConstraints = false
+        methodButton.setTitleColor(.systemBlue, for: .normal)
+        methodButton.contentHorizontalAlignment = .left
+        methodButton.layer.cornerRadius = 8
+        methodButton.layer.borderWidth = 0.5
+        methodButton.layer.borderColor = UIColor.separator.cgColor
+        methodButton.backgroundColor = .secondarySystemBackground
+        methodButton.contentEdgeInsets = UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
+        if #available(iOS 14.0, *) {
+            methodButton.showsMenuAsPrimaryAction = true
+        } else {
+            methodButton.addTarget(self, action: #selector(selectMethodTappedLegacy), for: .touchUpInside)
+        }
         
-        let statusCodeLabel = UILabel()
-        statusCodeLabel.translatesAutoresizingMaskIntoConstraints = false
-        statusCodeLabel.text = "Status Code"
-        statusCodeLabel.textColor = .white
-        statusCodeLabel.font = .preferredFont(forTextStyle: .headline)
+        self.methodButton = methodButton
+        updateMethodSelection()
+
+        let patternSection = UIStackView(arrangedSubviews: [
+            makeSectionLabel("URL or Pattern"),
+            patternField,
+        ])
+        patternSection.axis = .vertical
+        patternSection.spacing = 8
+
+        let statusCodeSection = UIStackView(arrangedSubviews: [
+            makeSectionLabel("Status Code"),
+            statusCodeField,
+        ])
+        statusCodeSection.axis = .vertical
+        statusCodeSection.spacing = 8
+
+        let methodSection = UIStackView(arrangedSubviews: [
+            makeSectionLabel("HTTP Method"),
+            methodButton,
+        ])
+        methodSection.axis = .vertical
+        methodSection.spacing = 8
+
+        let bodySection = UIStackView(arrangedSubviews: [
+            makeSectionLabel("Response Body"),
+            bodyTextView,
+        ])
+        bodySection.axis = .vertical
+        bodySection.spacing = 8
         
-        view.addSubview(patternLabel)
-        view.addSubview(patternField)
-        view.addSubview(statusCodeLabel)
-        view.addSubview(statusCodeField)
-        view.addSubview(bodyLabel)
-        view.addSubview(bodyTextView)
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        let contentView = UIView()
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        let formStack = UIStackView(arrangedSubviews: [
+            patternSection,
+            statusCodeSection,
+            methodSection,
+            bodySection,
+        ])
+        formStack.translatesAutoresizingMaskIntoConstraints = false
+        formStack.axis = .vertical
+        formStack.spacing = 16
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+        contentView.addSubview(formStack)
         
         NSLayoutConstraint.activate([
-            patternLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
-            patternLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            patternLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            
-            patternField.topAnchor.constraint(equalTo: patternLabel.bottomAnchor, constant: 8),
-            patternField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            patternField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            patternField.heightAnchor.constraint(equalToConstant: 44),
-            
-            statusCodeLabel.topAnchor.constraint(equalTo: patternField.bottomAnchor, constant: 16),
-            statusCodeLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            statusCodeLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            
-            statusCodeField.topAnchor.constraint(equalTo: statusCodeLabel.bottomAnchor, constant: 8),
-            statusCodeField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            statusCodeField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            statusCodeField.heightAnchor.constraint(equalToConstant: 44),
-            
-            bodyLabel.topAnchor.constraint(equalTo: statusCodeField.bottomAnchor, constant: 16),
-            bodyLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            bodyLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-            bodyTextView.topAnchor.constraint(equalTo: bodyLabel.bottomAnchor, constant: 8),
-            bodyTextView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            bodyTextView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            bodyTextView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16)
+            contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+
+            formStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+            formStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            formStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            formStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -24),
+
+            patternField.heightAnchor.constraint(equalToConstant: 44),
+            statusCodeField.heightAnchor.constraint(equalToConstant: 44),
+            methodButton.heightAnchor.constraint(equalToConstant: 44),
+            bodyTextView.heightAnchor.constraint(greaterThanOrEqualToConstant: 320)
         ])
         
         if let existingRule {
             patternField.text = existingRule.urlPattern
             bodyTextView.text = existingRule.responseBody
+            selectedHTTPMethod = existingRule.httpMethod
+            updateMethodSelection()
             if let responseStatusCode = existingRule.responseStatusCode {
                 statusCodeField.text = "\(responseStatusCode)"
             }
@@ -149,29 +200,122 @@ final class RewriteRuleEditViewController: BaseController {
         bodyEditorButton.accessibilityLabel = "Body Editor"
         navigationItem.rightBarButtonItems = [saveButton, bodyEditorButton, menuButton]
     }
+
+    private func setupNavigationInterception() {
+        navigationItem.hidesBackButton = true
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "chevron.backward"),
+            style: .plain,
+            target: self,
+            action: #selector(backTapped)
+        )
+    }
+
+    private func captureInitialState() {
+        initialDraftRule = currentDraftRule()
+    }
+
+    private func hasUnsavedChanges() -> Bool {
+        currentDraftRule() != initialDraftRule
+    }
+
+    private func currentDraftRule() -> ResponseBodyRewriteRule {
+        let pattern = (patternField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let statusCodeText = (statusCodeField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let statusCode: Int? = Int(statusCodeText)
+        return ResponseBodyRewriteRule(
+            urlPattern: pattern,
+            responseBody: bodyTextView.text ?? "",
+            responseStatusCode: statusCode,
+            httpMethod: selectedHTTPMethod
+        )
+    }
     
+    @objc private func openBodyEditorTapped() {
+        openKeyValueEditor()
+    }
+
     @objc private func showBodyEditorOptions() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        
-        alert.addAction(UIAlertAction(title: "Body Editor", style: .default) { [weak self] _ in
-            self?.openKeyValueEditor()
-        })
-        
         alert.addAction(UIAlertAction(title: "Clear Body", style: .destructive) { [weak self] _ in
             self?.bodyTextView.text = ""
         })
-        
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         if let popover = alert.popoverPresentationController {
             popover.barButtonItem = navigationItem.rightBarButtonItems?.last
         }
-        
         present(alert, animated: true)
     }
 
-    @objc private func openBodyEditorTapped() {
-        openKeyValueEditor()
+    @objc private func backTapped() {
+        guard hasUnsavedChanges() else {
+            showPopup = true
+            navigationController?.popViewController(animated: true)
+            return
+        }
+
+        let alert = UIAlertController(
+            title: "Unsaved Changes",
+            message: "You have unsaved changes. Discard them and go back?",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Keep Editing", style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: "Discard", style: .destructive) { [weak self] _ in
+            self?.showPopup = true
+            self?.navigationController?.popViewController(animated: true)
+        })
+        present(alert, animated: true)
+    }
+
+    private func updateMethodSelection() {
+        let title = selectedHTTPMethod?.rawValue ?? "All Methodes"
+        methodButton.setTitle(title, for: .normal)
+        if #available(iOS 14.0, *) {
+            methodButton.menu = buildMethodMenu()
+        }
+    }
+
+    private func buildMethodMenu() -> UIMenu {
+        var actions: [UIAction] = []
+        actions.append(
+            UIAction(
+                title: "All Methodes",
+                state: selectedHTTPMethod == nil ? .on : .off
+            ) { [weak self] _ in
+                self?.selectedHTTPMethod = nil
+                self?.updateMethodSelection()
+            }
+        )
+        actions.append(contentsOf: supportedHTTPMethods.map { method in
+            UIAction(
+                title: method.rawValue,
+                state: selectedHTTPMethod == method ? .on : .off
+            ) { [weak self] _ in
+                self?.selectedHTTPMethod = method
+                self?.updateMethodSelection()
+            }
+        })
+        return UIMenu(title: "HTTP Method", options: .displayInline, children: actions)
+    }
+
+    @objc private func selectMethodTappedLegacy() {
+        let alert = UIAlertController(title: "HTTP Method", message: "Select one method", preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: "All Methodes", style: .default) { [weak self] _ in
+            self?.selectedHTTPMethod = nil
+            self?.updateMethodSelection()
+        })
+        for method in supportedHTTPMethods {
+            alert.addAction(UIAlertAction(title: method.rawValue, style: .default) { [weak self] _ in
+                self?.selectedHTTPMethod = method
+                self?.updateMethodSelection()
+            })
+        }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = methodButton
+            popover.sourceRect = methodButton.bounds
+        }
+        present(alert, animated: false)
     }
     
     private func openKeyValueEditor() {
@@ -211,9 +355,12 @@ final class RewriteRuleEditViewController: BaseController {
         let rule = ResponseBodyRewriteRule(
             urlPattern: pattern,
             responseBody: body,
-            responseStatusCode: statusCode
+            responseStatusCode: statusCode,
+            httpMethod: selectedHTTPMethod
         )
         onSave(rule)
+        captureInitialState()
+        showPopup = true
         navigationController?.popViewController(animated: true)
     }
     

--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -144,6 +144,10 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         
         // Resolve rewrite rule once per request (first-match-wins order)
         matchedRewriteRule = NetworkInjectionManager.shared.matchingRewriteRule(for: request)
+        if let matchedRewriteRule, NetworkInjectionManager.shared.isRewriteShortCircuitEnabled() {
+            injectRewrittenResponse(using: matchedRewriteRule, for: request)
+            return
+        }
         
         threadOperator = ThreadOperator()
         startTime = Date()
@@ -250,6 +254,54 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
                 cachePolicy: cachePolicy
             )
             Self.report(data, matchedResponseModifier: false)
+        }
+    }
+    
+    private func injectRewrittenResponse(using rule: ResponseBodyRewriteRule, for request: URLRequest) {
+        guard let url = request.url else { return }
+        
+        let rewrittenData = rule.responseBody.data(using: .utf8) ?? Data()
+        let statusCode = rule.responseStatusCode ?? 200
+        
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )
+        
+        if let response {
+            self.response = response
+            self.data = rewrittenData
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: rewrittenData)
+        }
+        
+        client?.urlProtocolDidFinishLoading(self)
+        
+        let method = request.httpMethod
+        let requestId = request.requestId
+        let cachePolicy = getCachePolicy(value: request.cachePolicy.rawValue)
+        let requestHeaderFields = request.allHTTPHeaderFields
+        let now = Date()
+        
+        Task { @MainActor in
+            let data = NetworkReportData(
+                url: url,
+                method: method,
+                requestData: nil,
+                responseData: rewrittenData,
+                statusCode: "\(statusCode)",
+                mineType: "application/json",
+                startTime: now,
+                endTime: now,
+                error: nil,
+                requestHeaderFields: requestHeaderFields,
+                responseHeaderFields: ["Content-Type": "application/json"],
+                requestId: requestId,
+                cachePolicy: cachePolicy
+            )
+            Self.report(data, matchedResponseModifier: true)
         }
     }
     
@@ -461,14 +513,6 @@ extension CustomHTTPProtocol: URLSessionDataDelegate {
             Debug.print(#function)
             
             if self.matchedRewriteRule != nil {
-                if self.cachePolicy == .allowed {
-                    self.data.append(data)
-                } else if self.data.isEmpty {
-                    self.data = data
-                } else {
-                    self.data.append(data)
-                }
-                
                 self.didReceiveData = true
                 return
             }

--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -67,6 +67,8 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
     private var prevUrl: URL?
     private var prevStartTime: Date?
     private var matchedRewriteRule: ResponseBodyRewriteRule?
+    private let reportQueue = DispatchQueue(label: "com.debugswift.http-protocol.report")
+    private var didReport = false
 
     private var threadOperator: ThreadOperator?
     
@@ -186,6 +188,8 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         }
         """.data(using: .utf8) ?? Data()
         
+        guard markReportedIfNeeded() else { return }
+
         // Notify client of response
         if let response = httpResponse {
             self.response = response
@@ -225,6 +229,7 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
     }
     
     private func injectNetworkError(_ error: Error) {
+        guard markReportedIfNeeded() else { return }
         self.error = error
         client?.urlProtocol(self, didFailWithError: error)
         
@@ -270,6 +275,8 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             headerFields: ["Content-Type": "application/json"]
         )
         
+        guard markReportedIfNeeded() else { return }
+
         if let response {
             self.response = response
             self.data = rewrittenData
@@ -353,6 +360,8 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         let cachePolicy = getCachePolicy(value: request.cachePolicy.rawValue)
         let matchedResponseModifier = matchedRewriteRule != nil
 
+        guard markReportedIfNeeded() else { return }
+
         Task { @MainActor in
             guard NetworkHelper.shared.isNetworkEnable else {
                 return
@@ -374,6 +383,14 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
                 cachePolicy: cachePolicy
             )
             Self.report(reportData, matchedResponseModifier: matchedResponseModifier)
+        }
+    }
+
+    private func markReportedIfNeeded() -> Bool {
+        reportQueue.sync {
+            guard !didReport else { return false }
+            didReport = true
+            return true
         }
     }
     

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
@@ -7,6 +7,16 @@
 
 import Foundation
 
+public enum HTTPMethod: String, CaseIterable, Sendable, Codable {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case patch = "PATCH"
+    case delete = "DELETE"
+    case head = "HEAD"
+    case options = "OPTIONS"
+}
+
 /// Configuration for network request delay injection
 public struct RequestDelayConfig: Sendable {
     /// Whether delay injection is enabled
@@ -259,6 +269,9 @@ public struct ResponseBodyRewriteRule: Sendable, Equatable, Codable {
     
     /// Optional HTTP status code override for rewritten response
     public var responseStatusCode: Int?
+    
+    /// HTTP method to match (`nil` means all methods).
+    public var httpMethod: HTTPMethod?
 
     /// Whether this rule is active
     public var isEnabled: Bool
@@ -271,15 +284,18 @@ public struct ResponseBodyRewriteRule: Sendable, Equatable, Codable {
         urlPattern: String,
         responseBody: String,
         responseStatusCode: Int? = nil,
+        httpMethod: HTTPMethod? = nil,
         isEnabled: Bool = true,
         matchType: MatchType = .exact
     ) {
         self.urlPattern = urlPattern
         self.responseBody = responseBody
         self.responseStatusCode = responseStatusCode
+        self.httpMethod = httpMethod
         self.isEnabled = isEnabled
         self.matchType = matchType
     }
+
 }
 
 /// Configuration for response body rewrite injection

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionConfig.swift
@@ -246,6 +246,11 @@ public struct NetworkFailureConfig: Sendable {
 
 /// A single response body rewrite rule.
 public struct ResponseBodyRewriteRule: Sendable, Equatable, Codable {
+    public enum MatchType: String, Sendable, Equatable, Codable {
+        case exact
+        case wildcard
+    }
+
     /// URL pattern to match (supports wildcard `*` and `?`)
     public var urlPattern: String
     
@@ -257,17 +262,23 @@ public struct ResponseBodyRewriteRule: Sendable, Equatable, Codable {
 
     /// Whether this rule is active
     public var isEnabled: Bool
+
+    /// Matcher mode used for fast-path lookup.
+    /// Backward-compatible: missing value from older persisted data defaults to `.exact`.
+    public var matchType: MatchType
     
     public init(
         urlPattern: String,
         responseBody: String,
         responseStatusCode: Int? = nil,
-        isEnabled: Bool = true
+        isEnabled: Bool = true,
+        matchType: MatchType = .exact
     ) {
         self.urlPattern = urlPattern
         self.responseBody = responseBody
         self.responseStatusCode = responseStatusCode
         self.isEnabled = isEnabled
+        self.matchType = matchType
     }
 }
 

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
@@ -14,6 +14,7 @@ final class NetworkInjectionManager: @unchecked Sendable {
     private enum PersistenceKeys {
         static let rewriteRules = "DebugSwift.NetworkInjection.RewriteRules"
         static let rewriteAutoEnableOnRun = "DebugSwift.NetworkInjection.RewriteAutoEnableOnRun"
+        static let rewriteShortCircuitEnabled = "DebugSwift.NetworkInjection.RewriteShortCircuitEnabled"
     }
     
     private let queue = DispatchQueue(label: "com.debugswift.injection", attributes: .concurrent)
@@ -106,6 +107,17 @@ final class NetworkInjectionManager: @unchecked Sendable {
 
     func shouldAutoEnableRewriteOnRun() -> Bool {
         UserDefaults.standard.bool(forKey: PersistenceKeys.rewriteAutoEnableOnRun)
+    }
+    
+    func setRewriteShortCircuitEnabled(_ isEnabled: Bool) {
+        UserDefaults.standard.set(isEnabled, forKey: PersistenceKeys.rewriteShortCircuitEnabled)
+    }
+    
+    func isRewriteShortCircuitEnabled() -> Bool {
+        if UserDefaults.standard.object(forKey: PersistenceKeys.rewriteShortCircuitEnabled) == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: PersistenceKeys.rewriteShortCircuitEnabled)
     }
     
     private func loadPersistedRewriteRules() -> [ResponseBodyRewriteRule] {

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
@@ -117,7 +117,12 @@ final class NetworkInjectionManager: @unchecked Sendable {
         guard isEnabled else { return nil }
 
         let requestURLLowercased = url.absoluteString.lowercased()
+        let requestMethod = HTTPMethod(rawValue: (request.httpMethod ?? HTTPMethod.get.rawValue).uppercased()) ?? .get
         for rule in rules where rule.isEnabled {
+            if let allowedMethod = rule.httpMethod, allowedMethod != requestMethod {
+                continue
+            }
+
             switch rule.matchType {
             case .exact:
                 if requestURLLowercased == rule.urlPattern.lowercased() {

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
@@ -21,10 +21,16 @@ final class NetworkInjectionManager: @unchecked Sendable {
     private var _delayConfig: RequestDelayConfig = RequestDelayConfig()
     private var _failureConfig: NetworkFailureConfig = NetworkFailureConfig()
     private var _rewriteConfig: ResponseBodyRewriteConfig = ResponseBodyRewriteConfig()
+    private var _rewriteRulesSnapshot: [ResponseBodyRewriteRule] = []
     
     private init() {
         _rewriteConfig.isEnabled = shouldAutoEnableRewriteOnRun()
-        _rewriteConfig.rules = loadPersistedRewriteRules()
+        _rewriteConfig.rules = loadPersistedRewriteRules().map { rule in
+            var normalizedRule = rule
+            normalizedRule.matchType = rule.urlPattern.contains("*") || rule.urlPattern.contains("?") ? .wildcard : .exact
+            return normalizedRule
+        }
+        _rewriteRulesSnapshot = _rewriteConfig.rules
     }
     
     // MARK: - Delay Injection
@@ -84,9 +90,16 @@ final class NetworkInjectionManager: @unchecked Sendable {
     func setRewriteConfig(_ config: ResponseBodyRewriteConfig) {
         queue.sync(flags: .barrier) {
             let previousRules = _rewriteConfig.rules
-            _rewriteConfig = config
-            if previousRules != config.rules {
-                persistRewriteRules(config.rules)
+            var normalizedConfig = config
+            normalizedConfig.rules = config.rules.map { rule in
+                var normalizedRule = rule
+                normalizedRule.matchType = rule.urlPattern.contains("*") || rule.urlPattern.contains("?") ? .wildcard : .exact
+                return normalizedRule
+            }
+            _rewriteConfig = normalizedConfig
+            _rewriteRulesSnapshot = normalizedConfig.rules
+            if previousRules != normalizedConfig.rules {
+                persistRewriteRules(normalizedConfig.rules)
             }
         }
         Debug.print("✏️ Rewrite config updated: enabled=\(config.isEnabled), rules=\(config.rules.count)")
@@ -97,8 +110,31 @@ final class NetworkInjectionManager: @unchecked Sendable {
     }
     
     func matchingRewriteRule(for request: URLRequest) -> ResponseBodyRewriteRule? {
-        let config = getRewriteConfig()
-        return config.matchingRule(for: request)
+        guard let url = request.url else { return nil }
+        let (isEnabled, rules): (Bool, [ResponseBodyRewriteRule]) = queue.sync {
+            (_rewriteConfig.isEnabled, _rewriteRulesSnapshot)
+        }
+        guard isEnabled else { return nil }
+
+        let requestURLLowercased = url.absoluteString.lowercased()
+        for rule in rules where rule.isEnabled {
+            switch rule.matchType {
+            case .exact:
+                if requestURLLowercased == rule.urlPattern.lowercased() {
+                    return rule
+                }
+            case .wildcard:
+                if url.matches(
+                    wildcardPattern: rule.urlPattern,
+                    strategy: .full,
+                    queryStrategy: .exact
+                ) {
+                    return rule
+                }
+            }
+        }
+
+        return nil
     }
 
     func setRewriteAutoEnableOnRun(_ isEnabled: Bool) {

--- a/DebugSwift/Sources/Features/Network/Helpers/RewriteRulesCSV.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/RewriteRulesCSV.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum RewriteRulesCSV {
-    static let expectedHeader = ["url_pattern", "response_status_code", "response_body"]
+    static let expectedHeader = ["url_pattern", "response_status_code", "response_body", "http_method"]
 
     static func export(rules: [ResponseBodyRewriteRule]) -> String {
         var lines: [String] = []
@@ -16,10 +16,12 @@ enum RewriteRulesCSV {
 
         for rule in rules {
             let statusCode = rule.responseStatusCode.map(String.init) ?? ""
+            let methods = rule.httpMethod.map(\.rawValue) ?? ""
             let row = [
                 csvEscaped(rule.urlPattern),
                 csvEscaped(statusCode),
                 csvEscaped(rule.responseBody),
+                csvEscaped(methods),
             ].joined(separator: ",")
             lines.append(row)
         }
@@ -34,7 +36,7 @@ enum RewriteRulesCSV {
         }
 
         let normalizedHeader = header.map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-        guard normalizedHeader == expectedHeader else {
+        if normalizedHeader != expectedHeader {
             throw RewriteRulesCSVError.invalidHeader
         }
 
@@ -44,7 +46,8 @@ enum RewriteRulesCSV {
                 continue
             }
 
-            guard row.count == expectedHeader.count else {
+            let expectedColumnCount = expectedHeader.count
+            guard row.count == expectedColumnCount else {
                 throw RewriteRulesCSVError.invalidColumnCount(row: index + 2)
             }
 
@@ -53,7 +56,19 @@ enum RewriteRulesCSV {
                 throw RewriteRulesCSVError.emptyURLPattern(row: index + 2)
             }
 
-            let rawStatusCode = row[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            let statusIndex = 1
+            let bodyIndex = 2
+            let methodsIndex = 3
+
+            let httpMethod: HTTPMethod?
+            let rawMethod = row[methodsIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+            if rawMethod.isEmpty {
+                httpMethod = nil
+            } else {
+                httpMethod = HTTPMethod(rawValue: rawMethod.uppercased())
+            }
+
+            let rawStatusCode = row[statusIndex].trimmingCharacters(in: .whitespacesAndNewlines)
             let statusCode: Int?
             if rawStatusCode.isEmpty {
                 statusCode = nil
@@ -64,12 +79,13 @@ enum RewriteRulesCSV {
                 statusCode = value
             }
 
-            let responseBody = row[2]
+            let responseBody = row[bodyIndex]
             rules.append(
                 ResponseBodyRewriteRule(
                     urlPattern: urlPattern,
                     responseBody: responseBody,
-                    responseStatusCode: statusCode
+                    responseStatusCode: statusCode,
+                    httpMethod: httpMethod
                 )
             )
         }
@@ -165,7 +181,7 @@ enum RewriteRulesCSVError: LocalizedError, Equatable {
         case .emptyFile:
             return "The CSV file is empty."
         case .invalidHeader:
-            return "Invalid CSV header. Expected: url_pattern,response_status_code,response_body"
+            return "Invalid CSV header. Expected: url_pattern,response_status_code,response_body,http_method"
         case .invalidCSVFormat(let row):
             return "Row \(row) has invalid CSV format."
         case .invalidColumnCount(let row):


### PR DESCRIPTION
## Summary
Close #363 - Add `HttpMethod` as an injection parameter. 

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [x] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Launch the app and open injection-related screens.
2. Set `HttpMethod` in injection parameters and verify request-specific injection behavior.
3. Use reset injection menu and confirm injection state returns to default.

## Screenshots / recordings (if applicable)

<img width="541" height="1029" alt="image" src="https://github.com/user-attachments/assets/25568ceb-b3c3-4fb6-9b9b-841aeb55b4d8" />

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility
