### PR TITLE
feat(network-injection): add dialog for multi match response modifier rules

### DIFF
--- a/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
+++ b/DebugSwift/Sources/Features/Network/Details/ResponseModifierSettingsController.swift
@@ -56,7 +56,7 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
         guard let sectionType = Section(rawValue: section) else { return 0 }
         switch sectionType {
         case .options:
-            return 5
+            return 6
         case .rules:
             return max(rewriteConfig.rules.count, 1)
         }
@@ -133,6 +133,12 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
             toggle.addTarget(self, action: #selector(shortCircuitToggleChanged(_:)), for: .valueChanged)
             cell.accessoryView = toggle
         case 4:
+            cell.textLabel?.text = "Enable Multiple Match"
+            let toggle = UISwitch()
+            toggle.isOn = NetworkInjectionManager.shared.isRewriteMultipleMatchEnabled()
+            toggle.addTarget(self, action: #selector(multipleMatchToggleChanged(_:)), for: .valueChanged)
+            cell.accessoryView = toggle
+        case 5:
             cell.textLabel?.text = "Import / Export CSV"
             cell.accessoryType = .disclosureIndicator
         default:
@@ -191,6 +197,11 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
                 message: "When enabled, matched rules return mocked responses immediately from local data. This works offline and skips the real network request for matched rules."
             )
         case 4:
+            showInfoAlert(
+                title: "Multiple Match Selection",
+                message: "When enabled, if a request matches more than one rule, you can choose which rule to apply. Default is first-match behavior when disabled."
+            )
+        case 5:
             showImportExportMenu()
         default:
             break
@@ -216,7 +227,7 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
     private func confirmResetAll() {
         let alert = UIAlertController(
             title: "Reset All Response Modifier Settings?",
-            message: "This will disable Response Modifier, disable Auto-enable, keep Short-circuit Mode enabled, and remove all rules.",
+            message: "This will disable Response Modifier, disable Auto-enable, disable Multiple Match, keep Short-circuit Mode enabled, and remove all rules.",
             preferredStyle: .alert
         )
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
@@ -230,6 +241,7 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
         let resetConfig = ResponseBodyRewriteConfig(isEnabled: false, rules: [])
         NetworkInjectionManager.shared.setRewriteConfig(resetConfig)
         NetworkInjectionManager.shared.setRewriteAutoEnableOnRun(false)
+        NetworkInjectionManager.shared.setRewriteMultipleMatchEnabled(false)
         NetworkInjectionManager.shared.setRewriteShortCircuitEnabled(true)
         tableView.reloadData()
     }
@@ -246,6 +258,10 @@ final class ResponseModifierSettingsController: BaseTableController, UIDocumentP
     
     @objc private func shortCircuitToggleChanged(_ sender: UISwitch) {
         NetworkInjectionManager.shared.setRewriteShortCircuitEnabled(sender.isOn)
+    }
+
+    @objc private func multipleMatchToggleChanged(_ sender: UISwitch) {
+        NetworkInjectionManager.shared.setRewriteMultipleMatchEnabled(sender.isOn)
     }
     
     private func showInfoAlert(title: String, message: String) {

--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
     private static let requestProperty = "com.custom.http.protocol"
@@ -144,8 +145,7 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             return
         }
         
-        // Resolve rewrite rule once per request (first-match-wins order)
-        matchedRewriteRule = NetworkInjectionManager.shared.matchingRewriteRule(for: request)
+        matchedRewriteRule = resolveRewriteRule(for: request)
         if let matchedRewriteRule, NetworkInjectionManager.shared.isRewriteShortCircuitEnabled() {
             injectRewrittenResponse(using: matchedRewriteRule, for: request)
             return
@@ -165,6 +165,69 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
         dataTask = session?.dataTask(with: newRequest as URLRequest)
         dataTask?.resume()
+    }
+
+    private func resolveRewriteRule(for request: URLRequest) -> ResponseBodyRewriteRule? {
+        let manager = NetworkInjectionManager.shared
+        guard manager.isRewriteMultipleMatchEnabled() else {
+            return manager.matchingRewriteRule(for: request)
+        }
+
+        let matches = manager.matchingRewriteRules(for: request)
+        guard !matches.isEmpty else { return nil }
+        guard matches.count > 1 else { return matches.first }
+
+        return showMultipleMatchSelectionDialog(for: request, matches: matches)
+    }
+
+    private func showMultipleMatchSelectionDialog(
+        for request: URLRequest,
+        matches: [ResponseBodyRewriteRule]
+    ) -> ResponseBodyRewriteRule? {
+        if Thread.isMainThread {
+            return nil
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        let selectionBox = RewriteRuleSelectionBox()
+
+        DispatchQueue.main.async {
+            guard let presenter = UIApplication.topViewController() else {
+                semaphore.signal()
+                return
+            }
+
+            let requestLink = request.url?.absoluteString ?? "Unknown URL"
+            let requestMethod = (request.httpMethod ?? HTTPMethod.get.rawValue).uppercased()
+            let message = "[\(requestMethod)] \(requestLink)"
+
+            let alert = UIAlertController(
+                title: "Choose Response Modifier Rule",
+                message: message,
+                preferredStyle: .alert
+            )
+
+            for rule in matches {
+                let statusCode = rule.responseStatusCode ?? 200
+                let title = "Status Code: \(statusCode)"
+                alert.addAction(UIAlertAction(title: title, style: .default) { _ in
+                    selectionBox.set(rule)
+                    semaphore.signal()
+                })
+            }
+
+            alert.addAction(UIAlertAction(title: "No Rewrite", style: .cancel) { _ in
+                semaphore.signal()
+            })
+
+            presenter.present(alert, animated: true)
+        }
+
+        let waitResult = semaphore.wait(timeout: .now() + 30)
+        if waitResult == .timedOut {
+            return nil
+        }
+        return selectionBox.get()
     }
     
     private func injectHTTPError(statusCode: Int, for request: URLRequest) {
@@ -817,5 +880,20 @@ struct NetworkReportData: Sendable {
         self.responseHeaderFields = responseHeaderFields
         self.requestId = requestId
         self.cachePolicy = cachePolicy
+    }
+}
+
+private final class RewriteRuleSelectionBox: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "com.debugswift.http-protocol.selection-box")
+    private var value: ResponseBodyRewriteRule?
+    
+    func set(_ newValue: ResponseBodyRewriteRule?) {
+        queue.sync {
+            value = newValue
+        }
+    }
+    
+    func get() -> ResponseBodyRewriteRule? {
+        queue.sync { value }
     }
 }

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkInjectionManager.swift
@@ -15,6 +15,7 @@ final class NetworkInjectionManager: @unchecked Sendable {
         static let rewriteRules = "DebugSwift.NetworkInjection.RewriteRules"
         static let rewriteAutoEnableOnRun = "DebugSwift.NetworkInjection.RewriteAutoEnableOnRun"
         static let rewriteShortCircuitEnabled = "DebugSwift.NetworkInjection.RewriteShortCircuitEnabled"
+        static let rewriteMultipleMatchEnabled = "DebugSwift.NetworkInjection.RewriteMultipleMatchEnabled"
     }
     
     private let queue = DispatchQueue(label: "com.debugswift.injection", attributes: .concurrent)
@@ -131,28 +132,44 @@ final class NetworkInjectionManager: @unchecked Sendable {
 
         let requestURLLowercased = url.absoluteString.lowercased()
         let requestMethod = HTTPMethod(rawValue: (request.httpMethod ?? HTTPMethod.get.rawValue).uppercased()) ?? .get
-        for rule in rules where rule.isEnabled {
-            if let allowedMethod = rule.httpMethod, allowedMethod != requestMethod {
-                continue
-            }
-
-            switch rule.matchType {
-            case .exact:
-                if requestURLLowercased == rule.urlPattern.lowercased() {
-                    return rule
-                }
-            case .wildcard:
-                if url.matches(
-                    wildcardPattern: rule.urlPattern,
-                    strategy: .full,
-                    queryStrategy: .exact
-                ) {
-                    return rule
-                }
+        for rule in rules {
+            if matchesRule(
+                rule,
+                requestURLLowercased: requestURLLowercased,
+                requestURL: url,
+                requestMethod: requestMethod
+            ) {
+                return rule
             }
         }
-
         return nil
+    }
+
+    func matchingRewriteRules(for request: URLRequest) -> [ResponseBodyRewriteRule] {
+        guard let url = request.url else { return [] }
+        let (isEnabled, rules): (Bool, [ResponseBodyRewriteRule]) = queue.sync {
+            (_rewriteConfig.isEnabled, _rewriteRulesSnapshot)
+        }
+        guard isEnabled else { return [] }
+
+        let requestURLLowercased = url.absoluteString.lowercased()
+        let requestMethod = HTTPMethod(rawValue: (request.httpMethod ?? HTTPMethod.get.rawValue).uppercased()) ?? .get
+        return rules.filter { rule in
+            matchesRule(
+                rule,
+                requestURLLowercased: requestURLLowercased,
+                requestURL: url,
+                requestMethod: requestMethod
+            )
+        }
+    }
+
+    func setRewriteMultipleMatchEnabled(_ isEnabled: Bool) {
+        UserDefaults.standard.set(isEnabled, forKey: PersistenceKeys.rewriteMultipleMatchEnabled)
+    }
+    
+    func isRewriteMultipleMatchEnabled() -> Bool {
+        UserDefaults.standard.bool(forKey: PersistenceKeys.rewriteMultipleMatchEnabled)
     }
 
     func setRewriteAutoEnableOnRun(_ isEnabled: Bool) {
@@ -190,6 +207,29 @@ final class NetworkInjectionManager: @unchecked Sendable {
         
         if let encoded = try? JSONEncoder().encode(rules) {
             UserDefaults.standard.set(encoded, forKey: PersistenceKeys.rewriteRules)
+        }
+    }
+
+    private func matchesRule(
+        _ rule: ResponseBodyRewriteRule,
+        requestURLLowercased: String,
+        requestURL: URL,
+        requestMethod: HTTPMethod
+    ) -> Bool {
+        guard rule.isEnabled else { return false }
+        if let allowedMethod = rule.httpMethod, allowedMethod != requestMethod {
+            return false
+        }
+
+        switch rule.matchType {
+        case .exact:
+            return requestURLLowercased == rule.urlPattern.lowercased()
+        case .wildcard:
+            return requestURL.matches(
+                wildcardPattern: rule.urlPattern,
+                strategy: .full,
+                queryStrategy: .exact
+            )
         }
     }
 }

--- a/DebugSwift/Sources/Features/Network/Helpers/NetworkSessionRewriteRuleBuilder.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/NetworkSessionRewriteRuleBuilder.swift
@@ -9,9 +9,20 @@ import Foundation
 
 enum NetworkSessionRewriteRuleBuilder {
     static func makeRules(from models: [HttpModel]) -> [ResponseBodyRewriteRule] {
-        models.compactMap { model -> ResponseBodyRewriteRule? in
+        struct RuleKey: Hashable {
+            let urlPattern: String
+            let method: HTTPMethod?
+            let statusCode: Int?
+            let responseBody: String
+        }
+
+        var processedKeys = Set<RuleKey>()
+        var rules: [ResponseBodyRewriteRule] = []
+        rules.reserveCapacity(models.count)
+
+        for model in models {
             let urlPattern = model.url?.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            guard !urlPattern.isEmpty else { return nil }
+            guard !urlPattern.isEmpty else { continue }
 
             let methodText = model.method?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -22,14 +33,28 @@ enum NetworkSessionRewriteRuleBuilder {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let statusCode = statusCodeText.flatMap { Int($0) }
 
-            return ResponseBodyRewriteRule(
+            let responseBody = model.decryptedResponseData?.formattedString() ?? model.responseData?.formattedString() ?? ""
+            let ruleKey = RuleKey(
                 urlPattern: urlPattern,
-                responseBody: model.decryptedResponseData?.formattedString() ?? model.responseData?.formattedString() ?? "",
-                responseStatusCode: statusCode,
-                httpMethod: method,
-                isEnabled: true,
-                matchType: .exact
+                method: method,
+                statusCode: statusCode,
+                responseBody: responseBody
             )
+
+            if processedKeys.insert(ruleKey).inserted {
+                rules.append(
+                    ResponseBodyRewriteRule(
+                        urlPattern: urlPattern,
+                        responseBody: responseBody,
+                        responseStatusCode: statusCode,
+                        httpMethod: method,
+                        isEnabled: true,
+                        matchType: .exact
+                    )
+                )
+            }
         }
+
+        return rules
     }
 }


### PR DESCRIPTION
## Summary

- Add **Multiple Injection Rules** dialog in response modifier settings.
- Ignore duplicate injection rules when importing from session.
  
## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Enable Response Modifier and create multiple enabled rules that match the same request.
2. Enable Multiple Match, trigger the matching request, and verify the selection dialog appears.
3. Pick a rule and verify the selected mocked response is applied.
4. Disable Multiple Match and verify the first matching rule is applied automatically.
5. Import rewrite rules from session history and verify duplicates are skipped.

## Screenshots / recordings (if applicable)
<img width="400" height="657" alt="image" src="https://github.com/user-attachments/assets/3cc1368d-3780-42cb-b5e1-570e2cf7f89f" />
<img width="400" height="657" alt="image" src="https://github.com/user-attachments/assets/77d310ff-ca8c-4e6e-a9ff-5c170ad66699" />
<img width="480" height="788" alt="QuickTime movie" src="https://github.com/user-attachments/assets/efda0a47-7e60-4617-b566-f94213332795" />

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility