### PR TITLE
feat(network-monitor): Clear session

### DIFF
--- a/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
+++ b/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
@@ -164,7 +164,11 @@ final class NetworkSessionHistoryViewController: BaseController {
             }
             sessions.remove(at: indexPath.row)
             isLoading = false
-            tableView.deleteRows(at: [indexPath], with: .automatic)
+            if sessions.count == 1 {
+                tableView.reloadData()
+            } else {
+                tableView.deleteRows(at: [indexPath], with: .automatic)
+            }
             updateEmptyState()
             updateNavigationItems()
         }

--- a/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
+++ b/DebugSwift/Sources/Features/Network/History/NetworkSessionHistoryViewController.swift
@@ -15,6 +15,7 @@ import SwiftData
 final class NetworkSessionHistoryViewController: BaseController {
     private var sessions: [NetworkSessionPersistenceManager.SessionRecord] = []
     private var activeSessionID: UUID?
+    private var isLoading = false
     private var retentionInfoText: String {
         let days = NetworkSessionPersistenceManager.retentionDaysPreference
         return "Session history only preserves the last \(days) day\(days == 1 ? "" : "s") of data."
@@ -46,6 +47,7 @@ final class NetworkSessionHistoryViewController: BaseController {
         navigationItem.largeTitleDisplayMode = .never
         title = "Session History"
         setupViews()
+        setupNavigationItems()
         loadSessions()
     }
 
@@ -65,14 +67,28 @@ final class NetworkSessionHistoryViewController: BaseController {
         ])
     }
 
+    private func setupNavigationItems() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: "Clear All",
+            style: .plain,
+            target: self,
+            action: #selector(clearAllTapped)
+        )
+        updateNavigationItems()
+    }
+
     private func loadSessions() {
+        isLoading = true
+        updateNavigationItems()
         Task { @MainActor in
             async let loadedSessions = NetworkSessionPersistenceManager.shared.fetchSessions()
             async let loadedActiveSessionID = NetworkSessionPersistenceManager.shared.activeSessionID()
             sessions = await loadedSessions
             activeSessionID = await loadedActiveSessionID
+            isLoading = false
             tableView.reloadData()
             updateEmptyState()
+            updateNavigationItems()
         }
     }
 
@@ -84,6 +100,10 @@ final class NetworkSessionHistoryViewController: BaseController {
             tableView.backgroundView = nil
             tableView.separatorStyle = .singleLine
         }
+    }
+
+    private func updateNavigationItems() {
+        navigationItem.rightBarButtonItem?.isEnabled = !sessions.isEmpty && !isLoading
     }
 
     private func sessionSubtitle(_ session: NetworkSessionPersistenceManager.SessionRecord) -> String {
@@ -109,12 +129,52 @@ final class NetworkSessionHistoryViewController: BaseController {
         let remainingSeconds = seconds % 60
         return String(format: "%02d:%02d:%02d", hours, minutes, remainingSeconds)
     }
+
+    @objc private func clearAllTapped() {
+        let alert = UIAlertController(
+            title: "Clear All Sessions",
+            message: "Are you sure you want to remove all saved sessions? This action cannot be undone.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Clear", style: .destructive) { [weak self] _ in
+            self?.clearAllSessions()
+        })
+        present(alert, animated: true)
+    }
+
+    private func clearAllSessions() {
+        isLoading = true
+        updateNavigationItems()
+        Task { @MainActor in
+            await NetworkSessionPersistenceManager.shared.deleteAllSessions()
+            loadSessions()
+        }
+    }
+
+    private func deleteSession(at indexPath: IndexPath) {
+        let session = sessions[indexPath.row]
+        isLoading = true
+        updateNavigationItems()
+
+        Task { @MainActor in
+            await NetworkSessionPersistenceManager.shared.deleteSession(id: session.id)
+            if activeSessionID == session.id {
+                activeSessionID = nil
+            }
+            sessions.remove(at: indexPath.row)
+            isLoading = false
+            tableView.deleteRows(at: [indexPath], with: .automatic)
+            updateEmptyState()
+            updateNavigationItems()
+        }
+    }
 }
 
 @available(iOS 17.0, *)
 extension NetworkSessionHistoryViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        retentionInfoText
+        sessions.isEmpty ? nil : retentionInfoText
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -145,6 +205,22 @@ extension NetworkSessionHistoryViewController: UITableViewDataSource, UITableVie
         let title = DateFormatter.networkSessionNavigationTitleFormatter.string(from: session.startedAt)
         let controller = NetworkSessionRequestListViewController(sessionID: session.id, titleText: title)
         navigationController?.pushViewController(controller, animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        true
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    ) -> UISwipeActionsConfiguration? {
+        let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, completion in
+            self?.deleteSession(at: indexPath)
+            completion(true)
+        }
+        deleteAction.backgroundColor = .systemRed
+        return UISwipeActionsConfiguration(actions: [deleteAction])
     }
 }
 

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
@@ -169,6 +169,16 @@ final class NetworkSessionPersistenceManager {
         return await writeStore.fetchRequests(for: sessionID)
     }
 
+    func deleteSession(id: UUID) async {
+        guard let writeStore else { return }
+        await writeStore.deleteSession(id: id)
+    }
+
+    func deleteAllSessions() async {
+        guard let writeStore else { return }
+        await writeStore.deleteAllSessions()
+    }
+
     nonisolated private static func containsFileContentType(_ value: String) -> Bool {
         let normalized = value.lowercased()
         let markers = [

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
@@ -201,6 +201,41 @@ actor NetworkSessionPersistenceStore {
         }
     }
 
+    func deleteSession(id: UUID) {
+        if activeSession?.id == id {
+            activeSession = nil
+        }
+
+        deleteRequests(for: id)
+
+        let descriptor = FetchDescriptor<NetworkSessionEntity>(
+            predicate: #Predicate { session in
+                session.id == id
+            }
+        )
+
+        if let session = try? modelContext.fetch(descriptor).first {
+            modelContext.delete(session)
+            saveInternal(force: true)
+        }
+    }
+
+    func deleteAllSessions() {
+        activeSession = nil
+
+        let requestDescriptor = FetchDescriptor<NetworkRequestEntity>()
+        if let requests = try? modelContext.fetch(requestDescriptor) {
+            requests.forEach { modelContext.delete($0) }
+        }
+
+        let sessionDescriptor = FetchDescriptor<NetworkSessionEntity>()
+        if let sessions = try? modelContext.fetch(sessionDescriptor) {
+            sessions.forEach { modelContext.delete($0) }
+        }
+
+        saveInternal(force: true)
+    }
+
     private func beginSessionIfNeededInternal() {
         guard isEnabled else { return }
         guard activeSession == nil else { return }
@@ -223,18 +258,21 @@ actor NetworkSessionPersistenceStore {
 
         if let sessions = try? modelContext.fetch(descriptor), !sessions.isEmpty {
             sessions.forEach { session in
-                let sessionID = session.id
-                let requestDescriptor = FetchDescriptor<NetworkRequestEntity>(
-                    predicate: #Predicate { request in
-                        request.sessionID == sessionID
-                    }
-                )
-                if let requests = try? modelContext.fetch(requestDescriptor) {
-                    requests.forEach { modelContext.delete($0) }
-                }
+                deleteRequests(for: session.id)
                 modelContext.delete(session)
             }
             saveInternal(force: true)
+        }
+    }
+
+    private func deleteRequests(for sessionID: UUID) {
+        let requestDescriptor = FetchDescriptor<NetworkRequestEntity>(
+            predicate: #Predicate { request in
+                request.sessionID == sessionID
+            }
+        )
+        if let requests = try? modelContext.fetch(requestDescriptor) {
+            requests.forEach { modelContext.delete($0) }
         }
     }
 


### PR DESCRIPTION
## Summary

- Add swipe-to-delete for individual items in Session History
- Add `Clear All` action for Session History with confirmation

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Open Network > Session History with saved sessions present.
2. Swipe left on a session and verify it is removed from the list and no longer appears after reopening Session History.
3. Tap `Clear All`, confirm the action, and verify all saved sessions are removed.
4. Verify the empty state is shown after all sessions are removed.

## Screenshots / recordings (if applicable)

<img width="640" height="1218" alt="Screen Recording 2026-06-03 at 8 09 14 PM" src="https://github.com/user-attachments/assets/8c3ba4ac-2479-4dd5-88e6-6af313e35379" />

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility