### PR TITLE
fix(network): skip WebSocket upgrade requests in HTTP protocol

### DIFF
--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -34,6 +34,11 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             }
         }
 
+        // URLSessionWebSocketTask performs its handshake as an HTTP upgrade request.
+        if isWebSocketUpgradeRequest(request) {
+            return false
+        }
+
         for onlyScheme in DebugSwift.Network.shared.onlySchemes {
             if let scheme = request.url?.scheme?.lowercased(), scheme == onlyScheme.rawValue {
                 return true
@@ -41,6 +46,17 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
         }
 
         return false
+    }
+
+    private final class func isWebSocketUpgradeRequest(_ request: URLRequest) -> Bool {
+        guard let headers = request.allHTTPHeaderFields else { return false }
+
+        let upgrade = headers.first { $0.key.caseInsensitiveCompare("Upgrade") == .orderedSame }?.value
+        if upgrade?.caseInsensitiveCompare("websocket") == .orderedSame {
+            return true
+        }
+
+        return headers.keys.contains { $0.caseInsensitiveCompare("Sec-WebSocket-Key") == .orderedSame }
     }
 
     public override final class func canInit(with request: URLRequest) -> Bool {


### PR DESCRIPTION
## Summary

`CustomHTTPProtocol` was intercepting WebSocket handshakes because `URLSessionWebSocketTask` performs the upgrade as a normal HTTP request (`http://…` with `Upgrade: websocket` headers), not as a `ws://` URL. That broke WebSocket connections with connection-lost errors (`NSURLErrorDomain -1005`).

This change skips interception when the request is a WebSocket upgrade (`Upgrade: websocket` or `Sec-WebSocket-Key` header), leaving frame capture to `WebSocketMonitor`.

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Run the Example app with DebugSwift enabled.
2. Connect via **WebSocket Inspector Test** to a local WebSocket server (`ws://localhost:3001/websocket`).
3. Confirm the connection succeeds and frames appear in **Network → WebSocket**.

## Screenshots / recordings (if applicable)

N/A — networking protocol fix only.

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility

Made with [Cursor](https://cursor.com)