### PR TITLE
fix(network-monitor): Add configurable session history batch size and adjust begin session mechanism

### DIFF
--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
@@ -16,7 +16,9 @@ final class NetworkSessionPersistenceManager {
     private enum Preference {
         static let enabledKey = "DebugSwift.Network.SessionPersistence.Enabled"
         static let retentionDaysKey = "DebugSwift.Network.SessionPersistence.RetentionDays"
+        static let batchSizeKey = "DebugSwift.Network.SessionPersistence.BatchSize"
         static let defaultRetentionDays = 7
+        static let defaultBatchSize = 2
     }
     
     struct RequestSnapshot: Sendable {
@@ -77,6 +79,7 @@ final class NetworkSessionPersistenceManager {
 
     private(set) var isEnabled = false
     private var retentionDays = 7
+    private var batchSize = 2
 
     private init() {}
 
@@ -89,10 +92,20 @@ final class NetworkSessionPersistenceManager {
         return saved > 0 ? saved : Preference.defaultRetentionDays
     }
 
+    static var batchSizePreference: Int {
+        guard let saved = UserDefaults.standard.object(forKey: Preference.batchSizeKey) as? Int else {
+            return Preference.defaultBatchSize
+        }
+        return saved
+    }
+
     func activateFromPreferences() {
         Task {
             if Self.isPersistenceEnabledPreference {
-                await enable(retentionDays: Self.retentionDaysPreference)
+                await enable(
+                    retentionDays: Self.retentionDaysPreference,
+                    batchSize: Self.batchSizePreference
+                )
             } else {
                 await disable()
             }
@@ -101,31 +114,42 @@ final class NetworkSessionPersistenceManager {
 
     func applyFeatureEnabled(_ enabled: Bool) async {
         if enabled {
-            await enable(retentionDays: Self.retentionDaysPreference)
+            await enable(
+                retentionDays: Self.retentionDaysPreference,
+                batchSize: Self.batchSizePreference
+            )
         } else {
             await disable()
         }
     }
 
-    func enable(retentionDays: Int = 7) async {
+    func enable(retentionDays: Int, batchSize: Int) async {
         self.retentionDays = max(1, retentionDays)
+        self.batchSize = max(1, batchSize)
         UserDefaults.standard.set(true, forKey: Preference.enabledKey)
         UserDefaults.standard.set(self.retentionDays, forKey: Preference.retentionDaysKey)
+        UserDefaults.standard.set(self.batchSize, forKey: Preference.batchSizeKey)
         isEnabled = true
         if writeStore == nil {
             writeStore = await NetworkSessionPersistenceStore.make()
         }
         guard let writeStore else { return }
-        await writeStore.enable(retentionDays: self.retentionDays)
+        await writeStore.enable(
+            retentionDays: self.retentionDays,
+            batchSize: self.batchSize
+        )
     }
 
-    func setRetentionDays(_ days: Int) async {
-        UserDefaults.standard.set(max(1, days), forKey: Preference.retentionDaysKey)
-        retentionDays = Self.retentionDaysPreference
-
+    func configure(retentionDays: Int, batchSize: Int) async {
         if isEnabled {
-            await purgeExpiredSessions(retentionDays: retentionDays)
+            await enable(retentionDays: retentionDays, batchSize: batchSize)
+            return
         }
+
+        UserDefaults.standard.set(max(1, retentionDays), forKey: Preference.retentionDaysKey)
+        UserDefaults.standard.set(max(1, batchSize), forKey: Preference.batchSizeKey)
+        self.retentionDays = Self.retentionDaysPreference
+        self.batchSize = Self.batchSizePreference
     }
 
     func disable() async {

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceManager.swift
@@ -136,12 +136,6 @@ final class NetworkSessionPersistenceManager {
         self.writeStore = nil
     }
 
-    func beginSessionIfNeeded() async {
-        guard isEnabled else { return }
-        guard let writeStore else { return }
-        await writeStore.beginSessionIfNeeded()
-    }
-
     func persist(_ snapshot: RequestSnapshot) async {
         guard isEnabled else { return }
         guard snapshot.shouldPersist else { return }

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
@@ -231,7 +231,7 @@ actor NetworkSessionPersistenceStore {
         saveInternal(force: true)
     }
 
-    private func beginSessionIfNeededInternal() {
+    private func beginSessionIfNeeded() {
         guard isEnabled else { return }
         guard activeSession == nil else { return }
 

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
@@ -29,7 +29,7 @@ actor NetworkSessionPersistenceStore {
     private var activeSession: NetworkSessionEntity?
     private var pendingWriteCount = 0
     private var isEnabled = false
-    private let saveBatchSize = 2
+    private var saveBatchSize = 2
 
     nonisolated static func make() async -> NetworkSessionPersistenceStore? {
         await Task.detached(priority: .utility) {
@@ -84,10 +84,10 @@ actor NetworkSessionPersistenceStore {
         }
     }
 
-    func enable(retentionDays: Int) {
-        let safeRetentionDays = max(1, retentionDays)
+    func enable(retentionDays: Int, batchSize: Int) {
         isEnabled = true
-        purgeExpiredSessionsInternal(retentionDays: safeRetentionDays)
+        saveBatchSize = batchSize
+        purgeExpiredSessionsInternal(retentionDays: retentionDays)
     }
 
     func disable() {

--- a/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
+++ b/DebugSwift/Sources/Features/Network/Persistence/Network Session/NetworkSessionPersistenceStore.swift
@@ -29,7 +29,7 @@ actor NetworkSessionPersistenceStore {
     private var activeSession: NetworkSessionEntity?
     private var pendingWriteCount = 0
     private var isEnabled = false
-    private let saveBatchSize = 20
+    private let saveBatchSize = 2
 
     nonisolated static func make() async -> NetworkSessionPersistenceStore? {
         await Task.detached(priority: .utility) {
@@ -87,7 +87,6 @@ actor NetworkSessionPersistenceStore {
     func enable(retentionDays: Int) {
         let safeRetentionDays = max(1, retentionDays)
         isEnabled = true
-        beginSessionIfNeededInternal()
         purgeExpiredSessionsInternal(retentionDays: safeRetentionDays)
     }
 
@@ -97,13 +96,9 @@ actor NetworkSessionPersistenceStore {
         activeSession = nil
     }
 
-    func beginSessionIfNeeded() {
-        beginSessionIfNeededInternal()
-    }
-
     func persist(_ snapshot: NetworkSessionPersistenceManager.RequestSnapshot) {
         guard isEnabled, snapshot.shouldPersist else { return }
-        beginSessionIfNeededInternal()
+        beginSessionIfNeeded()
         guard let session = activeSession else { return }
 
         let capturedAt = Date()

--- a/DebugSwift/Sources/Settings/DebugSwift.Network.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.Network.swift
@@ -276,19 +276,24 @@ extension DebugSwift {
             clearWebSocketHistory()
         }
 
-        /// Configure how many days network sessions are kept for Session History.
-        /// The value is clamped to at least 1 day and is used when the
-        /// `.networkSessionPersistence` beta feature is enabled.
+        /// Configure how long Session History is kept and how often new requests are written to disk.
+        /// By default, Session History keeps 7 days of sessions and writes every 2 captured requests.
+        /// Use a longer `retentionDays` value if you want more historical sessions available in the Session History UI.
+        /// Use a smaller `batchSize` if you want captured requests to appear in persisted history sooner, at the cost of more frequent writes.
+        /// Use a larger `batchSize` if you want to reduce write frequency, with the tradeoff that the latest requests may not be saved until the batch fills or the feature is disabled.
         ///
         /// Example:
         /// ```swift
-        /// DebugSwift.Network.setSessionHistoryRetentionDays(14)
+        /// DebugSwift.Network.configureSessionHistory(retentionDays: 14, batchSize: 10)
         /// ```
-        public static func setSessionHistoryRetentionDays(_ days: Int) {
+        public static func configureSessionHistory(retentionDays: Int, batchSize: Int) {
 #if canImport(SwiftData)
             if #available(iOS 17.0, *) {
                 Task { @MainActor in
-                    await NetworkSessionPersistenceManager.shared.setRetentionDays(days)
+                    await NetworkSessionPersistenceManager.shared.configure(
+                        retentionDays: retentionDays,
+                        batchSize: batchSize
+                    )
                 }
             }
 #endif

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -51,7 +51,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             .setup(enableBetaFeatures: [.swiftUIRenderTracking, .networkSessionPersistence])
             .show()
         
-        DebugSwift.Network.setSessionHistoryRetentionDays(14)
+        DebugSwift.Network.configureSessionHistory(retentionDays: 14, batchSize: 1)
 
         // To fix Alamofire `uploadProgress`
 //        DebugSwift.Network.delegate = self

--- a/README.md
+++ b/README.md
@@ -583,8 +583,8 @@ DebugSwift.SwiftUIRender.shared.clearPersistentOverlays()
 ```swift
 debugSwift.setup(enableBetaFeatures: [.networkSessionPersistence])
 
-// Optional: change how many days sessions are kept
-DebugSwift.Network.setSessionHistoryRetentionDays(14)
+// Optional: change how many days sessions are kept and how often new requests are written to disk.
+DebugSwift.Network.configureSessionHistory(retentionDays: 14, batchSize: 1)
 ```
 
 After enabled, the Session History menu appears in the top toolbar. DebugSwift shows all captured network sessions within the retention period(default: 7 days), and you can directly import a full session into Response Modifier rules to mock the complete API state from that session.


### PR DESCRIPTION
## Summary

This PR is intended to reduce the risk of losing too much unsaved network session data before it is persisted.
- Add configurable session history batch size and reduce default value from `20` -> `2`
- Stop creating a session immediately and keep session creation deferred until needed

## Type of change

- [x] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Enable network session persistence in the app
2. Trigger a small number of network events and verify they are persisted with fewer pending writes
3. Simulate app termination during activity and confirm less session data is lost

## Screenshots / recordings (if applicable)

<img width="640" height="1218" alt="QuickTime movie" src="https://github.com/user-attachments/assets/edee8315-581d-42c8-a0d1-4efe10b8a84f" />

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [ ] I considered backward compatibility