### PR TITLE
fix(fab): force animation label inside ballView

### DIFF
--- a/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
+++ b/DebugSwift/Sources/Helpers/FloatingButton/Views/FloatBallView/FloatBallView.swift
@@ -209,18 +209,18 @@ extension FloatBallView {
     }
 
     private func startAnimation(text: String) {
-        guard let container = superview, window != nil else { return }
+        guard window != nil, ballView.superview === self else { return }
 
         let label = UILabel()
         label.text = text
         label.textAlignment = .center
         label.font = .systemFont(ofSize: 12)
         label.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(label)
+        ballView.addSubview(label)
 
         NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor)
+            label.centerXAnchor.constraint(equalTo: ballView.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: ballView.centerYAnchor)
         ])
         
         Task { @MainActor in


### PR DESCRIPTION
## Summary

Close #346 - The floating button is moved with layer.position via FloatBallPositionHelper, which changes its visual position outside Auto Layout. When the animation label is added to superview, its constraints can still resolve from the old layout geometry.
Adding it inside ballView keeps the animation in the same moving view subtree.

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Drag FAB 
2. Hit some API

## Screenshots / recordings (if applicable)

<img width="800" height="1314" alt="QuickTime movie" src="https://github.com/user-attachments/assets/c65b1d3b-238f-44b7-8494-7a36b5c348a3" />
## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility
