### PR TITLE
feat: add Battery Usage Monitor (Phase 1) — resolves #314

### DIFF
--- a/DebugSwift/Sources/Features/Performance/Battery/BatteryDebugController.swift
+++ b/DebugSwift/Sources/Features/Performance/Battery/BatteryDebugController.swift
@@ -1,0 +1,194 @@
+//
+//  BatteryDebugController.swift
+//  DebugSwift
+//
+//  Created by emircan.saglam on 7.06.2026.
+//
+
+import UIKit
+
+final class BatteryDebugController: BaseTableController {
+
+    // MARK: - Properties
+
+    private let monitor = BatteryMonitor.shared
+    private var isMonitoringEnabled = false {
+        didSet {
+            UserDefaults.standard.set(isMonitoringEnabled, forKey: "debugswift.battery.monitoringEnabled")
+            isMonitoringEnabled ? monitor.start() : monitor.stop()
+            tableView.reloadData()
+        }
+    }
+    private var refreshTimer: Timer?
+
+    // MARK: - Sections
+
+    private enum Section: Int, CaseIterable {
+        case toggle
+        case status
+        case history
+    }
+
+    // MARK: - Init
+
+    override init() {
+        super.init()
+        title = "Battery"
+        isMonitoringEnabled = UserDefaults.standard.bool(forKey: "debugswift.battery.monitoringEnabled")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(MenuSwitchTableViewCell.self, forCellReuseIdentifier: MenuSwitchTableViewCell.identifier)
+        tableView.register(SparklineMetricCell.self, forCellReuseIdentifier: SparklineMetricCell.identifier)
+        tableView.backgroundColor = .black
+        view.backgroundColor = .black
+
+        if isMonitoringEnabled {
+            monitor.start()
+        }
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, self.isMonitoringEnabled else { return }
+                self.tableView.reloadData()
+            }
+        }
+        RunLoop.main.add(refreshTimer!, forMode: .common)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        Section.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch Section(rawValue: section)! {
+        case .toggle: return 1
+        case .status: return isMonitoringEnabled && monitor.isAvailable ? 3 : 0
+        case .history: return isMonitoringEnabled ? 1 : 0
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch Section(rawValue: section)! {
+        case .toggle: return nil
+        case .status: return isMonitoringEnabled && monitor.isAvailable ? "Status" : nil
+        case .history: return isMonitoringEnabled ? "History" : nil
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch Section(rawValue: indexPath.section)! {
+        case .toggle: return toggleCell()
+        case .status: return statusCell(at: indexPath.row)
+        case .history: return historyCell()
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        (view as? UITableViewHeaderFooterView)?.textLabel?.textColor = .lightGray
+    }
+
+    // MARK: - Cells
+
+    private func toggleCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: MenuSwitchTableViewCell.identifier) as? MenuSwitchTableViewCell ?? .init()
+        cell.titleLabel.text = "Battery Monitoring"
+        cell.valueSwitch.isOn = isMonitoringEnabled
+        cell.delegate = self
+        return cell
+    }
+
+    private func statusCell(at row: Int) -> UITableViewCell {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: "BatteryStatusCell")
+        cell.backgroundColor = .black
+        cell.textLabel?.textColor = .white
+        cell.selectionStyle = .none
+
+        let latestSnapshot = monitor.snapshots.last
+
+        switch row {
+        case 0:
+            let level = latestSnapshot?.level ?? monitor.currentLevel
+            cell.textLabel?.text = "Battery Level"
+            cell.detailTextLabel?.text = level >= 0 ? "\(Int(level * 100))%" : "N/A"
+            cell.detailTextLabel?.textColor = levelColor(level)
+        case 1:
+            let state = latestSnapshot?.state ?? monitor.currentState
+            cell.textLabel?.text = "State"
+            cell.detailTextLabel?.text = state.displayName
+            cell.detailTextLabel?.textColor = .lightGray
+        case 2:
+            let impact = monitor.currentImpact
+            cell.textLabel?.text = "Energy Impact"
+            cell.detailTextLabel?.text = impact?.level.label ?? "Unknown"
+            cell.detailTextLabel?.textColor = impact?.level.color ?? .lightGray
+        default:
+            break
+        }
+
+        return cell
+    }
+
+    private func historyCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SparklineMetricCell.identifier) as? SparklineMetricCell ?? .init()
+
+        let measurements = monitor.snapshots.map { CGFloat($0.level * 100) }
+
+        guard measurements.count >= 2 else {
+            cell.configure(
+                title: "Battery Level",
+                value: "—",
+                color: .systemGray,
+                measurements: [],
+                peakText: "Waiting for data…"
+            )
+            return cell
+        }
+
+        let current = measurements.last ?? 0
+        let peak = measurements.max() ?? 0
+        let min = measurements.min() ?? 0
+
+        cell.configure(
+            title: "Battery Level",
+            value: "\(Int(current))%",
+            color: levelColor(Float(current / 100)),
+            measurements: measurements,
+            peakText: "Peak \(Int(peak))% · Min \(Int(min))%"
+        )
+
+        return cell
+    }
+
+    // MARK: - Helpers
+
+    private func levelColor(_ level: Float) -> UIColor {
+        switch level {
+        case 0.5...: return .systemGreen
+        case 0.2..<0.5: return .systemYellow
+        default: return .systemRed
+        }
+    }
+}
+
+// MARK: - MenuSwitchTableViewCellDelegate
+
+extension BatteryDebugController: MenuSwitchTableViewCellDelegate {
+    func menuSwitchTableViewCell(_ cell: MenuSwitchTableViewCell, didSetOn isOn: Bool) {
+        isMonitoringEnabled = isOn
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Battery/BatteryMetrics.swift
+++ b/DebugSwift/Sources/Features/Performance/Battery/BatteryMetrics.swift
@@ -1,0 +1,61 @@
+//
+//  BatteryMetrics.swift
+//  DebugSwift
+//
+//  Created by emircan.saglam on 7.06.2026.
+//
+
+import UIKit
+
+struct BatterySnapshot {
+    let level: Float
+    let state: UIDevice.BatteryState
+    let timestamp: Date
+}
+
+enum EnergyImpactLevel: Int {
+    case veryLow = 1
+    case low = 2
+    case moderate = 3
+    case high = 4
+    case veryHigh = 5
+
+    var label: String {
+        switch self {
+        case .veryLow: return "Very Low"
+        case .low: return "Low"
+        case .moderate: return "Moderate"
+        case .high: return "High"
+        case .veryHigh: return "Very High"
+        }
+    }
+
+    var color: UIColor {
+        switch self {
+        case .veryLow: return .systemGreen
+        case .low: return .systemGreen
+        case .moderate: return .systemYellow
+        case .high: return .systemOrange
+        case .veryHigh: return .systemRed
+        }
+    }
+}
+
+struct EnergyImpact {
+    let level: EnergyImpactLevel
+    let cpuUsage: Double
+    let isCharging: Bool
+
+    static func calculate(cpuUsage: Double, state: UIDevice.BatteryState) -> EnergyImpact {
+        let isCharging = state == .charging || state == .full
+        let level: EnergyImpactLevel
+        switch cpuUsage {
+        case 0..<10: level = .veryLow
+        case 10..<25: level = .low
+        case 25..<50: level = .moderate
+        case 50..<75: level = .high
+        default: level = .veryHigh
+        }
+        return EnergyImpact(level: level, cpuUsage: cpuUsage, isCharging: isCharging)
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Battery/BatteryMonitor.swift
+++ b/DebugSwift/Sources/Features/Performance/Battery/BatteryMonitor.swift
@@ -1,0 +1,196 @@
+//
+//  BatteryMonitor.swift
+//  DebugSwift
+//
+//  Created by emircan.saglam on 7.06.2026.
+//
+
+@preconcurrency import Foundation
+import UIKit
+
+/// Monitors battery level, state, and energy impact over time.
+/// Sampling occurs every 30 seconds to minimize monitoring overhead.
+/// Battery level and state changes are also captured instantly via system notifications.
+/// On Simulator, mock data is used since battery APIs are unavailable.
+@MainActor
+final class BatteryMonitor {
+    static let shared = BatteryMonitor()
+
+    // MARK: - Properties
+
+    private(set) var snapshots: [BatterySnapshot] = []
+    private(set) var isRunning = false
+    private(set) var currentImpact: EnergyImpact?
+
+    private let historyLimit = 60
+    private var timer: Timer?
+
+    private init() {}
+
+    // MARK: - Public API
+
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        setupNotifications()
+        sample()
+        timer = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.sample()
+            }
+        }
+        RunLoop.main.add(timer!, forMode: .common)
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        isRunning = false
+        timer?.invalidate()
+        timer = nil
+        UIDevice.current.isBatteryMonitoringEnabled = false
+        removeNotifications()
+    }
+
+    var currentLevel: Float {
+        UIDevice.current.batteryLevel
+    }
+
+    var currentState: UIDevice.BatteryState {
+        UIDevice.current.batteryState
+    }
+
+    /// Returns false on physical devices where battery APIs are unavailable.
+    /// Always returns true on Simulator using mock data.
+    var isAvailable: Bool {
+        #if targetEnvironment(simulator)
+        return true
+        #else
+        return UIDevice.current.batteryLevel >= 0
+        #endif
+    }
+
+    // MARK: - Notifications
+
+    /// Observes battery level and state changes for real-time updates
+    /// between the 30-second periodic samples.
+    private func setupNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(batteryLevelChanged),
+            name: UIDevice.batteryLevelDidChangeNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(batteryStateChanged),
+            name: UIDevice.batteryStateDidChangeNotification,
+            object: nil
+        )
+    }
+
+    private func removeNotifications() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIDevice.batteryLevelDidChangeNotification,
+            object: nil
+        )
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIDevice.batteryStateDidChangeNotification,
+            object: nil
+        )
+    }
+
+    @objc private nonisolated func batteryLevelChanged() {
+        Task { @MainActor in
+            self.sample()
+        }
+    }
+
+    @objc private nonisolated func batteryStateChanged() {
+        Task { @MainActor in
+            self.sample()
+        }
+    }
+
+    // MARK: - Sampling
+
+    private func sample() {
+        #if targetEnvironment(simulator)
+        let previousLevel = snapshots.last?.level ?? 0.9
+        let level = max(0.1, min(1.0, previousLevel - Float.random(in: 0.01...0.03)))
+        let state: UIDevice.BatteryState = .unplugged
+        #else
+        let level = UIDevice.current.batteryLevel
+        let state = UIDevice.current.batteryState
+        guard level >= 0 else { return }
+        #endif
+
+        let snapshot = BatterySnapshot(level: level, state: state, timestamp: Date())
+        snapshots.append(snapshot)
+
+        if snapshots.count > historyLimit {
+            snapshots.removeFirst(snapshots.count - historyLimit)
+        }
+
+        currentImpact = EnergyImpact.calculate(
+            cpuUsage: Self.currentCPUUsage(),
+            state: state
+        )
+    }
+
+    // MARK: - CPU Usage
+
+    /// Calculates current CPU usage across all threads.
+    /// Reuses the same mach thread inspection approach as PerformanceToolkit.
+    nonisolated static func currentCPUUsage() -> Double {
+        var totalUsageOfCPU: Double = 0.0
+        var threadsList: thread_act_array_t?
+        var threadsCount = mach_msg_type_number_t(0)
+        let threadsResult = task_threads(mach_task_self_, &threadsList, &threadsCount)
+
+        if threadsResult == KERN_SUCCESS, let threadsList = threadsList {
+            for index in 0..<threadsCount {
+                var threadInfo = thread_basic_info()
+                var threadInfoCount = mach_msg_type_number_t(THREAD_INFO_MAX)
+                let infoResult = withUnsafeMutablePointer(to: &threadInfo) {
+                    $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
+                        thread_info(
+                            threadsList[Int(index)],
+                            thread_flavor_t(THREAD_BASIC_INFO),
+                            $0,
+                            &threadInfoCount
+                        )
+                    }
+                }
+
+                guard infoResult == KERN_SUCCESS else { break }
+
+                let threadBasicInfo = threadInfo as thread_basic_info
+                if threadBasicInfo.flags & TH_FLAGS_IDLE == 0 {
+                    totalUsageOfCPU += Double(threadBasicInfo.cpu_usage) / Double(TH_USAGE_SCALE) * 100.0
+                }
+            }
+
+            let size = vm_size_t(Int(threadsCount) * MemoryLayout<thread_t>.stride)
+            vm_deallocate(mach_task_self_, vm_address_t(UInt(bitPattern: threadsList)), size)
+        }
+
+        return totalUsageOfCPU
+    }
+}
+
+// MARK: - UIDevice.BatteryState
+
+extension UIDevice.BatteryState {
+    var displayName: String {
+        switch self {
+        case .charging: return "Charging"
+        case .full: return "Full"
+        case .unplugged: return "Discharging"
+        case .unknown: return "Unknown"
+        @unknown default: return "Unknown"
+        }
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
+++ b/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
@@ -15,12 +15,22 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
     private let memoryWarningSimulator = PerformanceMemoryWarning()
     private let ioMonitor = DiskIOMonitor.shared
     private let diskAnalyzer = DiskAnalyzer()
+    private let batteryMonitor = BatteryMonitor.shared
 
     private var isDiskMonitoringEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: "debugswift.disk.monitoringEnabled") }
         set {
             UserDefaults.standard.set(newValue, forKey: "debugswift.disk.monitoringEnabled")
             if newValue { ioMonitor.start() } else { ioMonitor.stop() }
+            tableView.reloadData()
+        }
+    }
+
+    private var isBatteryMonitoringEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: "debugswift.battery.monitoringEnabled") }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "debugswift.battery.monitoringEnabled")
+            if newValue { batteryMonitor.start() } else { batteryMonitor.stop() }
             tableView.reloadData()
         }
     }
@@ -46,6 +56,9 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case diskMetrics
         case diskUsage
         case openFiles
+        case batteryToggle
+        case batteryStatus
+        case batteryHistory
     }
 
     // MARK: - UIViewController Lifecycle
@@ -60,9 +73,8 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         super.viewDidLoad()
         setupTableView()
         diskAnalyzer.measure()
-        if isDiskMonitoringEnabled {
-            ioMonitor.start()
-        }
+        if isDiskMonitoringEnabled { ioMonitor.start() }
+        if isBatteryMonitoringEnabled { batteryMonitor.start() }
     }
 
     // MARK: - Setup Methods
@@ -85,7 +97,6 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             SparklineMetricCell.self,
             forCellReuseIdentifier: SparklineMetricCell.identifier
         )
-
         tableView.backgroundColor = UIColor.black
         tableView.showsVerticalScrollIndicator = false
         view.backgroundColor = UIColor.black
@@ -104,7 +115,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .cpu:
             return 1
         case .memory:
-            return 2 // sparkline + memory warning button
+            return 2
         case .fps:
             return 1
         case .leaks:
@@ -118,6 +129,12 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             return diskAnalyzer.usageInfo != nil ? 7 : 0
         case .openFiles:
             return isDiskMonitoringEnabled ? ioMonitor.openFiles.count : 0
+        case .batteryToggle:
+            return 1
+        case .batteryStatus:
+            return isBatteryMonitoringEnabled && batteryMonitor.isAvailable ? 3 : 0
+        case .batteryHistory:
+            return isBatteryMonitoringEnabled ? 1 : 0
         }
     }
 
@@ -134,6 +151,9 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .diskMetrics: return nil
         case .diskUsage: return diskAnalyzer.usageInfo != nil ? "Disk Usage" : nil
         case .openFiles: return isDiskMonitoringEnabled ? "Open Files (\(ioMonitor.openFiles.count))" : nil
+        case .batteryToggle: return "Battery"
+        case .batteryStatus: return nil
+        case .batteryHistory: return isBatteryMonitoringEnabled ? "History" : nil
         }
     }
 
@@ -157,6 +177,12 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             return diskUsageCell(at: indexPath.row)
         case .openFiles:
             return openFileCell(at: indexPath.row)
+        case .batteryToggle:
+            return batteryToggleCell()
+        case .batteryStatus:
+            return batteryStatusCell(at: indexPath.row)
+        case .batteryHistory:
+            return batteryHistoryCell()
         }
     }
 
@@ -409,6 +435,94 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         return cell
     }
 
+    // MARK: - Cells: Battery
+
+    private func batteryToggleCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: MenuSwitchTableViewCell.identifier
+        ) as? MenuSwitchTableViewCell ?? .init()
+        cell.titleLabel.text = "Battery Monitoring"
+        cell.valueSwitch.isOn = isBatteryMonitoringEnabled
+        cell.valueSwitch.tag = 2
+        cell.delegate = self
+        return cell
+    }
+
+    private func batteryStatusCell(at row: Int) -> UITableViewCell {
+        let cell = UITableViewCell(style: .value1, reuseIdentifier: "BatteryStatusCell")
+        cell.backgroundColor = .black
+        cell.textLabel?.textColor = .white
+        cell.selectionStyle = .none
+
+        // Use latest snapshot if available, fall back to live values
+        let latestSnapshot = batteryMonitor.snapshots.last
+
+        switch row {
+        case 0:
+            let level = latestSnapshot?.level ?? batteryMonitor.currentLevel
+            cell.textLabel?.text = "Battery Level"
+            cell.detailTextLabel?.text = level >= 0 ? "\(Int(level * 100))%" : "N/A"
+            cell.detailTextLabel?.textColor = batteryLevelColor(level)
+        case 1:
+            let state = latestSnapshot?.state ?? batteryMonitor.currentState
+            cell.textLabel?.text = "State"
+            cell.detailTextLabel?.text = state.displayName
+            cell.detailTextLabel?.textColor = .lightGray
+        case 2:
+            let impact = batteryMonitor.currentImpact
+            cell.textLabel?.text = "Energy Impact"
+            cell.detailTextLabel?.text = impact?.level.label ?? "Unknown"
+            cell.detailTextLabel?.textColor = impact?.level.color ?? .lightGray
+        default:
+            break
+        }
+
+        return cell
+    }
+
+    private func batteryHistoryCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: SparklineMetricCell.identifier
+        ) as? SparklineMetricCell ?? SparklineMetricCell()
+
+        let measurements = batteryMonitor.snapshots.map { CGFloat($0.level * 100) }
+
+        guard measurements.count >= 2 else {
+            cell.configure(
+                title: "Battery Level",
+                value: "—",
+                color: .systemGray,
+                measurements: [],
+                peakText: "Waiting for data…"
+            )
+            return cell
+        }
+
+        let current = measurements.last ?? 0
+        let peak = measurements.max() ?? 0
+        let min = measurements.min() ?? 0
+
+        cell.configure(
+            title: "Battery Level",
+            value: "\(Int(current))%",
+            color: batteryLevelColor(Float(current / 100)),
+            measurements: measurements,
+            peakText: "Peak \(Int(peak))% · Min \(Int(min))%"
+        )
+
+        return cell
+    }
+
+    // MARK: - Helpers
+
+    private func batteryLevelColor(_ level: Float) -> UIColor {
+        switch level {
+        case 0.5...: return .systemGreen
+        case 0.2..<0.5: return .systemYellow
+        default: return .systemRed
+        }
+    }
+
     private func reuseCell(for reuseIdentifier: Identifier = .value) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier.rawValue) ?? UITableViewCell(style: .value1, reuseIdentifier: reuseIdentifier.rawValue)
         cell.selectionStyle = .none
@@ -493,10 +607,11 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
 
 extension PerformanceViewController: MenuSwitchTableViewCellDelegate {
     func menuSwitchTableViewCell(_ cell: MenuSwitchTableViewCell, didSetOn isOn: Bool) {
-        if cell.valueSwitch.tag == 0 {
-            performanceToolkit.isWidgetShown = isOn
-        } else {
-            isDiskMonitoringEnabled = isOn
+        switch cell.valueSwitch.tag {
+        case 0: performanceToolkit.isWidgetShown = isOn
+        case 1: isDiskMonitoringEnabled = isOn
+        case 2: isBatteryMonitoringEnabled = isOn
+        default: break
         }
     }
 }

--- a/DebugSwift/Sources/Settings/DebugSwift.Performance.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.Performance.swift
@@ -46,30 +46,18 @@ extension DebugSwift {
             }
 
             public var ignoredWindowClassNames: [String] {
-                get {
-                    PerformanceLeakDetector.shared.ignoredWindowClassNames
-                }
-                set {
-                    PerformanceLeakDetector.shared.ignoredWindowClassNames = newValue
-                }
+                get { PerformanceLeakDetector.shared.ignoredWindowClassNames }
+                set { PerformanceLeakDetector.shared.ignoredWindowClassNames = newValue }
             }
 
             public var ignoredViewControllerClassNames: [String] {
-                get {
-                    PerformanceLeakDetector.shared.ignoredViewControllerClassNames
-                }
-                set {
-                    PerformanceLeakDetector.shared.ignoredViewControllerClassNames = newValue
-                }
+                get { PerformanceLeakDetector.shared.ignoredViewControllerClassNames }
+                set { PerformanceLeakDetector.shared.ignoredViewControllerClassNames = newValue }
             }
 
             public var ignoredViewClassNames: [String] {
-                get {
-                    PerformanceLeakDetector.shared.ignoredViewClassNames
-                }
-                set {
-                    PerformanceLeakDetector.shared.ignoredViewClassNames = newValue
-                }
+                get { PerformanceLeakDetector.shared.ignoredViewClassNames }
+                set { PerformanceLeakDetector.shared.ignoredViewClassNames = newValue }
             }
         }
         
@@ -128,7 +116,28 @@ public class PerformanceManager: @unchecked Sendable {
     public let leakDetector = DebugSwift.Performance.LeakDetector()
     
     internal init() {}
-    
+
+    // MARK: - Battery Monitoring
+
+    /// Enables or disables battery monitoring programmatically.
+    /// When enabled, tracks battery level, state, and energy impact in real time.
+    ///
+    /// Usage:
+    /// ```swift
+    /// DebugSwift.Performance.shared.isBatteryMonitoringEnabled = true
+    /// ```
+    @MainActor
+    public var isBatteryMonitoringEnabled: Bool {
+        get { BatteryMonitor.shared.isRunning }
+        set {
+            if newValue {
+                BatteryMonitor.shared.start()
+            } else {
+                BatteryMonitor.shared.stop()
+            }
+        }
+    }
+
     // MARK: - Leak Detection (Legacy Support)
     
     private var leakCallbacks: [(LeakData) -> Void] = []


### PR DESCRIPTION
## Summary

Picks up #314 — implements Phase 1 of the Battery Usage Monitor.

Battery monitoring now lives in the Performance tab alongside CPU, Memory, FPS, and Disk I/O. The feature is opt-in via a toggle (or programmatically via `DebugSwift.Performance.shared.isBatteryMonitoringEnabled`).

**What's included:**
- `BatteryMonitor` — tracks battery level, state, and energy impact. Samples every 30s, with instant updates via battery notifications
- `BatteryMetrics` — data models: `BatterySnapshot`, `EnergyImpactLevel`, `EnergyImpact`
- Battery section in Performance tab — toggle, status rows, historical sparkline graph
- Simulator mock data support for testing without a physical device

**Not included (Phase 2+):**
- Component breakdown (CPU/GPU/Network/Location/Display progress bars)
- GPU tracking — not available via public iOS APIs
- Feature-level energy attribution
- Energy profiling sessions

## Type of change
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan
- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps
1. Run the Example app on a physical device or Simulator
2. Open DebugSwift → Performance tab → scroll to Battery section
3. Toggle **Battery Monitoring** on
4. Verify Battery Level, State, and Energy Impact appear
5. Wait 30 seconds — History graph should populate
6. On physical device: plug/unplug charger — State updates instantly

## Screenshots
<img width="300" alt="Battery monitoring disabled" src="https://github.com/user-attachments/assets/68129b7d-79b6-44b4-98f8-dc00267f58b7" />
<img width="300" alt="Battery monitoring enabled" src="https://github.com/user-attachments/assets/8d4d7c07-3a97-4570-bde9-c92c3438e7da" />

## Checklist
- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility