### PR TITLE
feat(network-injection): Add import action to Body Modifier Rule from the Network Session 

### DIFF
--- a/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
+++ b/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
@@ -222,10 +222,11 @@ final class NetworkViewControllerDetail: BaseTableController {
 
     private func appendRewriteRule(_ rule: ResponseBodyRewriteRule) {
         var config = NetworkInjectionManager.shared.getRewriteConfig()
+        config.isEnabled = true
         config.rules.append(rule)
         NetworkInjectionManager.shared.setRewriteConfig(config)
         showAlert(
-            with: "Rewrite rule created for this request",
+            with: "Rewrite rule created for this request. Response Modifier is now active.",
             title: "Response Modifier Added",
             rightButtonTitle: "OK"
         )

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
@@ -104,6 +104,19 @@ final class NetworkInjectionManager: @unchecked Sendable {
         }
         Debug.print("✏️ Rewrite config updated: enabled=\(config.isEnabled), rules=\(config.rules.count)")
     }
+
+    func replaceRewriteRulesFromSessionHistory(_ rules: [ResponseBodyRewriteRule]) {
+        queue.sync(flags: .barrier) {
+            var config = _rewriteConfig
+            config.isEnabled = true
+            config.rules = rules
+            _rewriteConfig = config
+            _rewriteRulesSnapshot = rules
+            persistRewriteRules(rules)
+        }
+        setRewriteShortCircuitEnabled(true)
+        Debug.print("✏️ Session history imported as rewrite rules: rules=\(rules.count)")
+    }
     
     func getRewriteConfig() -> ResponseBodyRewriteConfig {
         return queue.sync { _rewriteConfig }

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkSessionRewriteRuleBuilder.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkSessionRewriteRuleBuilder.swift
@@ -1,0 +1,35 @@
+//
+//  NetworkSessionRewriteRuleBuilder.swift
+//  DebugSwift
+//
+//  Created by Adjie Satryo on 16/05/26.
+//
+
+import Foundation
+
+enum NetworkSessionRewriteRuleBuilder {
+    static func makeRules(from models: [HttpModel]) -> [ResponseBodyRewriteRule] {
+        models.compactMap { model -> ResponseBodyRewriteRule? in
+            let urlPattern = model.url?.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !urlPattern.isEmpty else { return nil }
+
+            let methodText = model.method?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .uppercased()
+            let method = methodText.flatMap(HTTPMethod.init(rawValue:))
+
+            let statusCodeText = model.statusCode?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let statusCode = statusCodeText.flatMap { Int($0) }
+
+            return ResponseBodyRewriteRule(
+                urlPattern: urlPattern,
+                responseBody: model.decryptedResponseData?.formattedString() ?? model.responseData?.formattedString() ?? "",
+                responseStatusCode: statusCode,
+                httpMethod: method,
+                isEnabled: true,
+                matchType: .exact
+            )
+        }
+    }
+}

--- a/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
+++ b/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
@@ -15,6 +15,10 @@ import SwiftData
 final class NetworkSessionHistoryViewController: BaseController {
     private var sessions: [NetworkSessionPersistenceManager.SessionRecord] = []
     private var activeSessionID: UUID?
+    private var retentionInfoText: String {
+        let days = NetworkSessionPersistenceManager.retentionDaysPreference
+        return "Session history only preserves the last \(days) day\(days == 1 ? "" : "s") of data."
+    }
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .grouped)
@@ -33,7 +37,7 @@ final class NetworkSessionHistoryViewController: BaseController {
         label.numberOfLines = 0
         label.textColor = .secondaryLabel
         label.font = .systemFont(ofSize: 15, weight: .regular)
-        label.text = "No session history available."
+        label.text = "No session history available.\n\n\(retentionInfoText)"
         return label
     }()
 
@@ -102,6 +106,10 @@ final class NetworkSessionHistoryViewController: BaseController {
 
 @available(iOS 17.0, *)
 extension NetworkSessionHistoryViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        retentionInfoText
+    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         sessions.count
     }

--- a/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
+++ b/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
@@ -14,6 +14,7 @@ import SwiftData
 @MainActor
 final class NetworkSessionHistoryViewController: BaseController {
     private var sessions: [NetworkSessionPersistenceManager.SessionRecord] = []
+    private var activeSessionID: UUID?
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .grouped)
@@ -62,7 +63,10 @@ final class NetworkSessionHistoryViewController: BaseController {
 
     private func loadSessions() {
         Task { @MainActor in
-            sessions = await NetworkSessionPersistenceManager.shared.fetchSessions()
+            async let loadedSessions = NetworkSessionPersistenceManager.shared.fetchSessions()
+            async let loadedActiveSessionID = NetworkSessionPersistenceManager.shared.activeSessionID()
+            sessions = await loadedSessions
+            activeSessionID = await loadedActiveSessionID
             tableView.reloadData()
             updateEmptyState()
         }
@@ -80,11 +84,14 @@ final class NetworkSessionHistoryViewController: BaseController {
 
     private func sessionSubtitle(_ session: NetworkSessionPersistenceManager.SessionRecord) -> String {
         let requestsCount = session.requestCount
-        let countText = "\(requestsCount) requests"
+        let countText = requestsCount == 0 ? "No requests" : "\(requestsCount) request\(requestsCount == 1 ? "" : "s")"
+
+        if session.id == activeSessionID {
+            return "\(countText) • Active"
+        }
 
         guard let endedAt = session.endedAt else {
-            let activeText = "Active"
-            return "\(countText) • \(activeText)"
+            return countText
         }
 
         let duration = Int(max(endedAt.timeIntervalSince(session.startedAt), 0))

--- a/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
+++ b/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
@@ -99,8 +99,15 @@ final class NetworkSessionHistoryViewController: BaseController {
         }
 
         let duration = Int(max(endedAt.timeIntervalSince(session.startedAt), 0))
-        let durationText = "\(duration)s"
+        let durationText = formattedDuration(seconds: duration)
         return "\(countText) • \(durationText)"
+    }
+
+    private func formattedDuration(seconds: Int) -> String {
+        let hours = seconds / 3_600
+        let minutes = (seconds % 3_600) / 60
+        let remainingSeconds = seconds % 60
+        return String(format: "%02d:%02d:%02d", hours, minutes, remainingSeconds)
     }
 }
 

--- a/DebugSwift/Sources/Features/Network/History/NetworkSessionRequestListViewController.swift
+++ b/DebugSwift/Sources/Features/Network/History/NetworkSessionRequestListViewController.swift
@@ -59,6 +59,7 @@ final class NetworkSessionRequestListViewController: BaseController {
         super.viewDidLoad()
         navigationItem.largeTitleDisplayMode = .never
         setup()
+        setupNavigation()
         loadRequests()
     }
 
@@ -80,6 +81,19 @@ final class NetworkSessionRequestListViewController: BaseController {
             tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
+    }
+
+    private func setupNavigation() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: injectionSymbolImage(),
+            style: .plain,
+            target: self,
+            action: #selector(importSessionTapped)
+        )
+    }
+
+    private func injectionSymbolImage() -> UIImage? {
+        UIImage(systemName: "syringe")
     }
 
     private func loadRequests() {
@@ -120,6 +134,44 @@ final class NetworkSessionRequestListViewController: BaseController {
             tableView.backgroundView = nil
             tableView.separatorStyle = .singleLine
         }
+    }
+
+    @objc private func importSessionTapped() {
+        guard !requests.isEmpty else {
+            showMessageAlert(
+                title: "No Requests",
+                message: "This session does not contain any requests to import."
+            )
+            return
+        }
+
+        let alert = UIAlertController(
+            title: "Import Session to Response Modifier?",
+            message: "This will delete all existing Response Modifier rules and replace them with \(requests.count) rule(s) from this session.\n\nLong sessions can create many rules and may reduce network matching performance.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Import", style: .destructive) { [weak self] _ in
+            self?.importSessionRules()
+        })
+        present(alert, animated: true)
+    }
+
+    private func importSessionRules() {
+        let rules = NetworkSessionRewriteRuleBuilder.makeRules(
+            from: requests.map { $0.makeHttpModel() }
+        )
+        NetworkInjectionManager.shared.replaceRewriteRulesFromSessionHistory(rules)
+        showMessageAlert(
+            title: "Import Complete",
+            message: "Replaced existing Response Modifier rules with \(rules.count) rule(s) from this session."
+        )
+    }
+
+    private func showMessageAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 }
 

--- a/DebugSwift/Sources/Features/Network/History/NetworkSessionRequestListViewController.swift
+++ b/DebugSwift/Sources/Features/Network/History/NetworkSessionRequestListViewController.swift
@@ -164,7 +164,7 @@ final class NetworkSessionRequestListViewController: BaseController {
         NetworkInjectionManager.shared.replaceRewriteRulesFromSessionHistory(rules)
         showMessageAlert(
             title: "Import Complete",
-            message: "Replaced existing Response Modifier rules with \(rules.count) rule(s) from this session."
+            message: "Replaced existing Response Modifier rules with \(rules.count) rule(s) from this session. Response Modifier is now active."
         )
     }
 

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
@@ -150,6 +150,11 @@ final class NetworkSessionPersistenceManager {
         return await writeStore.fetchSessions()
     }
 
+    func activeSessionID() async -> UUID? {
+        guard let writeStore else { return nil }
+        return await writeStore.activeSessionID()
+    }
+
     func fetchRequests(for sessionID: UUID) async -> [RequestRecord] {
         guard let writeStore else { return [] }
         return await writeStore.fetchRequests(for: sessionID)

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
@@ -89,10 +89,6 @@ final class NetworkSessionPersistenceManager {
         return saved > 0 ? saved : Preference.defaultRetentionDays
     }
 
-    nonisolated static func setRetentionDaysPreference(_ days: Int) {
-        UserDefaults.standard.set(max(1, days), forKey: Preference.retentionDaysKey)
-    }
-
     func activateFromPreferences() {
         Task {
             if Self.isPersistenceEnabledPreference {
@@ -124,7 +120,7 @@ final class NetworkSessionPersistenceManager {
     }
 
     func setRetentionDays(_ days: Int) async {
-        Self.setRetentionDaysPreference(days)
+        UserDefaults.standard.set(max(1, days), forKey: Preference.retentionDaysKey)
         retentionDays = Self.retentionDaysPreference
 
         if isEnabled {

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
@@ -88,7 +88,11 @@ final class NetworkSessionPersistenceManager {
         let saved = UserDefaults.standard.integer(forKey: Preference.retentionDaysKey)
         return saved > 0 ? saved : Preference.defaultRetentionDays
     }
-    
+
+    nonisolated static func setRetentionDaysPreference(_ days: Int) {
+        UserDefaults.standard.set(max(1, days), forKey: Preference.retentionDaysKey)
+    }
+
     func activateFromPreferences() {
         Task {
             if Self.isPersistenceEnabledPreference {
@@ -117,6 +121,15 @@ final class NetworkSessionPersistenceManager {
         }
         guard let writeStore else { return }
         await writeStore.enable(retentionDays: self.retentionDays)
+    }
+
+    func setRetentionDays(_ days: Int) async {
+        Self.setRetentionDaysPreference(days)
+        retentionDays = Self.retentionDaysPreference
+
+        if isEnabled {
+            await purgeExpiredSessions(retentionDays: retentionDays)
+        }
     }
 
     func disable() async {

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
@@ -163,6 +163,10 @@ actor NetworkSessionPersistenceStore {
         }
     }
 
+    func activeSessionID() -> UUID? {
+        activeSession?.id
+    }
+
     func fetchRequests(for sessionID: UUID) -> [NetworkSessionPersistenceManager.RequestRecord] {
         let descriptor = FetchDescriptor<NetworkRequestEntity>(
             predicate: #Predicate { request in

--- a/DebugSwift/Sources/Settings/DebugSwift.Network.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.Network.swift
@@ -275,6 +275,26 @@ extension DebugSwift {
             clearNetworkHistory()
             clearWebSocketHistory()
         }
+
+        /// Configure how many days network sessions are kept for Session History.
+        /// The value is clamped to at least 1 day and is used when the
+        /// `.networkSessionPersistence` beta feature is enabled.
+        ///
+        /// Example:
+        /// ```swift
+        /// DebugSwift.Network.setSessionHistoryRetentionDays(14)
+        /// ```
+        public static func setSessionHistoryRetentionDays(_ days: Int) {
+#if canImport(SwiftData)
+            if #available(iOS 17.0, *) {
+                NetworkSessionPersistenceManager.setRetentionDaysPreference(days)
+
+                Task { @MainActor in
+                    await NetworkSessionPersistenceManager.shared.setRetentionDays(days)
+                }
+            }
+#endif
+        }
         
         // MARK: - Encryption/Decryption API
         

--- a/DebugSwift/Sources/Settings/DebugSwift.Network.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.Network.swift
@@ -287,8 +287,6 @@ extension DebugSwift {
         public static func setSessionHistoryRetentionDays(_ days: Int) {
 #if canImport(SwiftData)
             if #available(iOS 17.0, *) {
-                NetworkSessionPersistenceManager.setRetentionDaysPreference(days)
-
                 Task { @MainActor in
                     await NetworkSessionPersistenceManager.shared.setRetentionDays(days)
                 }

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -50,6 +50,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         debugSwift
             .setup(enableBetaFeatures: [.swiftUIRenderTracking, .networkSessionPersistence])
             .show()
+        
+        DebugSwift.Network.setSessionHistoryRetentionDays(14)
 
         // To fix Alamofire `uploadProgress`
 //        DebugSwift.Network.delegate = self

--- a/README.md
+++ b/README.md
@@ -488,7 +488,10 @@ debugSwift.setup(
 ```swift
 // Enable beta features (disabled by default)
 debugSwift.setup(
-    enableBetaFeatures: [.swiftUIRenderTracking] // Enable experimental SwiftUI render tracking
+    enableBetaFeatures: [
+        .swiftUIRenderTracking,      // Enable experimental SwiftUI render tracking
+        .networkSessionPersistence   // Enable experimental network session history
+    ]
 )
 ```
 
@@ -572,6 +575,17 @@ DebugSwift.SwiftUIRender.shared.clearStats()
 // Clear persistent overlays
 DebugSwift.SwiftUIRender.shared.clearPersistentOverlays()
 ```
+
+### Network Session History (Beta)
+
+⚠️ **Beta Feature**: Network session history is experimental, requires iOS 17 or later, and must be enabled explicitly.
+
+```swift
+// First enable the beta feature in setup
+debugSwift.setup(enableBetaFeatures: [.networkSessionPersistence])
+```
+
+After enabled, the Session History menu appears in the top toolbar. DebugSwift shows all network sessions captured in the last 7 days, and you can directly import a full session into Response Modifier rules to mock the complete API state from that session.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -581,11 +581,13 @@ DebugSwift.SwiftUIRender.shared.clearPersistentOverlays()
 ⚠️ **Beta Feature**: Network session history is experimental, requires iOS 17 or later, and must be enabled explicitly.
 
 ```swift
-// First enable the beta feature in setup
 debugSwift.setup(enableBetaFeatures: [.networkSessionPersistence])
+
+// Optional: change how many days sessions are kept
+DebugSwift.Network.setSessionHistoryRetentionDays(14)
 ```
 
-After enabled, the Session History menu appears in the top toolbar. DebugSwift shows all network sessions captured in the last 7 days, and you can directly import a full session into Response Modifier rules to mock the complete API state from that session.
+After enabled, the Session History menu appears in the top toolbar. DebugSwift shows all captured network sessions within the retention period(default: 7 days), and you can directly import a full session into Response Modifier rules to mock the complete API state from that session.
 
 ---
 


### PR DESCRIPTION
## Summary

Close  #361 - Mock API for entire session

- Added an inject/import action to the opened Network Session request list.
- Added unit test.
- Adjust session footer and description
- Auto enable Body Modifier during appending new rule

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [x] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Open a saved Network Session detail screen with captured requests.
2. Tap the inject button in the top-right corner and confirm the destructive warning.
3. Open Response Modifier rules and verify existing rules were replaced by rules from the session

## Screenshots / recordings (if applicable)
<img width="400" height="657" alt="image" src="https://github.com/user-attachments/assets/2536790c-a79e-488c-a9dc-7b5e2fe46bc2" />

<img width="400" height="657" alt="image" src="https://github.com/user-attachments/assets/373863e9-4ba9-4f87-b0ee-9a6dc4958cdb" />

<img width="400" height="657" alt="image" src="https://github.com/user-attachments/assets/a33a8003-f774-48a1-bdb4-b87726792e67" />

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility