### PR TITLE
fix(ci): add multi_json to Gemfile for Bundler 4 fastlane load

### DIFF
--- a/Example/Gemfile
+++ b/Example/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem "multi_json"
 gem "xcpretty-json-formatter"


### PR DESCRIPTION
## Summary

- Add `multi_json` explicitly to `Example/Gemfile` so `bundle exec fastlane` can load under Bundler 4
- Fixes CI failure: `multi_json is not part of the bundle` when `representable` (pulled in via fastlane/google-apis) requires it

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI/CD

## Test plan

- [ ] Unit tests updated
- [ ] Manual testing completed
- [x] CI passing

### Manual test steps

1. `cd Example && bundle install && bundle exec fastlane test`

## Screenshots / recordings (if applicable)

N/A

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility

Made with [Cursor](https://cursor.com)