### PR TITLE
Implement orientation forwarding

### DIFF
--- a/DebugSwift/Sources/Base/FeatureBase.swift
+++ b/DebugSwift/Sources/Base/FeatureBase.swift
@@ -31,6 +31,7 @@ public enum DebugSwiftSwizzleFeature: String, CaseIterable {
     case console
     case pushNotifications
     case swiftUIRender
+    case orientationForwarding
 }
 
 @MainActor

--- a/DebugSwift/Sources/Features/Interface/HyperionSwift/Measurement/Helpers/MeasurementWindowManager.swift
+++ b/DebugSwift/Sources/Features/Interface/HyperionSwift/Measurement/Helpers/MeasurementWindowManager.swift
@@ -75,7 +75,9 @@ public enum MeasurementWindowManager {
             window = MeasurementWindow(frame: UIScreen.main.bounds)
         }
 
-        let navigation = UINavigationController(rootViewController: CustomViewController())
+        let navigation = OrientationForwardingNavigationController(
+            rootViewController: CustomViewController()
+        )
         window.rootViewController = navigation
         window.isHidden = false
 

--- a/DebugSwift/Sources/Features/Interface/OrientationForwardingNavigationController.swift
+++ b/DebugSwift/Sources/Features/Interface/OrientationForwardingNavigationController.swift
@@ -1,0 +1,34 @@
+//
+//  OrientationForwardingNavigationController.swift
+//  DebugSwift
+//
+
+import UIKit
+
+final class OrientationForwardingNavigationController: UINavigationController {
+
+    // UIApplication.topViewController walks the full nav/tab/presented chain
+    // so it reaches whatever VC the app currently has on screen.
+    private var appTopViewController: UIViewController? {
+        UIApplication.topViewController()
+    }
+
+    override var shouldAutorotate: Bool {
+        appTopViewController?.shouldAutorotate ?? super.shouldAutorotate
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        appTopViewController?.supportedInterfaceOrientations ?? super.supportedInterfaceOrientations
+    }
+
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        appTopViewController?.preferredInterfaceOrientationForPresentation
+            ?? super.preferredInterfaceOrientationForPresentation
+    }
+
+    @available(iOS 26.0, *)
+    override var prefersInterfaceOrientationLocked: Bool {
+        appTopViewController?.prefersInterfaceOrientationLocked
+            ?? super.prefersInterfaceOrientationLocked
+    }
+}

--- a/DebugSwift/Sources/Features/Interface/OrientationForwardingNavigationController.swift
+++ b/DebugSwift/Sources/Features/Interface/OrientationForwardingNavigationController.swift
@@ -26,9 +26,4 @@ final class OrientationForwardingNavigationController: UINavigationController {
             ?? super.preferredInterfaceOrientationForPresentation
     }
 
-    @available(iOS 26.0, *)
-    override var prefersInterfaceOrientationLocked: Bool {
-        appTopViewController?.prefersInterfaceOrientationLocked
-            ?? super.prefersInterfaceOrientationLocked
-    }
 }

--- a/DebugSwift/Sources/Helpers/Extensions/UIWindowScene+.swift
+++ b/DebugSwift/Sources/Helpers/Extensions/UIWindowScene+.swift
@@ -1,0 +1,33 @@
+//
+//  UIWindowScene+.swift
+//  DebugSwift
+//
+
+import UIKit
+
+extension UIWindowScene {
+  @available(iOS 16.0, *)
+  static func db_swizzleRequestGeometryUpdate() {
+        DispatchQueue.once(token: "debugswift.uiwindowscene.db_swizzleRequestGeometryUpdate") {
+            let originalSelector = #selector(UIWindowScene.requestGeometryUpdate(_:errorHandler:))
+            let swizzledSelector = #selector(UIWindowScene.db_requestGeometryUpdate(_:errorHandler:))
+            guard
+                let originalMethod = class_getInstanceMethod(UIWindowScene.self, originalSelector),
+                let swizzledMethod = class_getInstanceMethod(UIWindowScene.self, swizzledSelector)
+            else { return }
+            method_exchangeImplementations(originalMethod, swizzledMethod)
+        }
+    }
+
+  @available(iOS 16.0, *)
+  @objc private func db_requestGeometryUpdate(
+      _ preferences: UIWindowScene.GeometryPreferences,
+        errorHandler: ((Error) -> Void)?
+    ) {
+        windows
+            .filter { $0 is CustomWindow || $0 is MeasurementWindow }
+            .forEach { $0.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations() }
+      
+        db_requestGeometryUpdate(preferences, errorHandler: errorHandler)
+    }
+}

--- a/DebugSwift/Sources/Helpers/Extensions/UIWindowScene+.swift
+++ b/DebugSwift/Sources/Helpers/Extensions/UIWindowScene+.swift
@@ -27,7 +27,26 @@ extension UIWindowScene {
         windows
             .filter { $0 is CustomWindow || $0 is MeasurementWindow }
             .forEach { $0.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations() }
-      
+
         db_requestGeometryUpdate(preferences, errorHandler: errorHandler)
+    }
+}
+
+extension UIViewController {
+    static func db_swizzleViewDidAppear() {
+        DispatchQueue.once(token: "debugswift.uiviewcontroller.db_swizzleViewDidAppear") {
+            let original = #selector(UIViewController.viewDidAppear(_:))
+            let swizzled = #selector(UIViewController.db_viewDidAppear(_:))
+            guard
+                let originalMethod = class_getInstanceMethod(UIViewController.self, original),
+                let swizzledMethod = class_getInstanceMethod(UIViewController.self, swizzled)
+            else { return }
+            method_exchangeImplementations(originalMethod, swizzledMethod)
+        }
+    }
+
+    @objc private func db_viewDidAppear(_ animated: Bool) {
+        db_viewDidAppear(animated)
+        WindowManager.window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
     }
 }

--- a/DebugSwift/Sources/Helpers/Extensions/UIWindowScene+.swift
+++ b/DebugSwift/Sources/Helpers/Extensions/UIWindowScene+.swift
@@ -47,6 +47,10 @@ extension UIViewController {
 
     @objc private func db_viewDidAppear(_ animated: Bool) {
         db_viewDidAppear(animated)
-        WindowManager.window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+        if #available(iOS 16.0, *) {
+            WindowManager.window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+        } else {
+            UIViewController.attemptRotationToDeviceOrientation()
+        }
     }
 }

--- a/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
+++ b/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
@@ -25,7 +25,7 @@ enum WindowManager {
         }
         window.windowLevel = .alert + 1
 
-        let navigation = UINavigationController(rootViewController: UIViewController())
+        let navigation = OrientationForwardingNavigationController(rootViewController: UIViewController())
         navigation.interactivePopGestureRecognizer?.isEnabled = false
         navigation.setBackgroundColor(color: .clear)
         window.rootViewController = navigation

--- a/DebugSwift/Sources/Settings/FeatureHandling.swift
+++ b/DebugSwift/Sources/Settings/FeatureHandling.swift
@@ -134,6 +134,7 @@ enum FeatureHandling {
         if #available(iOS 16.0, *) {
             UIWindowScene.db_swizzleRequestGeometryUpdate()
         }
+        UIViewController.db_swizzleViewDidAppear()
     }
 
     private static func enableSwiftUIRender() {

--- a/DebugSwift/Sources/Settings/FeatureHandling.swift
+++ b/DebugSwift/Sources/Settings/FeatureHandling.swift
@@ -81,6 +81,10 @@ enum FeatureHandling {
         if !methodsToDisable.contains(.swiftUIRender) {
             enableSwiftUIRender()
         }
+
+        if !methodsToDisable.contains(.orientationForwarding) {
+            enableOrientationForwarding()
+        }
     }
 
     private static func enableNetwork() {
@@ -126,6 +130,12 @@ enum FeatureHandling {
         StdoutCapture.shared.startCapturing()
     }
     
+    private static func enableOrientationForwarding() {
+        if #available(iOS 16.0, *) {
+            UIWindowScene.db_swizzleRequestGeometryUpdate()
+        }
+    }
+
     private static func enableSwiftUIRender() {
         // Only enable if beta features include SwiftUI render tracking
         guard enabledBetaFeatures.contains(.swiftUIRenderTracking) else { return }

--- a/Example/ExampleTests/Tests/Base/FeatureBaseTests.swift
+++ b/Example/ExampleTests/Tests/Base/FeatureBaseTests.swift
@@ -23,7 +23,7 @@ class FeatureBaseTests: XCTestCase {
 
     func testDebugSwiftSwizzleFeature_allCases() {
         // Given
-        let expectedCases: [DebugSwiftSwizzleFeature] = [.network, .webSocket, .wkWebView, .location, .views, .crashManager, .leaksDetector, .console, .pushNotifications, .swiftUIRender]
+        let expectedCases: [DebugSwiftSwizzleFeature] = [.network, .webSocket, .wkWebView, .location, .views, .crashManager, .leaksDetector, .console, .pushNotifications, .swiftUIRender, .orientationForwarding]
 
         // When
         let allCases = DebugSwiftSwizzleFeature.allCases


### PR DESCRIPTION
## Summary

This pull request introduces a new `OrientationForwardingNavigationController` to ensure that custom windows in the app (such as measurement and debug windows) properly forward orientation and rotation behaviors to match the main app's root view controller. The new navigation controller replaces standard `UINavigationController` instances in relevant window managers.

**Orientation Handling Improvements:**

* Added a new `OrientationForwardingNavigationController` class that overrides rotation and orientation properties to forward them from the app's root view controller, ensuring consistent interface orientation across custom windows.

**Integration into Window Managers:**

* Updated `MeasurementWindowManager` to use `OrientationForwardingNavigationController` instead of `UINavigationController` for its measurement window.
* Updated `WindowManager` to use `OrientationForwardingNavigationController` instead of `UINavigationController` for its alert-level window.

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [x] Unit tests updated
- [ ] Manual testing completed
- [ ] CI passing

### Manual test steps

1.
2.
3.

## Screenshots / recordings (if applicable)

<!-- Add visuals when UI or behavior changes -->

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [ ] I considered backward compatibility
