### PR TITLE
docs: AI automation design docs and implementation plans (v3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,11 @@ Thumbs.db
 # ============================================
 # Documentation & Generated Files
 # ============================================
-docs/
+# AI automation design docs (tracked); other generated docs still ignored
+docs/*
+!docs/AI_AUTOMATION.md
+!docs/plans/
+!docs/plans/**
 Documentation/
 *.docset
 *.hmap

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ DebugSwift
 ## 📋 Table of Contents
 
 - [🚀 Features](#features)
+- [🤖 AI Automation (v3)](#ai-automation-v3)
 - [🛠 Installation & Setup](#installation--setup)
 - [🔧 Troubleshooting](#troubleshooting)
 - [📝 Examples](#examples)
@@ -42,6 +43,13 @@ DebugSwift
 - **iOS 14.0+**
 - **Swift 6.0+**
 - **Xcode 16.0+**
+
+## AI Automation (v3)
+
+Design docs for making DebugSwift controllable and observable by AI agents (Cursor, MCP, terminal scripts):
+
+- **[AI Automation overview](docs/AI_AUTOMATION.md)** — architecture, feature inventory, log formats, MCP integration
+- **[Implementation plans (01–22)](docs/plans/README.md)** — step-by-step plans on branch `epic/v3`
 
 ## Features
 

--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -1,0 +1,652 @@
+# DebugSwift AI Automation
+
+> Main design doc for making every DebugSwift feature controllable and observable by AI agents (Cursor, MCP, terminal scripts, CI).
+
+> **Epic branch:** All implementation (Plans 01–22) merges into [`epic/v3`](./plans/README.md#integration-branch-epicv3) → `develop` when complete.
+
+## Goal
+
+An AI agent should be able to:
+
+1. **Enable / disable** any DebugSwift feature from the terminal (without tapping the UI)
+2. **Read structured logs** for data features (network, console, crashes, performance metrics)
+3. **Capture screenshots** for visual features (grid overlay, view debugger, touch indicators, etc.)
+4. Work on **Simulator** and, where possible, on **physical devices** running from Xcode
+
+Today DebugSwift is fully in-process and UI-driven. This doc defines the bridge layer to add on top of existing APIs.
+
+---
+
+## Table of Contents
+
+- [Current State](#current-state)
+- [Platform Matrix: Simulator vs Device](#platform-matrix-simulator-vs-device)
+- [Proposed Architecture](#proposed-architecture)
+- [Terminal Workflows (Today vs Target)](#terminal-workflows-today-vs-target)
+- [Feature Inventory](#feature-inventory)
+- [Visual Features & Screenshots](#visual-features--screenshots)
+- [Log Formats & Export Paths](#log-formats--export-paths)
+- [Implementation Phases](#implementation-phases)
+- [CLI Reference (Target)](#cli-reference-target)
+- [MCP Integration](#mcp-integration)
+- [Security & Constraints](#security--constraints)
+
+---
+
+## Current State
+
+### What exists today
+
+| Capability | Status |
+|---|---|
+| Programmatic setup (`setup`, `hideFeatures`, `disable`) | ✅ Public API |
+| Per-feature singleton APIs (`DebugSwift.Network`, `.Performance`, etc.) | ✅ Partial |
+| In-memory data stores (HTTP models, console, leaks, etc.) | ✅ Internal |
+| UI toggles (UserDefaults keys like `debugswift.oslog.capturingEnabled`) | ✅ UI only |
+| Terminal / CLI bridge | ❌ Not built |
+| Launch-argument / env-var feature flags | ❌ Not built |
+| Structured log export for AI | ❌ Not built |
+| Remote HTTP/MCP server | ❌ Not built |
+
+### Entry points (library)
+
+| File | Role |
+|---|---|
+| `DebugSwift/Sources/Settings/DebugSwift.swift` | Main public API |
+| `DebugSwift/Sources/Settings/FeatureHandling.swift` | Swizzle orchestration |
+| `DebugSwift/Sources/Base/FeatureBase.swift` | Feature enums |
+| `DebugSwift/Sources/Settings/DebugSwift.*.swift` | Per-domain APIs |
+
+### Feature enums
+
+```swift
+// Tabs (hide from UI)
+DebugSwiftFeature: network | performance | interface | resources | app
+
+// Instrumentation (disable swizzling)
+DebugSwiftSwizzleFeature: network | webSocket | wkWebView | location | views
+  | crashManager | leaksDetector | console | pushNotifications | swiftUIRender
+
+// Beta
+DebugSwiftBetaFeature: swiftUIRenderTracking | networkSessionPersistence
+```
+
+---
+
+## Platform Matrix: Simulator vs Device
+
+### Simulator — full support (recommended for AI)
+
+| Capability | Tool | Notes |
+|---|---|---|
+| Launch with env vars | `SIMCTL_CHILD_*` prefix | Passed to app process |
+| Launch with args | `xcrun simctl launch booted <bundle> --arg value` | Args arrive in `ProcessInfo` |
+| Screenshot (full screen) | `xcrun simctl io booted screenshot out.png` | Includes overlays (grid, HUD, float ball) |
+| UI hierarchy snapshot | XcodeBuild MCP `snapshot_ui` / `screenshot` | Semantic element refs for automation |
+| Read app sandbox files | `xcrun simctl get_app_container booted <bundle> data` | Pull NDJSON logs from container |
+| Stream system logs | `xcrun simctl spawn booted log stream --predicate ...` | OSLog, crashes |
+| Open URL (deep link trigger) | `xcrun simctl openurl booted debugswift://...` | Requires host app scheme + bridge handler |
+| Port forwarding | Simulator shares Mac network | Local HTTP bridge on `127.0.0.1:<port>` reachable from Mac |
+
+**Example — launch with AI bridge enabled:**
+
+```bash
+export SIMCTL_CHILD_DEBUGSWIFT_AI=1
+export SIMCTL_CHILD_DEBUGSWIFT_AI_PORT=9999
+xcrun simctl launch booted com.example.app
+```
+
+**Example — pull exported logs:**
+
+```bash
+CONTAINER=$(xcrun simctl get_app_container booted com.example.app data)
+cat "$CONTAINER/Library/Caches/debugswift-ai/network.jsonl"
+```
+
+**Example — screenshot for visual verification:**
+
+```bash
+xcrun simctl io booted screenshot /tmp/debugswift-screen.png
+# or via XcodeBuild MCP: screenshot tool
+```
+
+### Physical Device (Xcode Run) — partial support
+
+| Capability | Tool | iOS version | Notes |
+|---|---|---|---|
+| Launch with env vars | `DEVICECTL_CHILD_*` prefix + `devicectl` | 17+ | Requires `xcrun devicectl device process launch` |
+| Capture stdout/stderr | `devicectl ... launch --console` | 17+, Xcode 16+ | Routes app output to terminal |
+| Screenshot | No native `devicectl` screenshot | — | Use QuickTime, `idevicescreenshot` (libimobiledevice), or in-app export |
+| Read sandbox files | Harder than simulator | — | No `get_app_container` equivalent; need App Group + Files sharing, or HTTP bridge |
+| LLDB from Xcode | `po`, `expr` | All | Manual, not scriptable for agents unless debug server exposed |
+| Network bridge | Local HTTP if Mac can reach device IP | — | Device and Mac on same LAN; bridge binds `0.0.0.0` |
+
+**Example — launch on device with env vars (iOS 17+):**
+
+```bash
+export DEVICECTL_CHILD_DEBUGSWIFT_AI=1
+export DEVICECTL_CHILD_DEBUGSWIFT_AI_PORT=9999
+xcrun devicectl device process launch \
+  --device <DEVICE_UDID> \
+  --terminate-existing \
+  com.example.app
+```
+
+**Example — capture stdout while running on device (Xcode 16+):**
+
+```bash
+xcrun devicectl device process launch \
+  --device <DEVICE_UDID> \
+  --console \
+  com.example.app
+```
+
+### Physical Device — limitations
+
+| Limitation | Workaround |
+|---|---|
+| iOS 16 and below — no `devicectl` | Use `ios-deploy`, Xcode GUI, or in-app HTTP bridge started at launch |
+| No `simctl get_app_container` | Export logs via HTTP bridge or shared App Group container |
+| Screenshot from terminal | In-app `DebugSwift.AI.captureScreenshot()` writes PNG to export dir; pull via HTTP GET |
+| Sandboxed file access from Mac | HTTP bridge is the primary path for device AI integration |
+| Running from Xcode (⌘R) | Env vars can be set in Scheme → Run → Arguments → Environment Variables; same `DEBUGSWIFT_AI_*` keys |
+
+### Verdict
+
+| Environment | AI control | AI logs | AI screenshots |
+|---|---|---|---|
+| **Simulator + terminal** | ✅ Full (env + HTTP + simctl) | ✅ File pull + HTTP | ✅ `simctl io screenshot` + MCP |
+| **Device + devicectl (iOS 17+)** | ✅ Env vars | ⚠️ HTTP bridge or `--console` | ⚠️ In-app export or QuickTime |
+| **Device + Xcode Run (⌘R)** | ✅ Scheme env vars | ⚠️ HTTP bridge | ⚠️ In-app export |
+| **Device iOS 16** | ⚠️ Scheme args only | ⚠️ HTTP bridge only | ⚠️ In-app export |
+
+**Recommendation:** Build the HTTP + NDJSON export bridge first — it works on simulator and device with the same API.
+
+---
+
+## Proposed Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  AI Agent (Cursor / MCP / shell script)                     │
+└────────────┬───────────────────────────────┬────────────────┘
+             │ HTTP/JSON                      │ simctl / devicectl
+             ▼                                ▼
+┌────────────────────────┐         ┌──────────────────────────┐
+│  DebugSwift.AI Bridge  │         │  Platform tools           │
+│  (in-app, DEBUG only)  │         │  screenshot, file pull,   │
+│                        │         │  launch env vars          │
+│  GET  /status          │         └──────────────────────────┘
+│  POST /features/{id}   │
+│  GET  /logs/{stream}   │
+│  GET  /screenshot       │
+│  POST /actions/{id}    │
+└────────────┬───────────┘
+             │
+             ▼
+┌────────────────────────────────────────────────────────────┐
+│  Existing DebugSwift internals                              │
+│  NetworkHelper, StdoutCapture, LeakDetector, UserInterface… │
+└────────────────────────────────────────────────────────────┘
+             │
+             ▼
+┌────────────────────────────────────────────────────────────┐
+│  Export layer (always-on when AI enabled)                  │
+│  Library/Caches/debugswift-ai/*.jsonl                      │
+│  Library/Caches/debugswift-ai/screenshots/*.png            │
+└────────────────────────────────────────────────────────────┘
+```
+
+### New module: `DebugSwift.AI`
+
+Planned public surface:
+
+```swift
+public enum DebugSwiftAI {
+    /// Start bridge if DEBUGSWIFT_AI=1 or launch arg -DebugSwiftAI
+    public static func bootstrap()
+
+    /// Enable/disable any feature by string id (maps to existing APIs)
+    public static func setFeature(_ id: String, enabled: Bool) throws
+
+    /// Snapshot current state as JSON (for GET /status)
+    public static func status() -> AIStatus
+
+    /// Append-only export paths
+    public static var exportDirectory: URL
+
+    /// Capture key window → PNG in export dir
+    public static func captureScreenshot(label: String?) -> URL
+}
+```
+
+### Activation
+
+| Method | Simulator | Device |
+|---|---|---|
+| Environment variable `DEBUGSWIFT_AI=1` | `SIMCTL_CHILD_DEBUGSWIFT_AI=1` | `DEVICECTL_CHILD_DEBUGSWIFT_AI=1` or Xcode Scheme |
+| Launch argument `-DebugSwiftAI` | `simctl launch ... -- -DebugSwiftAI` | Scheme Arguments |
+| Programmatic (always in DEBUG) | `DebugSwiftAI.bootstrap()` in Example app | Same |
+
+### Dual output strategy
+
+Every data feature writes to **both**:
+
+1. **In-app HTTP API** — live queries, toggles, actions
+2. **NDJSON files** — tail-friendly, pull via `simctl get_app_container`, gitignore-friendly
+
+---
+
+## Terminal Workflows (Today vs Target)
+
+### Today (without bridge — limited)
+
+```bash
+# 1. Build & run Example on simulator (XcodeBuild MCP or xcodebuild)
+# 2. Screenshot only — no feature control
+xcrun simctl io booted screenshot /tmp/screen.png
+
+# 3. Console log file (if console swizzle enabled) — existing StdoutCapture
+CONTAINER=$(xcrun simctl get_app_container booted com.example.app data)
+cat "$CONTAINER/Library/Caches/com.example.app-output.log" 2>/dev/null || true
+```
+
+Setup is only controllable at compile/launch time via Swift code in `AppDelegate`/`ExampleApp.swift`:
+
+```swift
+debugSwift.setup(disable: [.network])  // must change code & rebuild
+```
+
+### Target (with `DebugSwift.AI` bridge)
+
+```bash
+# Enable AI bridge at launch
+export SIMCTL_CHILD_DEBUGSWIFT_AI=1
+export SIMCTL_CHILD_DEBUGSWIFT_AI_PORT=9999
+xcrun simctl launch booted com.example.app
+
+# Enable network logging
+curl -s -X POST localhost:9999/features/network \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled": true}'
+
+# Tail network logs (NDJSON)
+curl -s localhost:9999/logs/network?tail=50
+
+# Or from container file
+CONTAINER=$(xcrun simctl get_app_container booted com.example.app data)
+tail -f "$CONTAINER/Library/Caches/debugswift-ai/network.jsonl"
+
+# Enable grid overlay + screenshot
+curl -s -X POST localhost:9999/features/interface.grid -d '{"enabled": true}'
+xcrun simctl io booted screenshot /tmp/grid-overlay.png
+
+# In-app screenshot (includes DebugSwift UI if presented)
+curl -s localhost:9999/screenshot -o /tmp/in-app.png
+```
+
+---
+
+## Feature Inventory
+
+Legend:
+
+| Column | Meaning |
+|---|---|
+| **AI type** | `data` = JSON/logs only · `visual` = needs screenshot · `action` = trigger side-effect · `hybrid` = both |
+| **Approach** | `logs` = export existing data · `api` = expose existing public API · `redesign` = needs new headless/export path |
+| **Priority** | P0 = ship first · P1 · P2 |
+
+### Network tab
+
+| Feature | AI type | Approach | Enable/disable (target) | Log output (target) | Priority |
+|---|---|---|---|---|---|
+| HTTP Inspector | data | logs | `POST /features/network` | `network.jsonl` — method, url, status, headers, body refs | P0 |
+| WebSocket Inspector | data | logs | `POST /features/webSocket` | `websocket.jsonl` — connection id, frame type, payload | P0 |
+| WKWebView Inspector | data | api | `POST /features/wkWebView` | merged into `network.jsonl` with `source: webview` | P1 |
+| Request threshold / rate limit | data | logs | `POST /features/network.threshold` | `network-threshold.jsonl` | P1 |
+| Network injection (delay/fail/rewrite) | action | api | `POST /actions/network/inject` | `network-injection.jsonl` (rule applied events) | P1 |
+| Encryption/decryption | data | api | `POST /features/network.decryption` | decrypted body in `network.jsonl` when enabled | P2 |
+| Session History (beta) | data | logs | `POST /features/network.sessionHistory` | SwiftData export → `sessions.json` snapshot | P2 |
+| Clear history | action | api | `POST /actions/network/clear` | — | P1 |
+
+**Existing APIs:** `DebugSwift.Network.shared`, `disable: [.network]`, `clearAllNetworkData()`
+
+**Redesign needed:** HTTP model → stable JSON schema with body size limits (truncate >64KB, offer `GET /logs/network/:id/body`).
+
+---
+
+### Performance tab
+
+| Feature | AI type | Approach | Enable/disable (target) | Log output (target) | Priority |
+|---|---|---|---|---|---|
+| CPU / Memory / FPS charts | data | logs | always on when tab enabled | `performance.jsonl` — timestamped metrics (1 Hz) | P0 |
+| Floating Performance HUD | visual | api + screenshot | `POST /features/performance.hud` | screenshot confirms overlay | P1 |
+| Memory leak detector | data | logs | `POST /features/leaksDetector` | `leaks.jsonl` — class, retain cycle hint | P0 |
+| Thread checker | data | logs | `POST /features/threadChecker` | `thread-violations.jsonl` | P1 |
+| Memory warning simulator | action | api | `POST /actions/performance/memoryWarning` | event in `performance.jsonl` | P2 |
+| Disk I/O monitoring | data | logs | `POST /features/diskIO` | `disk-io.jsonl` | P1 |
+| Battery monitoring | data | logs | `POST /features/battery` | `battery.jsonl` | P2 |
+| Launch time | data | logs | auto on setup | included in `GET /status` | P1 |
+
+**Existing APIs:** `DebugSwift.Performance.ThreadChecker.enable()`, `isBatteryMonitoringEnabled`, `disable: [.leaksDetector]`
+
+**Redesign needed:** `PerformanceToolkit` metrics stream — today UI-bound; add timer-based sampler writing to export dir.
+
+---
+
+### Interface tab
+
+| Feature | AI type | Approach | Enable/disable (target) | Log output (target) | Priority |
+|---|---|---|---|---|---|
+| Colorized view borders | visual | api + screenshot | `POST /features/interface.colorize` | screenshot | P1 |
+| Slow animations | visual | api + screenshot | `POST /features/interface.slowAnimations` | screenshot (animation state in status) | P2 |
+| Touch indicators | visual | api + screenshot | `POST /features/interface.touchIndicators` | screenshot | P1 |
+| Grid overlay | visual | api + screenshot | `POST /features/interface.grid` | screenshot + grid config in status JSON | P1 |
+| Dark mode override | visual | api + screenshot | `POST /features/interface.darkMode` | screenshot | P2 |
+| UI measurements (HyperionSwift) | hybrid | api + screenshot | `POST /features/measurement` | `measurement.jsonl` when active | P1 |
+| SwiftUI render tracking (beta) | visual | logs + screenshot | `POST /features/swiftUIRender` | `swiftui-render.jsonl` | P1 |
+| Documentation Recorder | hybrid | redesign | `POST /actions/docRecorder/start\|stop` | `doc-recorder/` dir with annotated PNGs | P2 |
+| View Debugger (3D) | visual | redesign | `POST /actions/viewDebugger/open` | screenshot + `view-hierarchy.json` export | P2 |
+
+**Existing APIs:** `DebugSwift.Measurement.activate/deactivate`, `DebugSwift.SwiftUIRender.shared`, `disable: [.views]`
+
+**Redesign needed:**
+- View Debugger → export flat hierarchy JSON (already partially in `ViewElement` model)
+- Doc Recorder → headless capture mode without panel UI
+
+---
+
+### Resources tab
+
+| Feature | AI type | Approach | Enable/disable (target) | Log output (target) | Priority |
+|---|---|---|---|---|---|
+| Files (sandbox) | data | api | always available | `GET /resources/files?path=/` | P1 |
+| UserDefaults | data | api | always available | `GET /resources/userdefaults` | P1 |
+| Keychain | data | api | always available | `GET /resources/keychain` (keys only, no secrets in logs) | P2 |
+| HTTP Cookies | data | api | always available | `GET /resources/cookies` | P2 |
+| Core Data | data | api | requires host config | `GET /resources/coredata/:entity` | P2 |
+| SwiftData (iOS 17+) | data | api | requires host config | `GET /resources/swiftdata/:model` | P2 |
+| Database Browser (SQLite/Realm) | data | api | always available | `GET /resources/database/:path` | P2 |
+
+**Existing APIs:** `DebugSwift.Resources.shared.configureCoreData()`, `configureAppGroups()`, `configureSwiftData()`
+
+**Redesign needed:** Read-only JSON serializers for each store (no UI table view dependency).
+
+---
+
+### App tab
+
+| Feature | AI type | Approach | Enable/disable (target) | Log output (target) | Priority |
+|---|---|---|---|---|---|
+| Device Info | data | logs | always on | included in `GET /status` | P0 |
+| Console (print/NSLog) | data | logs | `POST /features/console` | `console.jsonl` + existing cache file | P0 |
+| OSLog Console | data | logs | `POST /features/oslog` | `oslog.jsonl` | P1 |
+| Crash Reports | data | logs | `POST /features/crashManager` | `crashes.jsonl` + screenshot path refs | P0 |
+| Simulated Location | action | api | `POST /actions/location` | `location.jsonl` | P1 |
+| Loaded Libraries | data | api | on demand | `GET /resources/libraries` | P2 |
+| Push Notifications | action | api | `POST /features/pushNotifications` | `push.jsonl` | P1 |
+| Deep Links | action | api | `POST /actions/deeplink` | `deeplink.jsonl` | P1 |
+| Custom Info / Actions | hybrid | api | host-defined | `GET /custom/info`, `POST /custom/actions/:id` | P1 |
+| APNS Token | data | logs | auto | in `GET /status` | P1 |
+
+**Existing APIs:** `DebugSwift.PushNotification.simulate()`, `DebugSwift.Console.shared`, `disable: [.console, .crashManager]`
+
+**Existing file log:** `Library/Caches/{bundleId}-output.log` (stdout capture — usable today on simulator)
+
+---
+
+### Shell / UI chrome
+
+| Feature | AI type | Approach | Enable/disable (target) | Log output (target) | Priority |
+|---|---|---|---|---|---|
+| Floating ball | visual | api | `POST /features/floatBall` | screenshot | P1 |
+| Present debugger UI | visual | api | `POST /actions/debugger/present` | screenshot of full debugger | P1 |
+| Hide debugger UI | action | api | `POST /actions/debugger/dismiss` | — | P1 |
+| Tab visibility | api | api | `POST /features/tabs/:tab` | status JSON | P1 |
+
+**Existing APIs:** `show()`, `hide()`, `DebugSwift.App.presentDebugger()`, `debugViewController()`
+
+---
+
+## Visual Features & Screenshots
+
+### Three screenshot sources (use all)
+
+| Source | Captures | Best for |
+|---|---|---|
+| `xcrun simctl io booted screenshot` | Full simulator screen including status bar | Grid, HUD, float ball, app UI together |
+| XcodeBuild MCP `screenshot` | Same as simctl, returns path/base64 | Cursor agent integration |
+| `GET /screenshot` (in-app) | `UIWindow` render | Exact app pixels; works on device |
+| `GET /screenshot?label=viewDebugger` | Named exports to `debugswift-ai/screenshots/` | Before/after comparisons |
+
+### Visual feature workflow for AI
+
+```bash
+# 1. Enable feature
+curl -X POST localhost:9999/features/interface.grid \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled": true, "opacity": 0.3, "color": "#FF0000"}'
+
+# 2. Wait for UI settle (agent loop or MCP wait)
+sleep 0.5
+
+# 3. Capture
+xcrun simctl io booted screenshot /tmp/grid-on.png
+# AND/OR
+curl -s 'localhost:9999/screenshot?label=grid-on' -o /tmp/grid-in-app.png
+
+# 4. Disable
+curl -X POST localhost:9999/features/interface.grid -d '{"enabled": false}'
+xcrun simctl io booted screenshot /tmp/grid-off.png
+```
+
+### Visual features requiring redesign
+
+| Feature | Why | Redesign |
+|---|---|---|
+| View Debugger 3D | SceneKit view not readable as text | Export `view-hierarchy.json` + 2D snapshot |
+| Doc Recorder | Multi-step annotated sequence | Headless recorder → PNG sequence in export dir |
+| SwiftUI render highlights | Transient overlays | Extend `SwiftUIRenderTracker` to log render rects + optional screenshot on each render burst |
+| Performance HUD | Small overlay | Include HUD metrics in `performance.jsonl` so screenshot is optional |
+
+---
+
+## Log Formats & Export Paths
+
+### Directory layout
+
+```
+Library/Caches/debugswift-ai/
+├── status.json              # latest snapshot (overwritten)
+├── network.jsonl
+├── websocket.jsonl
+├── console.jsonl
+├── oslog.jsonl
+├── performance.jsonl
+├── leaks.jsonl
+├── thread-violations.jsonl
+├── crashes.jsonl
+├── push.jsonl
+├── deeplink.jsonl
+└── screenshots/
+    ├── grid-on-20250616120000.png
+    └── view-debugger-20250616120100.png
+```
+
+### NDJSON line schema (common envelope)
+
+```json
+{
+  "ts": "2025-06-16T12:00:00.000Z",
+  "feature": "network",
+  "event": "request.completed",
+  "data": {
+    "id": "req-abc123",
+    "method": "GET",
+    "url": "https://api.example.com/users",
+    "status": 200,
+    "durationMs": 142
+  }
+}
+```
+
+### HTTP API (target)
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/status` | All feature states + device info |
+| `GET` | `/features` | List all controllable features |
+| `POST` | `/features/:id` | `{"enabled": true, ...options}` |
+| `GET` | `/logs/:stream` | Query params: `tail`, `since`, `filter` |
+| `GET` | `/logs/:stream/:id` | Single record (e.g. full HTTP body) |
+| `GET` | `/screenshot` | PNG bytes; query: `label` |
+| `POST` | `/actions/:id` | Trigger actions (push, deeplink, memory warning) |
+| `GET` | `/resources/*` | Resources tab data |
+
+---
+
+## Implementation Phases
+
+> **Detailed step-by-step plans:** [docs/plans/README.md](./plans/README.md) — 22 plans with file touch lists, schemas, and verification commands.
+
+### Phase 0 — Document & prototype (this doc)
+
+- [x] Feature inventory
+- [x] Platform matrix
+- [x] Implementation plans (`docs/plans/`)
+- [ ] Example app: read `DEBUGSWIFT_AI` env in Scheme → [Plan 13](./plans/13-example-integration.md)
+
+### Phase 1 — P0 data features (MVP)
+
+- [ ] [01 Foundation](./plans/01-foundation-module.md) + [02 Bootstrap](./plans/02-activation-bootstrap.md)
+- [ ] [03 NDJSON layer](./plans/03-ndjson-export-layer.md) + [04 HTTP server](./plans/04-http-server-core.md)
+- [ ] [05 Feature registry](./plans/05-feature-registry.md)
+- [ ] Exporters: [06 Network](./plans/06-network-export.md), [07 Console](./plans/07-console-export.md), [08 Performance](./plans/08-performance-export.md), [09 Leaks/Crashes](./plans/09-leaks-crashes-export.md)
+- [ ] [10 Status](./plans/10-status-endpoint.md) + [11 Logs/Features API](./plans/11-logs-features-api.md)
+- [ ] [12 Shell scripts](./plans/12-shell-scripts.md) + [13 Example integration](./plans/13-example-integration.md)
+- [ ] [22 Security baseline](./plans/22-security-hardening.md)
+
+### Phase 2 — Visual + actions
+
+- [ ] [14 Interface toggles](./plans/14-interface-visual-features.md)
+- [ ] [15 Screenshot endpoint](./plans/15-screenshot-endpoint.md)
+- [ ] [16 Actions API](./plans/16-actions-api.md)
+
+### Phase 3 — Resources + advanced
+
+- [ ] [17 Resources endpoints](./plans/17-resources-endpoints.md)
+- [ ] [18 View hierarchy export](./plans/18-view-hierarchy-export.md)
+- [ ] [19 Network injection API](./plans/19-network-injection-api.md)
+- [ ] [20 Device parity](./plans/20-device-parity.md)
+
+### Phase 4 — MCP server
+
+- [ ] [21 MCP package](./plans/21-mcp-package.md)
+
+---
+
+## CLI Reference (Target)
+
+Future `debugswift` CLI (thin wrapper over simctl + curl):
+
+```bash
+# Install (future)
+brew install debugswift/tap/debugswift-cli
+
+# Launch with AI enabled
+debugswift launch --simulator "iPhone 16" --bundle com.example.app --ai
+
+# Feature control
+debugswift feature network --enable
+debugswift feature interface.grid --enable --opacity 0.5
+
+# Logs
+debugswift logs network --tail 20 --follow
+debugswift logs console --since 5m
+
+# Screenshot
+debugswift screenshot --output /tmp/screen.png
+debugswift screenshot --in-app --label debugger-open
+
+# Device
+debugswift launch --device "Matheus iPhone" --ai --port 9999
+```
+
+Until CLI exists, use `curl` + `simctl`/`devicectl` directly (see [Terminal Workflows](#terminal-workflows-today-vs-target)).
+
+---
+
+## MCP Integration
+
+Planned MCP tools (Phase 4):
+
+| Tool | Maps to |
+|---|---|
+| `debugswift_status` | `GET /status` |
+| `debugswift_set_feature` | `POST /features/:id` |
+| `debugswift_get_logs` | `GET /logs/:stream` |
+| `debugswift_screenshot` | simctl + `GET /screenshot` |
+| `debugswift_action` | `POST /actions/:id` |
+
+Cursor config (future):
+
+```json
+{
+  "mcpServers": {
+    "debugswift": {
+      "command": "npx",
+      "args": ["-y", "@debugswift/mcp"],
+      "env": {
+        "DEBUGSWIFT_AI_PORT": "9999",
+        "DEBUGSWIFT_BUNDLE_ID": "com.example.app"
+      }
+    }
+  }
+}
+```
+
+Works alongside **XcodeBuild MCP** (`screenshot`, `snapshot_ui`, `build_run_sim`) — DebugSwift MCP adds *in-app debug data*, XcodeBuild MCP adds *build/run/sim control*.
+
+---
+
+## Security & Constraints
+
+| Rule | Rationale |
+|---|---|
+| Bridge compiles only in `#if DEBUG` | Never ship open HTTP in Release |
+| Bind `127.0.0.1` by default | Simulator/Mac localhost only |
+| Optional token: `DEBUGSWIFT_AI_TOKEN` | Prevent accidental exposure if port forwarded |
+| Truncate large bodies in JSONL | Avoid multi-MB log lines |
+| Keychain export: keys/metadata only | No secret values in logs |
+| AI bridge off by default | Opt-in via env var |
+
+---
+
+## Related Files
+
+| Path | Purpose |
+|---|---|
+| `DebugSwift/Sources/Settings/DebugSwift.swift` | Entry point |
+| `DebugSwift/Sources/Settings/FeatureHandling.swift` | Feature orchestration |
+| `DebugSwift/Sources/Features/App/Console/Helpers/StdoutCapture.swift` | Existing file log |
+| `DebugSwift/Sources/Features/Interface/DocRecorder/ScreenshotCapturer.swift` | Reuse for AI screenshots |
+| `Example/Example/ExampleApp.swift` | Integration example (target) |
+
+---
+
+## Quick Answers
+
+**Can AI control DebugSwift from the simulator terminal today?**  
+Partially — screenshots yes (`simctl io screenshot`), stdout log file yes, feature toggles no (needs Phase 1 bridge).
+
+**Can AI control it when running on a physical device from Xcode?**  
+Yes, with caveats — use Scheme environment variables to enable the bridge, HTTP API for control/logs, in-app screenshot export. iOS 17+ also supports `devicectl` with `DEVICECTL_CHILD_*` env vars.
+
+**Which features only need logs vs redesign?**  
+- **Logs only:** network, console, oslog, performance metrics, leaks, crashes, push/deeplink history  
+- **API expose only:** most toggles (grid, colorize, HUD, measurement)  
+- **Redesign:** view debugger 3D export, doc recorder headless mode, network body pagination
+
+**Best path for Cursor agents?**  
+Simulator + `DebugSwift.AI` HTTP bridge + XcodeBuild MCP for build/run/screenshot + this doc's NDJSON tail for structured data.

--- a/docs/plans/01-foundation-module.md
+++ b/docs/plans/01-foundation-module.md
@@ -1,0 +1,115 @@
+# Plan 01 — Foundation Module (`DebugSwift.AI`)
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** —
+
+## Goal
+
+Create the `DebugSwift.AI` public module: types, export directory resolution, and the static API surface that every later step plugs into. No HTTP server yet — just the shell.
+
+## Why this first
+
+All export writers, HTTP handlers, and bootstrap logic need a single home. Today there is zero `AI` code in the repo (`grep DEBUGSWIFT` returns nothing).
+
+## Public API (target)
+
+```swift
+#if DEBUG
+public enum DebugSwiftAI {
+    public static func bootstrap()
+    public static func setFeature(_ id: String, enabled: Bool, options: [String: Any]?) throws
+    public static func status() -> AIStatus
+    public static var exportDirectory: URL { get }
+    public static func captureScreenshot(label: String?) -> URL?
+}
+#endif
+```
+
+Supporting types:
+
+```swift
+public struct AIStatus: Codable {
+    public let bridgeEnabled: Bool
+    public let port: Int
+    public let features: [String: FeatureState]
+    public let device: DeviceInfo
+    public let launchTimeMs: Double?
+}
+
+public struct FeatureState: Codable {
+    public let enabled: Bool
+    public let options: [String: String]?
+}
+```
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/DebugSwift.AI.swift` | Public enum, re-exports |
+| `DebugSwift/Sources/AI/Models/AIStatus.swift` | Codable status models |
+| `DebugSwift/Sources/AI/Models/AIFeatureID.swift` | Known feature string constants |
+| `DebugSwift/Sources/AI/Internal/AIConfiguration.swift` | Port, token, enabled flag (reads env) |
+| `DebugSwift/Sources/AI/Internal/AIExportDirectory.swift` | `Library/Caches/debugswift-ai/` |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `DebugSwift/Package.swift` or Xcode target | Add `AI` source group to DebugSwift target |
+| `.gitignore` | Ignore `debugswift-ai/` in Example if needed (usually inside simulator container) |
+
+## Implementation tasks
+
+- [ ] Create `AIExportDirectory` resolving:
+  ```swift
+  FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+      .appendingPathComponent("debugswift-ai", isDirectory: true)
+  ```
+- [ ] On first access, `createDirectory(at:withIntermediateDirectories:)` for `debugswift-ai/` and `screenshots/`
+- [ ] Wrap entire module in `#if DEBUG` — Release builds must not link AI symbols
+- [ ] `AIConfiguration` reads (non-fatal defaults):
+  - `DEBUGSWIFT_AI` → `ProcessInfo.processInfo.environment`
+  - `DEBUGSWIFT_AI_PORT` → default `9999`
+  - `DEBUGSWIFT_AI_TOKEN` → optional Bearer token
+- [ ] `bootstrap()` stub: log + create export dirs (full wiring in Plan 02)
+- [ ] `status()` stub: return `bridgeEnabled: false`, empty features, device info from `UIDevice` + `Bundle.main`
+- [ ] `setFeature` stub: `throw AIError.notBootstrapped` until Plan 05
+- [ ] `captureScreenshot` stub: return `nil` until Plan 15
+
+## Device info helper
+
+Reuse patterns from existing App tab view models:
+
+```swift
+DeviceInfo(
+    name: UIDevice.current.name,
+    model: UIDevice.current.model,
+    systemVersion: UIDevice.current.systemVersion,
+    bundleId: Bundle.main.bundleIdentifier ?? "",
+    appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+)
+```
+
+## Acceptance criteria
+
+- [ ] `import DebugSwift` + `DebugSwiftAI.exportDirectory` compiles in DEBUG Example
+- [ ] Release configuration does not expose `DebugSwiftAI`
+- [ ] Export directory path matches doc: `Library/Caches/debugswift-ai/`
+
+## Verification
+
+```bash
+# After Example integration (Plan 13), in lldb or print:
+po DebugSwiftAI.exportDirectory
+```
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| SPM vs Xcode target file drift | Update both if dual-build (Bazel/SPM/Xcode) |
+| `@MainActor` on public API | Keep `bootstrap()` callable from `AppDelegate`; use `MainActor.assumeIsolated` internally where needed |
+
+## Next
+
+→ [02 — Activation Bootstrap](./02-activation-bootstrap.md)

--- a/docs/plans/02-activation-bootstrap.md
+++ b/docs/plans/02-activation-bootstrap.md
@@ -1,0 +1,82 @@
+# Plan 02 — Activation Bootstrap
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [01](./01-foundation-module.md)
+
+## Goal
+
+Start the AI bridge automatically when the host app opts in via environment variable, launch argument, or explicit `DebugSwiftAI.bootstrap()` call.
+
+## Activation matrix
+
+| Method | Detection | Simulator | Device |
+|--------|-----------|-----------|--------|
+| Env `DEBUGSWIFT_AI=1` | `ProcessInfo.processInfo.environment["DEBUGSWIFT_AI"] == "1"` | `SIMCTL_CHILD_DEBUGSWIFT_AI=1` | `DEVICECTL_CHILD_*` or Scheme |
+| Launch arg `-DebugSwiftAI` | `ProcessInfo.processInfo.arguments.contains("-DebugSwiftAI")` | `simctl launch ... -- -DebugSwiftAI` | Scheme Arguments |
+| Programmatic | `DebugSwiftAI.bootstrap()` in `AppDelegate` | Always available in DEBUG | Same |
+
+**Default:** bridge OFF. No behavior change for existing integrators.
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Internal/AIActivation.swift` | Parses env/args, idempotent flag |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `DebugSwift/Sources/AI/DebugSwift.AI.swift` | Wire `bootstrap()` |
+| `DebugSwift/Sources/Settings/DebugSwift.swift` | Optional: call `DebugSwiftAI.bootstrap()` at end of `setup()` behind `#if DEBUG` — **or** require explicit call in host app (prefer explicit in Example) |
+| `Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme` | Add env vars for local dev |
+| `Example/Example/ExampleApp.swift` | `DebugSwiftAI.bootstrap()` after `setup()` |
+
+## Implementation tasks
+
+- [ ] `AIActivation.shouldStart` — true if env OR launch arg OR forced programmatic
+- [ ] `bootstrap()` is idempotent — second call no-ops with debug log
+- [ ] On start:
+  1. Create export directories (Plan 01)
+  2. Start HTTP server (Plan 04) on configured port
+  3. Register NDJSON writers (Plan 03 hooks, no-op until feature exporters attach)
+  4. Write initial `status.json`
+- [ ] On `setup(disable:)` — bridge still starts but respects disabled swizzles; feature registry reflects `DebugSwift.App.shared.disableMethods`
+- [ ] Document Scheme env vars in Example README (Plan 13)
+
+## Example Scheme snippet
+
+```xml
+<EnvironmentVariables>
+   <EnvironmentVariable key="DEBUGSWIFT_AI" value="1" isEnabled="YES"/>
+   <EnvironmentVariable key="DEBUGSWIFT_AI_PORT" value="9999" isEnabled="YES"/>
+</EnvironmentVariables>
+```
+
+## Example AppDelegate
+
+```swift
+debugSwift.setup(enableBetaFeatures: [...])
+#if DEBUG
+DebugSwiftAI.bootstrap()
+#endif
+debugSwift.show()
+```
+
+## Acceptance criteria
+
+- [ ] Launch Example with Scheme env → `curl localhost:9999/status` responds (after Plan 04)
+- [ ] Launch without env → no server listening, zero perf impact
+- [ ] `simctl launch` with `SIMCTL_CHILD_DEBUGSWIFT_AI=1` works
+
+## Verification
+
+```bash
+export SIMCTL_CHILD_DEBUGSWIFT_AI=1
+export SIMCTL_CHILD_DEBUGSWIFT_AI_PORT=9999
+xcrun simctl launch booted com.example.app  # replace bundle id
+curl -s localhost:9999/status | jq .
+```
+
+## Next
+
+→ [03 — NDJSON Export Layer](./03-ndjson-export-layer.md) · [04 — HTTP Server](./04-http-server-core.md)

--- a/docs/plans/03-ndjson-export-layer.md
+++ b/docs/plans/03-ndjson-export-layer.md
@@ -1,0 +1,89 @@
+# Plan 03 — NDJSON Export Layer
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [01](./01-foundation-module.md)
+
+## Goal
+
+Shared append-only JSONL writer with a common envelope schema. Every data feature (network, console, performance, …) calls one API instead of rolling its own file I/O.
+
+## Envelope schema (from AI_AUTOMATION.md)
+
+```json
+{
+  "ts": "2025-06-16T12:00:00.000Z",
+  "feature": "network",
+  "event": "request.completed",
+  "data": { }
+}
+```
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Export/NDJSONWriter.swift` | Thread-safe append per stream |
+| `DebugSwift/Sources/AI/Export/AIEvent.swift` | `struct AIEvent: Codable` |
+| `DebugSwift/Sources/AI/Export/AIEventEncoder.swift` | ISO8601 dates, compact JSON line |
+| `DebugSwift/Sources/AI/Export/AIStreamRegistry.swift` | Named streams → file URLs |
+
+## Stream registry
+
+| Stream ID | File |
+|-----------|------|
+| `network` | `network.jsonl` |
+| `websocket` | `websocket.jsonl` |
+| `console` | `console.jsonl` |
+| `oslog` | `oslog.jsonl` |
+| `performance` | `performance.jsonl` |
+| `leaks` | `leaks.jsonl` |
+| `crashes` | `crashes.jsonl` |
+| `push` | `push.jsonl` |
+| `deeplink` | `deeplink.jsonl` |
+
+## Implementation tasks
+
+- [ ] `NDJSONWriter` uses dedicated serial `DispatchQueue` per stream (avoid cross-stream blocking)
+- [ ] `append(event: AIEvent, stream: String)` — encode one line + `\n`, append atomically via `FileHandle`
+- [ ] Rotate/truncate policy: **none for MVP** — document max file size in Plan 22
+- [ ] `bodyTruncationLimit` constant `65536` — used by network exporter (Plan 06)
+- [ ] In-memory ring buffer (optional, 500 lines) per stream for `GET /logs?tail=N` without full file read
+- [ ] `AIStreamRegistry.shared.writer(for: "network")` singleton accessors
+- [ ] Unit-testable: inject temp directory URL in `#if DEBUG` tests
+
+## API sketch
+
+```swift
+enum AIExport {
+    static func emit(feature: String, event: String, data: [String: Any]) {
+        let payload = AIEvent(ts: .now, feature: feature, event: event, data: data)
+        NDJSONWriter.shared.append(payload, stream: feature)
+    }
+}
+```
+
+Use `JSONSerialization` or `Codable` with `AnyCodable` helper for `data` dict — prefer small `Codable` structs per event type where possible.
+
+## Dual output contract
+
+Every `emit()` must:
+
+1. Append to `.jsonl` file
+2. Push to in-memory ring (for HTTP tail)
+3. **Not** block main thread — network/console hooks may fire on background queues
+
+## Acceptance criteria
+
+- [ ] Two rapid `emit` calls produce two valid JSON lines parseable by `jq -c .`
+- [ ] Concurrent emits from network thread don't corrupt lines
+- [ ] File appears at `exportDirectory/network.jsonl` when stream is `network`
+
+## Verification
+
+```bash
+CONTAINER=$(xcrun simctl get_app_container booted <bundle> data)
+tail -3 "$CONTAINER/Library/Caches/debugswift-ai/network.jsonl" | jq .
+```
+
+## Next
+
+→ Feature-specific exporters: [06](./06-network-export.md) … [09](./09-leaks-crashes-export.md)

--- a/docs/plans/04-http-server-core.md
+++ b/docs/plans/04-http-server-core.md
@@ -1,0 +1,82 @@
+# Plan 04 — HTTP Server Core
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [01](./01-foundation-module.md), [02](./02-activation-bootstrap.md)
+
+## Goal
+
+Minimal embedded HTTP server in DEBUG builds: bind localhost, route requests, JSON responses, optional token auth. No business logic — delegates to handlers added in later plans.
+
+## Technology choice
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Network.framework `NWListener`** | No deps, Apple-native | Manual HTTP parsing |
+| **SwiftNIO** | Full HTTP | Heavy dependency |
+| **GCD + socket** | Tiny | Reinventing wheel |
+
+**Recommendation:** `NWListener` + lightweight HTTP request parser (or reuse if project already has one — grep shows none). Keep dependency-free.
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/HTTP/AIServer.swift` | Start/stop listener |
+| `DebugSwift/Sources/AI/HTTP/AIHTTPRequest.swift` | Parse method, path, query, body |
+| `DebugSwift/Sources/AI/HTTP/AIHTTPResponse.swift` | Status, headers, JSON body |
+| `DebugSwift/Sources/AI/HTTP/AIRouter.swift` | Route table |
+| `DebugSwift/Sources/AI/HTTP/AIAuthMiddleware.swift` | `DEBUGSWIFT_AI_TOKEN` Bearer check |
+
+## Bind address
+
+| Environment | Bind |
+|-------------|------|
+| Simulator default | `127.0.0.1:<port>` — Mac reaches via port forward |
+| Device on LAN | Config `DEBUGSWIFT_AI_BIND=0.0.0.0` (opt-in, Plan 20) |
+
+## Route table (stubs → filled in Plan 11+)
+
+| Method | Path | Handler |
+|--------|------|---------|
+| GET | `/status` | Plan 10 |
+| GET | `/features` | Plan 05 |
+| POST | `/features/:id` | Plan 05 |
+| GET | `/logs/:stream` | Plan 11 |
+| GET | `/logs/:stream/:id` | Plan 06 |
+| GET | `/screenshot` | Plan 15 |
+| POST | `/actions/:id` | Plan 16 |
+| GET | `/resources/*` | Plan 17 |
+
+## Implementation tasks
+
+- [ ] `AIServer.start(port:)` called from `bootstrap()`
+- [ ] `AIServer.stop()` on app terminate (optional `NSNotification` observer)
+- [ ] Parse query: `tail`, `since`, `filter` for logs endpoint
+- [ ] CORS: not needed (local agents only)
+- [ ] Max body size 1 MB for POST
+- [ ] Return `401` if token configured and `Authorization: Bearer <token>` missing/wrong
+- [ ] Return `404` unknown routes, `405` wrong method
+- [ ] JSON error envelope: `{"error": "...", "code": "feature_not_found"}`
+- [ ] Log server start to os_log category `DebugSwift.AI` (not NDJSON — meta)
+
+## Threading
+
+- Accept connections on listener queue
+- Feature toggles that touch UI → `DispatchQueue.main.async`
+- Log reads from ring buffer — lock-free or serial queue
+
+## Acceptance criteria
+
+- [ ] `curl localhost:9999/status` returns `200` JSON (even if empty)
+- [ ] Wrong token → `401`
+- [ ] Release build: no listener code compiled
+
+## Verification
+
+```bash
+curl -v localhost:9999/status
+curl -v -H "Authorization: Bearer wrong" localhost:9999/status  # when token set
+```
+
+## Next
+
+→ [05 — Feature Registry](./05-feature-registry.md) · [10 — Status](./10-status-endpoint.md) · [11 — Logs API](./11-logs-features-api.md)

--- a/docs/plans/05-feature-registry.md
+++ b/docs/plans/05-feature-registry.md
@@ -1,0 +1,102 @@
+# Plan 05 — Feature Registry
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [01](./01-foundation-module.md), [04](./04-http-server-core.md)
+
+## Goal
+
+Map string feature IDs (`network`, `interface.grid`, `leaksDetector`) to existing DebugSwift enable/disable APIs. Single source of truth for `POST /features/:id` and `GET /status`.
+
+## ID namespace
+
+```
+{swizzleFeature}           → DebugSwiftSwizzleFeature
+{tab}.{subfeature}         → UI toggles / toolkit flags
+actions/{name}             → side effects (Plan 16)
+```
+
+### P0 registry (Phase 1)
+
+| ID | Maps to | Enable | Disable |
+|----|---------|--------|---------|
+| `network` | `DebugSwiftSwizzleFeature.network` | `FeatureHandling` → `enableNetwork()` | `NetworkHelper.shared.disable()` |
+| `console` | `.console` | `enableConsole()` | stop StdoutCapture |
+| `leaksDetector` | `.leaksDetector` | `enableLeaksDetector()` | disable leak detector |
+| `crashManager` | `.crashManager` | `enableCrashManager()` | inverse |
+| `webSocket` | `.webSocket` | `WebSocketMonitor` | `.disable()` |
+| `performance` | Performance tab sampler | start `PerformanceToolkit` timer export | stop sampler |
+
+### P1+ (Phase 2, register stubs now)
+
+| ID | API |
+|----|-----|
+| `interface.grid` | `Interface.Grid` controller / UserDefaults key |
+| `interface.touchIndicators` | `UserInterfaceToolkit` |
+| `interface.colorize` | UIView swizzle border |
+| `performance.hud` | `PerformanceToolkit.isWidgetShown` |
+| `floatBall` | `FloatViewManager.show/hide` |
+| `oslog` | OSLog capture UserDefaults `debugswift.oslog.capturingEnabled` |
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Features/AIFeatureRegistry.swift` | Registry + dispatch |
+| `DebugSwift/Sources/AI/Features/AIFeatureDescriptor.swift` | Metadata: id, type, options schema |
+| `DebugSwift/Sources/AI/Features/Handlers/AISwizzleFeatureHandler.swift` | Swizzle features |
+| `DebugSwift/Sources/AI/Features/Handlers/AIInterfaceFeatureHandler.swift` | Interface subfeatures (Phase 2) |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `DebugSwift/Sources/Settings/FeatureHandling.swift` | Expose `enableX()` / package-private toggles if currently `private` — may need `internal` wrappers |
+| `DebugSwift/Sources/AI/DebugSwift.AI.swift` | `setFeature` delegates to registry |
+
+## `setFeature` contract
+
+```json
+POST /features/network
+{"enabled": true}
+
+POST /features/interface.grid
+{"enabled": true, "opacity": 0.3, "color": "#FF0000"}
+```
+
+```swift
+public static func setFeature(
+    _ id: String,
+    enabled: Bool,
+    options: [String: Any]? = nil
+) throws
+```
+
+Throws: `unknownFeature`, `invalidOptions`, `mainActorRequired`
+
+## Implementation tasks
+
+- [ ] `AIFeatureRegistry.allDescriptors()` → `GET /features` list
+- [ ] Read current state from existing singletons:
+  - `NetworkHelper.shared.isNetworkEnable`
+  - `DebugSwift.App.shared.disableMethods`
+  - UserDefaults keys for UI features
+- [ ] All UI mutations on `@MainActor`
+- [ ] After toggle, refresh `status.json` and emit `feature.toggled` NDJSON event
+- [ ] Respect `setup(disable:)` — registry reports `enabled: false` for disabled-at-launch features; `POST enabled:true` re-enables at runtime
+
+## Acceptance criteria
+
+- [ ] `POST /features/network {"enabled":true}` causes HTTP traffic to appear in network inspector
+- [ ] `POST {"enabled":false}` stops new captures
+- [ ] Unknown ID → `404` with JSON error
+
+## Verification
+
+```bash
+curl -X POST localhost:9999/features/network -H 'Content-Type: application/json' -d '{"enabled":true}'
+# trigger network in app
+curl localhost:9999/logs/network?tail=5
+```
+
+## Next
+
+→ [06](./06-network-export.md) … [11](./11-logs-features-api.md)

--- a/docs/plans/06-network-export.md
+++ b/docs/plans/06-network-export.md
@@ -1,0 +1,84 @@
+# Plan 06 — Network Export
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [03](./03-ndjson-export-layer.md), [05](./05-feature-registry.md)
+
+## Goal
+
+Emit structured NDJSON for every HTTP/WebSocket request captured by existing swizzles. Truncate large bodies; offer full body via `GET /logs/network/:id/body`.
+
+## Hook points (existing code)
+
+| File | Hook |
+|------|------|
+| `DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift` | Request/response completion |
+| `DebugSwift/Sources/Features/Network/Helpers/NetworkHelper.swift` | Enable gate |
+| `DebugSwift/Sources/Features/Network/Models/HTTP.Model.swift` | Source model (`HttpModel`) |
+| `DebugSwift/Sources/Features/Network/Main/Network.ViewModel.swift` | May already aggregate — avoid duplicate emits |
+
+## JSON `data` schema (per event)
+
+```json
+{
+  "id": "req-abc123",
+  "method": "GET",
+  "url": "https://api.example.com/users",
+  "status": 200,
+  "durationMs": 142,
+  "requestHeaders": {},
+  "responseHeaders": {},
+  "requestBodyRef": "bodies/req-abc123-req.bin",
+  "responseBodyRef": "bodies/req-abc123-res.bin",
+  "requestBodyTruncated": false,
+  "responseBodyTruncated": true,
+  "source": "urlsession"
+}
+```
+
+Events: `request.started`, `request.completed`, `request.failed`
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Export/Exporters/AINetworkExporter.swift` | HttpModel → AIEvent |
+| `DebugSwift/Sources/AI/Export/BodyStore.swift` | Spill bodies >64KB to `bodies/` dir |
+
+## Implementation tasks
+
+- [ ] Add `AINetworkExporter.shared.record(model: HttpModel, phase:)` called from HTTPProtocol completion path
+- [ ] Guard: only emit when `NetworkHelper.shared.isNetworkEnable` AND AI bridge active
+- [ ] Map `HttpModel.id` (index-based today) → stable `req-<uuid>` stored on model or side table
+- [ ] Truncate inline body preview to 4KB in JSONL; flag `truncated: true`
+- [ ] Store full body in `debugswift-ai/bodies/<id>-req.bin` when AI enabled
+- [ ] `GET /logs/network/:id` returns full metadata + inline body or ref
+- [ ] WebSocket frames → `websocket.jsonl` with `feature: "websocket"` (same exporter, different stream)
+- [ ] WKWebView (P1): add `"source": "webview"` field — hook `WKWebViewNetworkMonitor`
+
+## Redesign notes (from doc)
+
+`HttpModel` is UI-oriented (`statusCode: String?`, `index: Int`). Exporter layer must normalize:
+
+```swift
+func normalize(_ model: HttpModel) -> NetworkAIRecord { ... }
+```
+
+Do **not** refactor `HttpModel` in Phase 1 — adapter only.
+
+## Acceptance criteria
+
+- [ ] Example app network call → line in `network.jsonl`
+- [ ] `curl localhost:9999/logs/network?tail=1` matches file
+- [ ] 100KB response → truncated in JSONL, full in body store
+
+## Verification
+
+```bash
+# In Example, tap a network demo button
+CONTAINER=$(xcrun simctl get_app_container booted com.example.app data)
+tail -1 "$CONTAINER/Library/Caches/debugswift-ai/network.jsonl" | jq .
+curl -s "localhost:9999/logs/network/$(jq -r .data.id)" | jq .
+```
+
+## Next
+
+→ [11 — Logs API](./11-logs-features-api.md)

--- a/docs/plans/07-console-export.md
+++ b/docs/plans/07-console-export.md
@@ -1,0 +1,73 @@
+# Plan 07 — Console Export
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [03](./03-ndjson-export-layer.md), [05](./05-feature-registry.md)
+
+## Goal
+
+Mirror `print` / `NSLog` capture into `console.jsonl` while preserving existing `StdoutCapture` file log (`{bundleId}-output.log`).
+
+## Hook point
+
+`DebugSwift/Sources/Features/App/Console/Helpers/StdoutCapture.swift`
+
+Function `processCompleteLogLineGlobal(_ line: String)` already:
+
+1. Appends to `StdoutCapture.shared.logUrl`
+2. Calls `appendConsoleOutputSafelyGlobal(line)`
+
+Add step 3: `AIConsoleExporter.emit(line:)` when bridge + console feature enabled.
+
+## JSON schema
+
+```json
+{
+  "ts": "...",
+  "feature": "console",
+  "event": "line",
+  "data": {
+    "text": "Hey, DebugSwift is running!",
+    "source": "stdout"
+  }
+}
+```
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Export/Exporters/AIConsoleExporter.swift` | Line → AIEvent |
+
+## Implementation tasks
+
+- [ ] Hook in `processCompleteLogLineGlobal` — keep hook minimal (one line call)
+- [ ] Strip ANSI color codes if present
+- [ ] Cap line length 16KB — truncate with `"truncated": true`
+- [ ] Feature gate: `console` swizzle enabled via registry
+- [ ] Bridge gate: `AIActivation.isRunning`
+- [ ] Existing in-app console UI unchanged — reads same `appendConsoleOutputSafelyGlobal`
+
+## Dual output (doc requirement)
+
+| Sink | Path |
+|------|------|
+| Legacy | `Library/Caches/{bundleId}-output.log` |
+| AI | `Library/Caches/debugswift-ai/console.jsonl` |
+| HTTP | `GET /logs/console?tail=50` |
+
+## Acceptance criteria
+
+- [ ] `print("test-ai-console")` in Example → new JSONL line within 1s
+- [ ] Legacy log file still receives same line
+- [ ] `POST /features/console {"enabled":false}` stops new JSONL lines
+
+## Verification
+
+```bash
+curl -s localhost:9999/logs/console?tail=5 | jq .
+CONTAINER=$(xcrun simctl get_app_container booted com.example.app data)
+tail -1 "$CONTAINER/Library/Caches/debugswift-ai/console.jsonl"
+```
+
+## Next
+
+→ [10](./10-status-endpoint.md) · [11](./11-logs-features-api.md)

--- a/docs/plans/08-performance-export.md
+++ b/docs/plans/08-performance-export.md
@@ -1,0 +1,74 @@
+# Plan 08 — Performance Export
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [03](./03-ndjson-export-layer.md), [05](./05-feature-registry.md)
+
+## Goal
+
+1 Hz metrics stream (CPU, memory, FPS) to `performance.jsonl` decoupled from UI charts.
+
+## Problem
+
+`PerformanceToolkit` (`DebugSwift/Sources/Features/Performance/Helpers/Performance.Toolkit.swift`) is UI-bound:
+
+- Timer drives widget updates
+- Measurements stored in `[CGFloat]` arrays for charts
+- No external export today
+
+## Approach
+
+Add **headless sampler** that reuses measurement logic without requiring widget visible.
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Export/Exporters/AIPerformanceSampler.swift` | 1 Hz timer, emits NDJSON |
+| `DebugSwift/Sources/AI/Export/Exporters/AIPerformanceMetrics.swift` | Read CPU/mem/FPS from existing helpers |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `Performance.Toolkit.swift` | Extract `updateMeasurements()` core into shared `PerformanceMetricsReader` OR call from sampler in parallel (avoid duplicate Timer — prefer single timer fan-out) |
+
+## JSON schema
+
+```json
+{
+  "feature": "performance",
+  "event": "sample",
+  "data": {
+    "cpuPercent": 12.4,
+    "memoryMB": 128.5,
+    "fps": 60.0,
+    "leakCount": 0
+  }
+}
+```
+
+Optional events: `memory.warning.simulated` (Plan 16 action)
+
+## Implementation tasks
+
+- [ ] Start sampler when `POST /features/performance {"enabled":true}` OR when performance tab swizzle not disabled and bridge starts
+- [ ] Reuse `FPSCounter`, existing CPU/memory helpers from toolkit's `updateMeasurements`
+- [ ] Include `LaunchTimeTracker.shared` result in first sample + `GET /status`
+- [ ] HUD visibility (`performance.hud`) does not gate sampler — doc says metrics in JSONL make screenshot optional
+- [ ] Stop timer when feature disabled or bridge stops
+- [ ] Disk I/O / battery (P1): separate streams `disk-io.jsonl`, `battery.jsonl` — stub registry entries
+
+## Acceptance criteria
+
+- [ ] ~1 line/sec in `performance.jsonl` while app foregrounded
+- [ ] Values roughly match Performance tab UI
+- [ ] No retain cycle / main thread blocking
+
+## Verification
+
+```bash
+curl -s localhost:9999/logs/performance?tail=3 | jq .
+```
+
+## Next
+
+→ [10](./10-status-endpoint.md)

--- a/docs/plans/09-leaks-crashes-export.md
+++ b/docs/plans/09-leaks-crashes-export.md
@@ -1,0 +1,84 @@
+# Plan 09 — Leaks & Crashes Export
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [03](./03-ndjson-export-layer.md), [05](./05-feature-registry.md)
+
+## Goal
+
+Export memory leak detections and crash reports as NDJSON for AI triage.
+
+## Leaks — hook points
+
+| File | Role |
+|------|------|
+| `DebugSwift/Sources/Features/Performance/Helpers/Performance.LeakDetector.swift` | Detection engine |
+| `DebugSwift/Sources/Features/Performance/Leak/LeaksViewModel.swift` | UI list — hook when new leak added |
+
+## Leaks JSON schema
+
+```json
+{
+  "feature": "leaks",
+  "event": "leak.detected",
+  "data": {
+    "id": "leak-1",
+    "className": "MyViewController",
+    "hint": "retain cycle via closure",
+    "count": 1
+  }
+}
+```
+
+## Crashes — hook points
+
+| File | Role |
+|------|------|
+| `DebugSwift/Sources/Features/App/Crash/Main/CrashViewModel.swift` | Crash log list |
+| Crash manager swizzle (`FeatureHandling.enableCrashManager`) | New crash capture |
+
+## Crashes JSON schema
+
+```json
+{
+  "feature": "crashes",
+  "event": "crash.recorded",
+  "data": {
+    "id": "crash-uuid",
+    "name": "SIGABRT",
+    "reason": "...",
+    "stackSummary": ["Frame0", "Frame1"],
+    "screenshotRef": "screenshots/crash-uuid.png"
+  }
+}
+```
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Export/Exporters/AILeaksExporter.swift` | |
+| `DebugSwift/Sources/AI/Export/Exporters/AICrashesExporter.swift` | Optional auto-screenshot on crash |
+
+## Implementation tasks
+
+- [ ] Register `leaksDetector` and `crashManager` in feature registry
+- [ ] Emit on detection — not on UI cell render
+- [ ] Crash stack: truncate to 50 frames in JSONL; full in `crashes/<id>.txt` side file
+- [ ] Optional: `DebugSwiftAI.captureScreenshot(label: "crash-\(id)")` on crash (Plan 15 dependency — stub ref until then)
+- [ ] Thread checker (P1): `thread-violations.jsonl` — separate exporter stub
+
+## Acceptance criteria
+
+- [ ] Induced leak in Example (if exists) → `leaks.jsonl` entry
+- [ ] Simulated crash (debug menu) → `crashes.jsonl` entry
+- [ ] Features respect enable/disable via POST
+
+## Verification
+
+```bash
+curl -s localhost:9999/logs/leaks?tail=10
+curl -s localhost:9999/logs/crashes?tail=5
+```
+
+## Next
+
+→ [10](./10-status-endpoint.md)

--- a/docs/plans/10-status-endpoint.md
+++ b/docs/plans/10-status-endpoint.md
@@ -1,0 +1,79 @@
+# Plan 10 — Status Endpoint
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [01](./01-foundation-module.md), [05](./05-feature-registry.md), exporters 06–09
+
+## Goal
+
+`GET /status` returns live JSON snapshot of bridge state, all feature flags, device info, launch time. Mirror to `status.json` on every meaningful change.
+
+## Response schema
+
+```json
+{
+  "bridgeEnabled": true,
+  "port": 9999,
+  "exportDirectory": "Library/Caches/debugswift-ai",
+  "device": {
+    "name": "iPhone 16",
+    "model": "iPhone",
+    "systemVersion": "18.0",
+    "bundleId": "com.example.app",
+    "appVersion": "1.0"
+  },
+  "launchTimeMs": 342.5,
+  "apnsToken": "abc...",
+  "features": {
+    "network": { "enabled": true, "options": null },
+    "console": { "enabled": true },
+    "leaksDetector": { "enabled": true },
+    "crashManager": { "enabled": true },
+    "performance": { "enabled": true }
+  },
+  "streams": {
+    "network": { "lineCount": 42, "lastTs": "2025-06-16T12:00:00Z" },
+    "console": { "lineCount": 128 }
+  }
+}
+```
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/HTTP/Handlers/AIStatusHandler.swift` | Build + encode `AIStatus` |
+| `DebugSwift/Sources/AI/Internal/AIStatusWriter.swift` | Overwrite `status.json` atomically |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `DebugSwift/Sources/AI/Models/AIStatus.swift` | Extend with `streams`, `apnsToken` |
+| `DebugSwift/Sources/Helpers/Managers/APNSTokenManager.swift` | Read token for status (no secret beyond what UI shows) |
+
+## Implementation tasks
+
+- [ ] `AIStatusBuilder.build()` aggregates registry + `LaunchTimeTracker` + `APNSTokenManager`
+- [ ] Stream stats from `NDJSONWriter` line counters / last timestamp
+- [ ] Call `AIStatusWriter.persist()` after:
+  - bootstrap
+  - any `setFeature`
+  - optional: every 30s heartbeat timer
+- [ ] `GET /status` reads fresh build (not stale file)
+- [ ] `DebugSwiftAI.status()` returns same struct for in-process use
+
+## Acceptance criteria
+
+- [ ] `curl localhost:9999/status` valid JSON matching schema
+- [ ] Toggle network → `features.network.enabled` flips on next GET
+- [ ] `status.json` on disk matches HTTP response (modulo timestamp)
+
+## Verification
+
+```bash
+curl -s localhost:9999/status | jq '.features.network'
+cat "$(xcrun simctl get_app_container booted com.example.app data)/Library/Caches/debugswift-ai/status.json" | jq .
+```
+
+## Next
+
+→ [11 — Logs & Features API](./11-logs-features-api.md)

--- a/docs/plans/11-logs-features-api.md
+++ b/docs/plans/11-logs-features-api.md
@@ -1,0 +1,97 @@
+# Plan 11 — Logs & Features HTTP API
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [04](./04-http-server-core.md), [05](./05-feature-registry.md), [03](./03-ndjson-export-layer.md), [10](./10-status-endpoint.md)
+
+## Goal
+
+Wire HTTP routes for feature control and log retrieval — the primary agent interface for Phase 1 MVP.
+
+## Endpoints
+
+### `GET /features`
+
+Returns `AIFeatureRegistry.allDescriptors()`:
+
+```json
+{
+  "features": [
+    {
+      "id": "network",
+      "type": "data",
+      "enabled": true,
+      "description": "HTTP/WebSocket inspector",
+      "optionsSchema": null
+    }
+  ]
+}
+```
+
+### `POST /features/:id`
+
+Body: `{"enabled": bool, ...options}`
+
+→ `DebugSwiftAI.setFeature(id, enabled:, options:)`
+
+Response: updated feature state + triggers status refresh
+
+### `GET /logs/:stream`
+
+Query params:
+
+| Param | Behavior |
+|-------|----------|
+| `tail=N` | Last N lines from ring buffer |
+| `since=ISO8601` | Lines with `ts >= since` |
+| `filter=substring` | Client-side filter on `data` JSON string (MVP) |
+
+Response:
+
+```json
+{
+  "stream": "network",
+  "lines": [ { /* AIEvent */ }, ... ],
+  "truncated": false
+}
+```
+
+### `GET /logs/:stream/:id`
+
+Single record by `data.id` — scan recent buffer + optional file grep (MVP: buffer only; Phase 3: index)
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/HTTP/Handlers/AIFeaturesHandler.swift` | GET/POST features |
+| `DebugSwift/Sources/AI/HTTP/Handlers/AILogsHandler.swift` | GET logs |
+| `DebugSwift/Sources/AI/HTTP/Handlers/AILogQuery.swift` | tail/since/filter parser |
+
+## Implementation tasks
+
+- [ ] Register routes in `AIRouter`
+- [ ] Validate `stream` against allowlist (prevent path traversal)
+- [ ] Max `tail` = 1000
+- [ ] `Content-Type: application/json` on all JSON responses
+- [ ] `POST` invalid JSON → `400`
+- [ ] CORS not required
+- [ ] Integration test: enable network → fetch logs (Example UITest or shell script in Plan 12)
+
+## Acceptance criteria
+
+- [ ] Full MVP workflow from AI_AUTOMATION.md works:
+
+```bash
+curl -X POST localhost:9999/features/network -d '{"enabled":true}'
+curl -s localhost:9999/logs/network?tail=50
+```
+
+- [ ] Unknown stream → `404`
+- [ ] Unknown feature → `404`
+
+## Verification
+
+See [12 — Shell Scripts](./12-shell-scripts.md) for `ai-smoke-test.sh`
+
+## Next
+
+→ [12](./12-shell-scripts.md) · [13](./13-example-integration.md)

--- a/docs/plans/12-shell-scripts.md
+++ b/docs/plans/12-shell-scripts.md
@@ -1,0 +1,82 @@
+# Plan 12 — Shell Scripts
+
+**Phase:** 1 · **Priority:** P0 · **Depends on:** [11](./11-logs-features-api.md)
+
+## Goal
+
+Terminal helpers for agents and developers: tail logs, smoke-test bridge, simulator screenshot wrapper.
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `scripts/ai-tail-logs.sh` | Tail NDJSON from HTTP or container file |
+| `scripts/ai-smoke-test.sh` | Enable features + assert logs |
+| `scripts/ai-screenshot.sh` | simctl + optional in-app (Phase 2) |
+| `scripts/ai-container-path.sh` | Resolve simulator app data container |
+
+## `ai-tail-logs.sh`
+
+```bash
+#!/usr/bin/env bash
+# Usage: ./scripts/ai-tail-logs.sh [stream] [--follow] [--tail N] [--port 9999] [--bundle com.example.app]
+```
+
+Behavior:
+
+1. If `curl localhost:$PORT/logs/$STREAM?tail=$N` succeeds → use HTTP (live)
+2. Else fallback: `simctl get_app_container` + `tail -f .../debugswift-ai/$STREAM.jsonl`
+3. Pipe through `jq -c .` for readability
+
+## `ai-smoke-test.sh`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+PORT=${DEBUGSWIFT_AI_PORT:-9999}
+curl -sf "localhost:$PORT/status" | jq -e '.bridgeEnabled == true'
+curl -sf -X POST "localhost:$PORT/features/network" -H 'Content-Type: application/json' -d '{"enabled":true}'
+# ... assert logs/network returns array
+```
+
+Exit non-zero on failure — usable in CI.
+
+## `ai-container-path.sh`
+
+```bash
+#!/usr/bin/env bash
+BUNDLE=${1:?bundle id}
+xcrun simctl get_app_container booted "$BUNDLE" data
+```
+
+## `ai-screenshot.sh` (stub until Plan 15)
+
+```bash
+#!/usr/bin/env bash
+OUT=${1:-/tmp/debugswift-screen.png}
+xcrun simctl io booted screenshot "$OUT"
+# Optional: --in-app calls curl localhost:9999/screenshot
+```
+
+## Implementation tasks
+
+- [ ] `chmod +x` all scripts
+- [ ] Use env vars: `DEBUGSWIFT_AI_PORT`, `DEBUGSWIFT_BUNDLE_ID`
+- [ ] Document in Example README (Plan 13)
+- [ ] Add `scripts/` mention to main README or AI_AUTOMATION.md Related Files
+
+## Acceptance criteria
+
+- [ ] `./scripts/ai-tail-logs.sh network --tail 5` prints JSON lines with app running
+- [ ] `./scripts/ai-smoke-test.sh` passes against Example with AI Scheme
+
+## Verification
+
+```bash
+./scripts/ai-smoke-test.sh
+./scripts/ai-tail-logs.sh console --follow
+```
+
+## Next
+
+→ [13 — Example Integration](./13-example-integration.md)

--- a/docs/plans/13-example-integration.md
+++ b/docs/plans/13-example-integration.md
@@ -1,0 +1,75 @@
+# Plan 13 — Example Integration & Docs
+
+**Phase:** 0–1 · **Priority:** P0 · **Depends on:** [02](./02-activation-bootstrap.md), [11](./11-logs-features-api.md), [12](./12-shell-scripts.md)
+
+## Goal
+
+Example app demonstrates AI bridge end-to-end. Developers and Cursor agents can copy Scheme + AppDelegate pattern.
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `Example/Example/ExampleApp.swift` | `DebugSwiftAI.bootstrap()` after setup |
+| `Example/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme` | Env: `DEBUGSWIFT_AI=1`, `DEBUGSWIFT_AI_PORT=9999` |
+| `Example/README.md` (create if missing) or root `README.md` | Simulator workflow section |
+
+## Scheme configuration
+
+Add to **Run** action:
+
+```xml
+<EnvironmentVariables>
+   <EnvironmentVariable key="DEBUGSWIFT_AI" value="1" isEnabled="YES"/>
+   <EnvironmentVariable key="DEBUGSWIFT_AI_PORT" value="9999" isEnabled="YES"/>
+</EnvironmentVariables>
+```
+
+Optional separate Scheme **Example (AI)** so default Run stays unchanged — team preference.
+
+## README section (target content)
+
+### AI Automation Quick Start
+
+1. Run Example with AI Scheme (⌘R)
+2. `curl localhost:9999/status`
+3. Enable network: `curl -X POST localhost:9999/features/network -d '{"enabled":true}'`
+4. Trigger network in app
+5. `./scripts/ai-tail-logs.sh network --tail 10`
+6. Pull from container:
+
+```bash
+CONTAINER=$(./scripts/ai-container-path.sh com.example.app)
+ls "$CONTAINER/Library/Caches/debugswift-ai/"
+```
+
+### simctl launch (no Xcode)
+
+```bash
+export SIMCTL_CHILD_DEBUGSWIFT_AI=1
+export SIMCTL_CHILD_DEBUGSWIFT_AI_PORT=9999
+xcrun simctl launch booted com.example.app
+```
+
+## Implementation tasks
+
+- [ ] Resolve Example bundle ID (check `Example/Example/Info.plist` or project settings)
+- [ ] Add bootstrap call guarded `#if DEBUG`
+- [ ] Verify deep link `debugswift://` still works alongside bridge
+- [ ] Add link from `AI_AUTOMATION.md` → `docs/plans/README.md`
+- [ ] Optional: Example UI button "Copy AI status URL" for demos
+
+## Smoke test checklist
+
+- [ ] Xcode Run → `curl /status` → `bridgeEnabled: true`
+- [ ] Network toggle + log tail
+- [ ] Console `print` appears in `console.jsonl`
+- [ ] Container path script resolves
+
+## Acceptance criteria
+
+- [ ] New contributor can follow README only and control DebugSwift from terminal in <5 min
+
+## Next
+
+Phase 2 → [14](./14-interface-visual-features.md)

--- a/docs/plans/14-interface-visual-features.md
+++ b/docs/plans/14-interface-visual-features.md
@@ -1,0 +1,80 @@
+# Plan 14 — Interface Visual Features
+
+**Phase:** 2 · **Priority:** P1 · **Depends on:** [05](./05-feature-registry.md)
+
+## Goal
+
+HTTP toggles for visual Interface tab features so agents can enable overlays, then verify via screenshot (Plan 15).
+
+## Feature IDs & existing code
+
+| ID | Existing implementation |
+|----|-------------------------|
+| `interface.grid` | `DebugSwift/Sources/Features/Interface/Grid/Interface.Grid.Controller.swift` |
+| `interface.touchIndicators` | `UserInterfaceToolkit` |
+| `interface.colorize` | UIView border swizzle (views feature) |
+| `interface.slowAnimations` | `UIView.setAnimationsEnabled` / speed hack |
+| `interface.darkMode` | Override `UIUserInterfaceStyle` |
+| `performance.hud` | `PerformanceToolkit.isWidgetShown` |
+| `floatBall` | `FloatViewManager` |
+| `swiftUIRender` | `SwiftUIRenderTracker` (beta) |
+| `measurement` | `DebugSwift.Measurement.activate/deactivate` |
+
+## POST body options
+
+```json
+// interface.grid
+{"enabled": true, "opacity": 0.3, "color": "#FF0000"}
+
+// interface.slowAnimations
+{"enabled": true, "speed": 0.25}
+```
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Features/Handlers/AIInterfaceFeatureHandler.swift` | Grid, touch, colorize, dark mode |
+| `DebugSwift/Sources/AI/Features/Handlers/AIShellFeatureHandler.swift` | floatBall, debugger present/dismiss |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `UserInterfaceToolkit.swift` | Expose programmatic toggle if UI-only today |
+| `Interface.Grid.Controller.swift` | Accept opacity/color without UI |
+| `AIFeatureRegistry.swift` | Register P1 interface IDs |
+
+## Implementation tasks
+
+- [ ] All toggles run on `@MainActor`
+- [ ] Persist options in status JSON `features.interface.grid.options`
+- [ ] `interface.grid` off → remove overlay window
+- [ ] `measurement` → emit `measurement.jsonl` when active (hybrid)
+- [ ] `swiftUIRender` → `swiftui-render.jsonl` with render rects
+- [ ] Tab visibility: `tabs.network` → maps to `DebugSwiftFeature` hide list (runtime hide is hard — document limitation or mutate `hiddenFeatures`)
+
+## Agent workflow (from doc)
+
+```bash
+curl -X POST localhost:9999/features/interface.grid -d '{"enabled":true,"opacity":0.3}'
+sleep 0.5  # agent settle — not a code fix, doc only
+xcrun simctl io booted screenshot /tmp/grid-on.png
+```
+
+## Acceptance criteria
+
+- [ ] Grid visible after POST without opening Interface tab
+- [ ] Status reflects grid options
+- [ ] Disable restores clean UI
+
+## Verification
+
+```bash
+curl -X POST localhost:9999/features/interface.grid -H 'Content-Type: application/json' -d '{"enabled":true}'
+./scripts/ai-screenshot.sh /tmp/grid.png
+```
+
+## Next
+
+→ [15 — Screenshot Endpoint](./15-screenshot-endpoint.md)

--- a/docs/plans/15-screenshot-endpoint.md
+++ b/docs/plans/15-screenshot-endpoint.md
@@ -1,0 +1,76 @@
+# Plan 15 — Screenshot Endpoint
+
+**Phase:** 2 · **Priority:** P1 · **Depends on:** [01](./01-foundation-module.md), [04](./04-http-server-core.md)
+
+## Goal
+
+`GET /screenshot` returns PNG bytes; labeled captures saved to `debugswift-ai/screenshots/` for before/after comparisons. Works on **device** where simctl cannot.
+
+## Reuse existing code
+
+`DebugSwift/Sources/Features/Interface/DocRecorder/ScreenshotCapturer.swift`
+
+- `captureScreenshot() -> UIImage?` — composites app windows below overlay level
+- Already handles multi-window scenes
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/HTTP/Handlers/AIScreenshotHandler.swift` | HTTP handler |
+| `DebugSwift/Sources/AI/Internal/AIScreenshotStore.swift` | Save labeled PNGs |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `DebugSwift/Sources/AI/DebugSwift.AI.swift` | Implement `captureScreenshot(label:)` |
+
+## API
+
+```
+GET /screenshot
+GET /screenshot?label=grid-on
+```
+
+Response:
+
+- `Content-Type: image/png`
+- Body: raw PNG
+- If `label` provided: also write `screenshots/grid-on-20250616120000.png`
+
+## Implementation tasks
+
+- [ ] Handler runs on main actor (UIKit)
+- [ ] Reuse `ScreenshotCapturer` — consider making it `internal` shared instance
+- [ ] Filename: `{label}-{yyyyMMddHHmmss}.png` or UUID if no label
+- [ ] Return latest bytes even if disk write fails
+- [ ] Max dimension cap optional (none for MVP)
+- [ ] Wire crash exporter screenshot ref (Plan 09)
+- [ ] Update `scripts/ai-screenshot.sh` `--in-app` flag
+
+## Three screenshot sources (doc)
+
+| Source | When to use |
+|--------|-------------|
+| simctl | Full simulator chrome + status bar |
+| XcodeBuild MCP | Cursor integration |
+| `GET /screenshot` | Device + exact window pixels |
+
+## Acceptance criteria
+
+- [ ] `curl -s localhost:9999/screenshot -o /tmp/x.png && file /tmp/x.png` → PNG
+- [ ] Labeled file appears in export dir
+- [ ] Works with grid overlay enabled (Plan 14)
+
+## Verification
+
+```bash
+curl -s 'localhost:9999/screenshot?label=test' -o /tmp/in-app.png
+CONTAINER=$(./scripts/ai-container-path.sh com.example.app)
+ls "$CONTAINER/Library/Caches/debugswift-ai/screenshots/"
+```
+
+## Next
+
+→ [16 — Actions API](./16-actions-api.md) · [09](./09-leaks-crashes-export.md) crash screenshots

--- a/docs/plans/16-actions-api.md
+++ b/docs/plans/16-actions-api.md
@@ -1,0 +1,79 @@
+# Plan 16 — Actions API
+
+**Phase:** 2 · **Priority:** P1 · **Depends on:** [04](./04-http-server-core.md), [05](./05-feature-registry.md)
+
+## Goal
+
+`POST /actions/:id` triggers side effects without a persistent enabled state.
+
+## Action catalog
+
+| Path | Maps to | NDJSON |
+|------|---------|--------|
+| `POST /actions/push` | `DebugSwift.PushNotification.simulate(...)` | `push.jsonl` |
+| `POST /actions/deeplink` | Open URL in app | `deeplink.jsonl` |
+| `POST /actions/location` | Simulated location | `location.jsonl` |
+| `POST /actions/performance/memoryWarning` | `UIApplication.shared.perform(...)` | `performance.jsonl` event |
+| `POST /actions/network/clear` | `DebugSwift.Network.shared.clearAllNetworkData()` | — |
+| `POST /actions/debugger/present` | `DebugSwift.App.presentDebugger()` | screenshot recommended |
+| `POST /actions/debugger/dismiss` | Dismiss debugger VC | — |
+| `POST /actions/docRecorder/start` | P2 — stub 501 | — |
+| `POST /actions/viewDebugger/open` | P2 — stub 501 | — |
+
+## Request examples
+
+```json
+POST /actions/push
+{"title": "Test", "body": "Hello AI", "delay": 0}
+
+POST /actions/deeplink
+{"url": "myapp://path?x=1"}
+
+POST /actions/location
+{"latitude": 37.7749, "longitude": -122.4194}
+```
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/HTTP/Handlers/AIActionsHandler.swift` | Route + validate body |
+| `DebugSwift/Sources/AI/Actions/AIActionRegistry.swift` | Id → closure |
+| `DebugSwift/Sources/AI/Export/Exporters/AIPushExporter.swift` | |
+| `DebugSwift/Sources/AI/Export/Exporters/AIDeeplinkExporter.swift` | |
+
+## Existing APIs
+
+| File | API |
+|------|-----|
+| `DebugSwift.PushNotification.swift` | `simulate()` |
+| `DeepLink.Models.swift` | URL handling |
+| Location feature | `FeatureHandling.enableLocation()` + simulator |
+| `DebugSwift.App.swift` | `presentDebugger()` |
+| `DebugSwift.Network.swift` | `clearAllNetworkData()` |
+
+## Implementation tasks
+
+- [ ] Separate namespace from features — actions are verbs
+- [ ] Validate URLs before deeplink (scheme allowlist optional)
+- [ ] Push simulation requires feature enabled or auto-enable for action
+- [ ] Emit NDJSON `action.completed` with payload echo
+- [ ] Custom host actions (P1): `GET /custom/info`, `POST /custom/actions/:id` via `DebugSwift.App.shared.customAction` reflection — fragile, document
+
+## Acceptance criteria
+
+- [ ] `POST /actions/push` shows notification in simulator
+- [ ] `POST /actions/deeplink` triggers Example deep link handler
+- [ ] `POST /actions/network/clear` empties network log stream
+
+## Verification
+
+```bash
+curl -X POST localhost:9999/actions/push -H 'Content-Type: application/json' \
+  -d '{"title":"AI","body":"test"}'
+curl -s localhost:9999/logs/push?tail=1 | jq .
+```
+
+## Next
+
+→ [17](./17-resources-endpoints.md)

--- a/docs/plans/17-resources-endpoints.md
+++ b/docs/plans/17-resources-endpoints.md
@@ -1,0 +1,68 @@
+# Plan 17 — Resources Endpoints
+
+**Phase:** 3 · **Priority:** P1–P2 · **Depends on:** [04](./04-http-server-core.md)
+
+## Goal
+
+Read-only JSON for Resources tab data — no UITableView dependency.
+
+## Endpoints
+
+| Method | Path | Source |
+|--------|------|--------|
+| GET | `/resources/files?path=/` | Sandbox browser |
+| GET | `/resources/userdefaults` | UserDefaults snapshot |
+| GET | `/resources/cookies` | `HTTPCookieStorage` |
+| GET | `/resources/keychain` | Keys/metadata only — **no secret values** |
+| GET | `/resources/libraries` | Loaded libraries VM |
+| GET | `/resources/coredata/:entity` | Requires `configureCoreData()` |
+| GET | `/resources/swiftdata/:model` | iOS 17+ |
+| GET | `/resources/database/:path` | SQLite/Realm browser |
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/HTTP/Handlers/AIResourcesHandler.swift` | Route multiplexer |
+| `DebugSwift/Sources/AI/Resources/AIFilesSerializer.swift` | Directory listing |
+| `DebugSwift/Sources/AI/Resources/AIUserDefaultsSerializer.swift` | |
+| `DebugSwift/Sources/AI/Resources/AICookiesSerializer.swift` | |
+| `DebugSwift/Sources/AI/Resources/AIKeychainSerializer.swift` | Metadata only |
+
+## Files to reference (existing)
+
+| Path | Role |
+|------|------|
+| `DebugSwift/Sources/Settings/DebugSwift.Resources.swift` | Configuration |
+| `DebugSwift/Sources/Helpers/Managers/FileManager.swift` | Sandbox paths |
+| Resources tab ViewControllers | Copy query logic, not UI |
+
+## Security rules
+
+- Keychain: return `account`, `service`, `accessGroup` — never `kSecValueData`
+- Files: jail `path` to sandbox — reject `..` segments
+- Max response size 5 MB — paginate directory listings
+
+## Implementation tasks
+
+- [ ] P1 first: files, userdefaults
+- [ ] P2: cookies, keychain metadata, coredata/swiftdata when configured in Example
+- [ ] `GET /resources/files?path=Documents` → `{ "entries": [{ "name", "isDirectory", "size" }] }`
+- [ ] Optional NDJSON audit log for resource reads (debug only)
+
+## Acceptance criteria
+
+- [ ] `curl localhost:9999/resources/userdefaults` returns JSON dict
+- [ ] Path traversal `?path=../../etc` → `400`
+- [ ] Keychain response contains no plaintext secrets
+
+## Verification
+
+```bash
+curl -s 'localhost:9999/resources/files?path=/' | jq .
+curl -s localhost:9999/resources/userdefaults | jq 'keys | length'
+```
+
+## Next
+
+→ [18](./18-view-hierarchy-export.md)

--- a/docs/plans/18-view-hierarchy-export.md
+++ b/docs/plans/18-view-hierarchy-export.md
@@ -1,0 +1,76 @@
+# Plan 18 — View Hierarchy Export
+
+**Phase:** 3 · **Priority:** P2 · **Depends on:** [14](./14-interface-visual-features.md), [15](./15-screenshot-endpoint.md)
+
+## Goal
+
+Export flat view hierarchy JSON for AI analysis — alternative to unreadable 3D View Debugger SceneKit view.
+
+## Existing model
+
+`DebugSwift/Sources/Features/Interface/ViewDebugger/Models/Element.swift` (`ViewElement`)
+
+Partial tree already built for View Debugger UI.
+
+## Deliverables
+
+| Output | Path |
+|--------|------|
+| HTTP | `GET /actions/viewDebugger/export` or `GET /resources/view-hierarchy` |
+| File | `debugswift-ai/view-hierarchy.json` |
+| Visual | `GET /screenshot?label=view-debugger` |
+
+## JSON schema (flat nodes)
+
+```json
+{
+  "root": "node-0",
+  "nodes": [
+    {
+      "id": "node-0",
+      "class": "UIWindow",
+      "frame": {"x":0,"y":0,"w":393,"h":852},
+      "accessibilityLabel": null,
+      "children": ["node-1"],
+      "isHidden": false,
+      "alpha": 1.0
+    }
+  ]
+}
+```
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Export/ViewHierarchy/AIViewHierarchyExporter.swift` | Walk key window |
+| `DebugSwift/Sources/AI/Export/ViewHierarchy/AIViewNode.swift` | Codable node |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `Element.swift` | Share traversal logic with exporter (extract `ViewHierarchyWalker`) |
+
+## Implementation tasks
+
+- [ ] Walk from key window root — skip DebugSwift overlay windows (same filter as `ScreenshotCapturer`)
+- [ ] Max depth 30, max nodes 2000 — truncate with `"truncated": true`
+- [ ] `POST /actions/viewDebugger/open` — P2: present debugger OR just export (prefer export-only for AI)
+- [ ] Doc Recorder headless mode — separate P2 redesign (not this plan)
+
+## Acceptance criteria
+
+- [ ] Export on Example home screen → valid tree with `UIView`/`UILabel` classes
+- [ ] File + HTTP return same content
+- [ ] 3D debugger UI not required for export
+
+## Verification
+
+```bash
+curl -s localhost:9999/resources/view-hierarchy | jq '.nodes | length'
+```
+
+## Next
+
+→ [19](./19-network-injection-api.md)

--- a/docs/plans/19-network-injection-api.md
+++ b/docs/plans/19-network-injection-api.md
@@ -1,0 +1,84 @@
+# Plan 19 — Network Injection API
+
+**Phase:** 3 · **Priority:** P1 · **Depends on:** [06](./06-network-export.md), [05](./05-feature-registry.md)
+
+## Goal
+
+Programmatic network mocking: delay, fail, rewrite — via HTTP without UI.
+
+## Existing capabilities
+
+Grep `Network` for injection, threshold, rewrite:
+
+- `DebugSwift.Network` threshold API (`NetworkThresholdTracker`)
+- Body editor / injection UI in Network tab
+- `EncryptionService` for decrypt toggle (`network.decryption` feature)
+
+## Endpoints
+
+```
+POST /actions/network/inject
+POST /features/network.decryption
+POST /features/network.threshold
+DELETE /actions/network/inject/:ruleId
+```
+
+## Inject rule schema
+
+```json
+{
+  "id": "rule-1",
+  "match": {
+    "urlPattern": "https://api.example.com/*",
+    "method": "GET"
+  },
+  "action": {
+    "type": "delay",
+    "delayMs": 2000
+  }
+}
+```
+
+Actions: `delay`, `fail` (status code), `rewrite` (status/headers/body), `drop`
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `DebugSwift/Sources/AI/Network/AINetworkInjectionStore.swift` | In-memory rules |
+| `DebugSwift/Sources/AI/HTTP/Handlers/AINetworkInjectionHandler.swift` | |
+| `DebugSwift/Sources/AI/Export/Exporters/AINetworkInjectionExporter.swift` | `network-injection.jsonl` |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `HTTPProtocol.swift` or injection hook | Apply rules before request/response |
+
+## Implementation tasks
+
+- [ ] Audit existing injection implementation — wire AI store to same engine (don't duplicate)
+- [ ] Emit `rule.applied` to `network-injection.jsonl`
+- [ ] `network.decryption` → `DebugSwift.Network.shared.isDecryptionEnabled`
+- [ ] `network.threshold` → POST body `{"limit": 100}`
+- [ ] Rule limit: max 50 active rules
+
+## Acceptance criteria
+
+- [ ] Inject delay → network.jsonl shows increased `durationMs`
+- [ ] Inject fail → status 500 without server change
+- [ ] Clear rules endpoint works
+
+## Verification
+
+```bash
+curl -X POST localhost:9999/actions/network/inject -d '{
+  "match":{"urlPattern":"*"},
+  "action":{"type":"delay","delayMs":3000}
+}'
+# trigger request, check duration
+```
+
+## Next
+
+→ [20](./20-device-parity.md)

--- a/docs/plans/20-device-parity.md
+++ b/docs/plans/20-device-parity.md
@@ -1,0 +1,89 @@
+# Plan 20 — Device Parity
+
+**Phase:** 3 · **Priority:** P1 · **Depends on:** [04](./04-http-server-core.md), [15](./15-screenshot-endpoint.md), [11](./11-logs-features-api.md)
+
+## Goal
+
+Same HTTP + NDJSON API works on physical device (Xcode Run, devicectl) — not just Simulator.
+
+## Platform gaps (from AI_AUTOMATION.md)
+
+| Simulator | Device workaround |
+|-----------|-------------------|
+| `simctl get_app_container` | HTTP GET logs OR App Group |
+| `simctl io screenshot` | `GET /screenshot` |
+| `127.0.0.1` bridge | LAN IP or USB port forwarding |
+| `SIMCTL_CHILD_*` | `DEVICECTL_CHILD_*` or Scheme env |
+
+## Configuration additions
+
+| Env | Purpose |
+|-----|---------|
+| `DEBUGSWIFT_AI_BIND=0.0.0.0` | Listen on all interfaces (device on Wi‑Fi) |
+| `DEBUGSWIFT_AI_PORT=9999` | Same as simulator |
+| `DEBUGSWIFT_AI_TOKEN=<secret>` | Required when bind != localhost |
+
+## Files to modify
+
+| Path | Change |
+|------|--------|
+| `AIConfiguration.swift` | Parse `DEBUGSWIFT_AI_BIND` |
+| `AIServer.swift` | Bind address from config |
+| `docs/AI_AUTOMATION.md` | Device troubleshooting section |
+
+## Files to create
+
+| Path | Purpose |
+|------|---------|
+| `scripts/ai-device-launch.sh` | devicectl wrapper with env |
+| `docs/plans/device-testing-checklist.md` | Manual QA matrix |
+
+## `ai-device-launch.sh`
+
+```bash
+#!/usr/bin/env bash
+DEVICE_UDID=${1:?}
+BUNDLE=${2:?}
+export DEVICECTL_CHILD_DEBUGSWIFT_AI=1
+export DEVICECTL_CHILD_DEBUGSWIFT_AI_PORT=9999
+export DEVICECTL_CHILD_DEBUGSWIFT_AI_BIND=0.0.0.0
+export DEVICECTL_CHILD_DEBUGSWIFT_AI_TOKEN="${DEBUGSWIFT_AI_TOKEN:?set token}"
+xcrun devicectl device process launch --device "$DEVICE_UDID" --terminate-existing "$BUNDLE" --console
+```
+
+## Testing matrix
+
+| Scenario | iOS 16 | iOS 17+ |
+|----------|--------|---------|
+| Xcode Scheme env | ✅ | ✅ |
+| devicectl launch | ❌ | ✅ |
+| curl from Mac to device IP | ✅ with token | ✅ |
+| NDJSON via HTTP | ✅ | ✅ |
+| Screenshot via `/screenshot` | ✅ | ✅ |
+| Pull container file | ❌ | ❌ |
+
+## Implementation tasks
+
+- [ ] Default bind `127.0.0.1` — opt-in `0.0.0.0`
+- [ ] Log bound address on startup: `AI bridge listening on http://192.168.x.x:9999`
+- [ ] Document Mac firewall + same Wi‑Fi requirement
+- [ ] iOS 16 path: Scheme-only, no devicectl — still valid
+- [ ] `--console` stdout may include bridge startup log for agents
+
+## Acceptance criteria
+
+- [ ] iPhone on Wi‑Fi: `curl http://<device-ip>:9999/status` with token
+- [ ] Screenshot PNG retrievable from device
+- [ ] Simulator behavior unchanged
+
+## Verification
+
+```bash
+./scripts/ai-device-launch.sh <UDID> com.example.app
+# From Mac on same network:
+curl -H "Authorization: Bearer $TOKEN" http://192.168.1.x:9999/status
+```
+
+## Next
+
+→ [21](./21-mcp-package.md)

--- a/docs/plans/21-mcp-package.md
+++ b/docs/plans/21-mcp-package.md
@@ -1,0 +1,115 @@
+# Plan 21 — MCP Package (`@debugswift/mcp`)
+
+**Phase:** 4 · **Priority:** P1 · **Depends on:** [11](./11-logs-features-api.md), [15](./15-screenshot-endpoint.md), [16](./16-actions-api.md)
+
+## Goal
+
+Cursor MCP server that wraps the in-app HTTP bridge + simctl helpers — agents call tools instead of raw curl.
+
+## Package layout (new repo or monorepo `packages/debugswift-mcp`)
+
+```
+packages/debugswift-mcp/
+├── package.json
+├── src/
+│   ├── index.ts          # MCP server entry
+│   ├── client.ts         # HTTP client to bridge
+│   ├── simctl.ts         # screenshot, container path
+│   └── tools/
+│       ├── status.ts
+│       ├── setFeature.ts
+│       ├── getLogs.ts
+│       ├── screenshot.ts
+│       └── action.ts
+└── README.md
+```
+
+## MCP tools (from AI_AUTOMATION.md)
+
+| Tool | HTTP / shell |
+|------|----------------|
+| `debugswift_status` | `GET /status` |
+| `debugswift_set_feature` | `POST /features/:id` |
+| `debugswift_get_logs` | `GET /logs/:stream?tail&since` |
+| `debugswift_screenshot` | simctl + optional `GET /screenshot` |
+| `debugswift_action` | `POST /actions/:id` |
+
+## Environment variables
+
+```json
+{
+  "DEBUGSWIFT_AI_PORT": "9999",
+  "DEBUGSWIFT_BUNDLE_ID": "com.example.app",
+  "DEBUGSWIFT_AI_TOKEN": "",
+  "DEBUGSWIFT_SIMULATOR_UDID": "booted"
+}
+```
+
+## Cursor config snippet
+
+```json
+{
+  "mcpServers": {
+    "debugswift": {
+      "command": "npx",
+      "args": ["-y", "@debugswift/mcp"],
+      "env": {
+        "DEBUGSWIFT_AI_PORT": "9999",
+        "DEBUGSWIFT_BUNDLE_ID": "com.example.app"
+      }
+    }
+  }
+}
+```
+
+## Coexistence with XcodeBuild MCP
+
+| Concern | Owner |
+|---------|-------|
+| build, run, test | XcodeBuild MCP |
+| in-app debug data, feature toggles | DebugSwift MCP |
+| simulator screenshot | Either — DebugSwift adds in-app option |
+
+Document in README: start app with XcodeBuild, then use DebugSwift tools.
+
+## Implementation tasks
+
+- [ ] TypeScript MCP SDK (`@modelcontextprotocol/sdk`)
+- [ ] HTTP client with token header + timeout 5s
+- [ ] `debugswift_get_logs` returns parsed JSON array as tool result text
+- [ ] `debugswift_screenshot` params: `{ inApp?: boolean, label?: string, outputPath?: string }`
+- [ ] `debugswift_set_feature` params: `{ id, enabled, options? }`
+- [ ] Publish to npm `@debugswift/mcp` (or GitHub packages)
+- [ ] Integration test against running Example bridge (optional CI with simulator)
+
+## Tool schemas (sketch)
+
+```typescript
+// debugswift_set_feature
+{
+  id: string,
+  enabled: boolean,
+  options?: Record<string, unknown>
+}
+
+// debugswift_get_logs
+{
+  stream: 'network' | 'console' | 'performance' | ...,
+  tail?: number,
+  since?: string
+}
+```
+
+## Acceptance criteria
+
+- [ ] Cursor lists 5 tools when configured
+- [ ] Agent can enable network + read logs in one session
+- [ ] Works with `DEBUGSWIFT_AI_TOKEN` when set
+
+## Verification
+
+Manual in Cursor: "Enable network logging and show last 5 requests"
+
+## Next
+
+→ [22](./22-security-hardening.md)

--- a/docs/plans/22-security-hardening.md
+++ b/docs/plans/22-security-hardening.md
@@ -1,0 +1,82 @@
+# Plan 22 — Security Hardening
+
+**Phase:** 1–4 (ongoing) · **Priority:** P0 · **Depends on:** [04](./04-http-server-core.md)
+
+## Goal
+
+Ensure AI bridge cannot ship in Release, cannot leak secrets, and cannot be accidentally exposed on hostile networks.
+
+## Rules (from AI_AUTOMATION.md)
+
+| Rule | Implementation |
+|------|----------------|
+| `#if DEBUG` only | Entire `Sources/AI/` excluded from Release target |
+| Bind `127.0.0.1` default | `AIConfiguration.bindAddress` |
+| Optional token | `DEBUGSWIFT_AI_TOKEN` → Bearer on all mutating routes + logs |
+| Truncate bodies | 64KB JSONL, 4KB inline preview (Plan 06) |
+| Keychain: metadata only | Plan 17 |
+| Off by default | No env → no server |
+
+## Files to create / modify
+
+| Path | Change |
+|------|--------|
+| `DebugSwift/Sources/AI/HTTP/AIAuthMiddleware.swift` | Enforce token on POST, optional on GET |
+| `DebugSwift/Sources/AI/Internal/AIConfiguration.swift` | Warn if `0.0.0.0` without token |
+| `BUILD.bazel` / Xcode | Release excludes AI sources |
+| `.github/workflows/` | CI: grep Release binary for `DebugSwiftAI` symbol — must fail if found |
+
+## Hardening tasks
+
+### Compile-time
+
+- [ ] Verify Release Example archive has no `DebugSwiftAI` strings (`strings` check)
+- [ ] SPM conditional compilation flag `DEBUG` matches Xcode
+
+### Runtime
+
+- [ ] Refuse start if Release somehow calls bootstrap (assert + return)
+- [ ] Rate limit: max 100 req/s per connection (optional, P2)
+- [ ] Max concurrent connections 10
+
+### Data
+
+- [ ] Redact `Authorization` headers in network.jsonl by default
+- [ ] Config flag `DEBUGSWIFT_AI_REDACT_HEADERS=1` (default on)
+- [ ] Log rotation: when `*.jsonl` > 50MB, rename to `.jsonl.1` (P2)
+
+### Device / LAN (Plan 20)
+
+- [ ] If bind != localhost → require non-empty token
+- [ ] Log warning: `Binding to 0.0.0.0 — ensure DEBUGSWIFT_AI_TOKEN is set`
+
+## Threat model (brief)
+
+| Threat | Mitigation |
+|--------|------------|
+| Release app opens port | DEBUG compile gate |
+| Coffee shop Wi‑Fi exposure | localhost default + token on LAN |
+| Agent dumps keychain | metadata-only serializer |
+| Huge response blows agent context | truncation + `GET /logs/:id` for detail |
+
+## Acceptance criteria
+
+- [ ] Release build: `curl localhost:9999` connection refused (no server)
+- [ ] Token set: request without header → 401
+- [ ] Network log lines redact `Authorization` values
+
+## Verification
+
+```bash
+# Debug build with token
+export DEBUGSWIFT_AI_TOKEN=test
+curl -s localhost:9999/features/network -X POST -d '{"enabled":true}'  # 401
+curl -s -H "Authorization: Bearer test" localhost:9999/status  # 200
+
+# Release archive symbol check
+strings Example.app/Example | grep -i DebugSwiftAI && exit 1 || echo OK
+```
+
+## Completes
+
+AI automation MVP → production-safe incremental rollout across Phases 1–4.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,145 @@
+# DebugSwift AI Automation — Implementation Plans
+
+Step-by-step implementation plans derived from [AI_AUTOMATION.md](../AI_AUTOMATION.md).
+
+Each plan is self-contained: goal, prerequisites, file touch list, tasks, acceptance criteria, and verification commands.
+
+## Integration branch: `epic/v3`
+
+All AI automation work (Plans 01–22) merges into **`epic/v3`**. That epic branch is the long-lived integration line for v3; it lands in `develop` when the full epic is done.
+
+### Branching model
+
+```
+develop
+  └── epic/v3                          ← integration target for all AI plans
+        ├── maatheusgois-dd/ai/01-foundation
+        ├── maatheusgois-dd/ai/02-bootstrap
+        ├── maatheusgois-dd/ai/03-ndjson
+        └── … (one PR per plan, or batch P0 as single PR)
+```
+
+| Rule | Detail |
+|------|--------|
+| **Base branch for PRs** | `epic/v3` (not `main` / `develop`) |
+| **PR target** | `epic/v3` |
+| **Assignee** | `maatheusgois-dd` |
+| **PR state** | Draft until smoke test passes |
+| **Epic completion** | Single PR: `epic/v3` → `develop` |
+
+### Suggested PR batches
+
+| PR | Plans | Rationale |
+|----|-------|-----------|
+| `ai/p0-core` | 01–05 | Foundation compiles; empty `/status` |
+| `ai/p0-exporters` | 06–11 | MVP logs + HTTP API |
+| `ai/p0-tooling` | 12–13, 22 | Scripts, Example, security baseline |
+| `ai/visual` | 14–16 | Screenshots + actions |
+| `ai/advanced` | 17–20 | Resources, device parity |
+| `ai/mcp` | 21 | MCP package (may live outside this repo) |
+
+Docs-only changes (this folder + `AI_AUTOMATION.md`) can go directly to `epic/v3` or ship first as `maatheusgois-dd/ai/plans`.
+
+### Create the epic branch (once)
+
+```bash
+git fetch origin develop
+git checkout -b epic/v3 origin/develop
+git push -u origin epic/v3
+```
+
+## Dependency graph
+
+```mermaid
+flowchart TD
+    P01[01 Foundation Module]
+    P02[02 Activation Bootstrap]
+    P03[03 NDJSON Export Layer]
+    P04[04 HTTP Server Core]
+    P05[05 Feature Registry]
+    P01 --> P02
+    P01 --> P03
+    P02 --> P04
+    P03 --> P06
+    P04 --> P05
+    P05 --> P06
+    P05 --> P07
+    P05 --> P08
+    P05 --> P09
+    P06 --> P10
+    P07 --> P10
+    P08 --> P10
+    P09 --> P10
+    P10 --> P11
+    P11 --> P12
+    P02 --> P13
+    P11 --> P13
+    P05 --> P14
+    P04 --> P15
+    P05 --> P16
+    P04 --> P17
+    P14 --> P18
+    P06 --> P19
+    P11 --> P20
+    P11 --> P21
+    P04 --> P22
+```
+
+## Phase 0 — Prep
+
+| Step | Plan | Status |
+|------|------|--------|
+| 0 | [13 — Example Integration](./13-example-integration.md) | Partial (scheme env vars pending) |
+
+## Phase 1 — P0 MVP (data features)
+
+| Step | Plan | Delivers |
+|------|------|----------|
+| 1 | [01 — Foundation Module](./01-foundation-module.md) | `DebugSwift.AI` public surface, export dir |
+| 2 | [02 — Activation Bootstrap](./02-activation-bootstrap.md) | Env/launch-arg detection, `bootstrap()` |
+| 3 | [03 — NDJSON Export Layer](./03-ndjson-export-layer.md) | Shared writer, envelope schema |
+| 4 | [04 — HTTP Server Core](./04-http-server-core.md) | Localhost server, routing, auth token |
+| 5 | [05 — Feature Registry](./05-feature-registry.md) | String IDs → existing APIs |
+| 6 | [06 — Network Export](./06-network-export.md) | `network.jsonl`, body truncation |
+| 7 | [07 — Console Export](./07-console-export.md) | `console.jsonl` + StdoutCapture hook |
+| 8 | [08 — Performance Export](./08-performance-export.md) | `performance.jsonl` 1 Hz sampler |
+| 9 | [09 — Leaks & Crashes Export](./09-leaks-crashes-export.md) | `leaks.jsonl`, `crashes.jsonl` |
+| 10 | [10 — Status Endpoint](./10-status-endpoint.md) | `GET /status`, `status.json` |
+| 11 | [11 — Logs & Features API](./11-logs-features-api.md) | `POST /features/*`, `GET /logs/*` |
+| 12 | [12 — Shell Scripts](./12-shell-scripts.md) | `scripts/ai-tail-logs.sh`, helpers |
+| 13 | [13 — Example Integration](./13-example-integration.md) | Scheme, README, smoke test |
+
+## Phase 2 — Visual + actions
+
+| Step | Plan | Delivers |
+|------|------|----------|
+| 14 | [14 — Interface Visual Features](./14-interface-visual-features.md) | Grid, touch, colorize, HUD toggles |
+| 15 | [15 — Screenshot Endpoint](./15-screenshot-endpoint.md) | `GET /screenshot`, labeled PNGs |
+| 16 | [16 — Actions API](./16-actions-api.md) | push, deeplink, location, debugger UI |
+
+## Phase 3 — Advanced
+
+| Step | Plan | Delivers |
+|------|------|----------|
+| 17 | [17 — Resources Endpoints](./17-resources-endpoints.md) | Files, UserDefaults, cookies JSON |
+| 18 | [18 — View Hierarchy Export](./18-view-hierarchy-export.md) | `view-hierarchy.json` |
+| 19 | [19 — Network Injection API](./19-network-injection-api.md) | Delay/fail/rewrite rules |
+| 20 | [20 — Device Parity](./20-device-parity.md) | devicectl, LAN HTTP, device screenshots |
+
+## Phase 4 — MCP + hardening
+
+| Step | Plan | Delivers |
+|------|------|----------|
+| 21 | [21 — MCP Package](./21-mcp-package.md) | `@debugswift/mcp`, Cursor config |
+| 22 | [22 — Security Hardening](./22-security-hardening.md) | DEBUG gate, token, body limits |
+
+## Suggested build order
+
+1. **Week 1:** 01 → 02 → 03 → 04 → 05 (skeleton works, `curl /status` returns empty state)
+2. **Week 2:** 06 → 07 → 09 → 08 → 10 → 11 (P0 logs + toggles)
+3. **Week 3:** 12 → 13 → 22 (scripts, Example, security baseline)
+4. **Week 4+:** 14 → 15 → 16 → 17 → 18 → 19 → 20 → 21
+
+## Out of scope (future CLI)
+
+The `debugswift` brew CLI from AI_AUTOMATION.md is a thin wrapper over simctl + curl. Defer until Phase 1–2 HTTP API is stable; scripts in step 12 cover the gap.


### PR DESCRIPTION
## Summary

- Add `docs/AI_AUTOMATION.md` — design doc for AI-controllable DebugSwift (HTTP bridge, NDJSON logs, MCP)
- Add `docs/plans/01`–`22` + README — step-by-step implementation plans for v3 epic
- Fix `.gitignore` to track `docs/AI_AUTOMATION.md` and `docs/plans/` (was blocking all of `docs/`)
- Add README **AI Automation (v3)** section linking to design doc and plans index

## Type of change

- [x] Docs

## Test plan

- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Verify `docs/AI_AUTOMATION.md` and all 22 plan files render on GitHub
2. Confirm README links resolve to design doc and `docs/plans/README.md`
3. Confirm `.gitignore` allows future edits under `docs/plans/` without `git add -f`

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility

Made with [Cursor](https://cursor.com)