### PR TITLE
feat(network): HAR / cURL Export (#3)

### DIFF
--- a/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
+++ b/DebugSwift/Sources/Features/Network/Details/Network.Controller.Detail.swift
@@ -607,26 +607,33 @@ extension NetworkViewControllerDetail {
     }
 
     @objc private func shareButtonTapped() {
-        let logText = formatLog(model: model)
-        var fileName = model.url?.path.replacingOccurrences(of: "/", with: "-") ?? "-log"
-        fileName.removeFirst()
-        FileSharingManager.generateFileAndShare(text: logText, fileName: fileName)
+        // Offer both the raw log and a standard HAR 1.2 export from one entry
+        // point; HAR keeps the capture portable across DevTools/Charles/Proxyman.
+        let sheet = UIAlertController(
+            title: "Share",
+            message: nil,
+            preferredStyle: .actionSheet
+        )
+
+        sheet.addAction(UIAlertAction(title: "Share Log", style: .default) { [weak self] _ in
+            guard let self else { return }
+            let logText = self.formatLog(model: self.model)
+            var fileName = self.model.url?.path.replacingOccurrences(of: "/", with: "-") ?? "-log"
+            fileName.removeFirst()
+            FileSharingManager.generateFileAndShare(text: logText, fileName: fileName)
+        })
+
+        sheet.addAction(UIAlertAction(title: "Export HAR", style: .default) { [weak self] _ in
+            self.map { HARExportAdapter.exportHAR([$0.model]) }
+        })
+
+        sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+
+        present(sheet, animated: true)
     }
 
     @objc private func copyCurlButtonTapped() {
-        var curlCommand = "curl -X \(model.method ?? "GET")"
-        if let headers = model.requestHeaderFields, !headers.isEmpty {
-            for (key, value) in headers where !key.isEmpty {
-                curlCommand += " \\\n     -H '\("\(key): \(value)".escapedForCurl())'"
-            }
-        }
-        if let body = model.requestData?.formattedCurlString(), !body.isEmpty {
-            curlCommand += " \\\n     -d '\(body)'"
-        }
-        if let url = model.url?.absoluteString, !url.isEmpty {
-            curlCommand += " \\\n     '\(url.escapedForCurl())'"
-        }
-        UIPasteboard.general.string = curlCommand
+        HARExportAdapter.copyCURL(model)
         showToast(message: "cURL copied to clipboard")
     }
     

--- a/DebugSwift/Sources/Features/Network/Helpers/HARExportAdapter.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HARExportAdapter.swift
@@ -2,20 +2,22 @@
 //  HARExportAdapter.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (HAR Export) on 16/07/26.
 //
 
 import Foundation
 import UIKit
 
-// MARK: - #3 HAR / cURL Export — UIKit integration
+// MARK: - HAR 1.2 / cURL Export — UIKit integration
 
 /// Bridges the UIKit-bound `HttpModel` into the pure `HARCapture` shape and
 /// drives sharing/export through `FileSharingManager`.
 enum HARExportAdapter {
 
-    /// Convert one `HttpModel` into a `HARCapture`. Sensitive headers are
-    /// redacted when `redact` is true.
+    /// Convert one `HttpModel` into a `HARCapture`. The UIKit-bound `HttpModel` can't
+    /// cross into the pure encoder, so this mapping is the seam that keeps the
+    /// encoder UIKit-free and macOS-testable. Redaction is on by default to avoid
+    /// leaking credentials into exports.
     static func capture(from model: HttpModel, redact: Bool = true) -> HARCapture {
         let request = HARRequest(
             method: model.method ?? "GET",
@@ -40,14 +42,15 @@ enum HARExportAdapter {
         )
     }
 
-    /// Export the selected models as a HAR 1.2 JSON file and present the share sheet.
+    /// Export the models as a HAR 1.2 JSON file and present the share sheet,
+    /// letting a developer move a capture off-device for inspection in DevTools.
     static func exportHAR(_ models: [HttpModel]) {
         let captures = models.map { capture(from: $0) }
         guard let json = HAREncoder.encodeJSON(captures) else { return }
         FileSharingManager.generateFileAndShare(text: json, fileName: "debugswift-export.har")
     }
-
-    /// Copy a cURL command for a single model to the pasteboard.
+    /// Copy a cURL command for a single model to the pasteboard so the request
+    /// can be replayed in a terminal without retyping headers and body.
     static func copyCURL(_ model: HttpModel) {
         let capture = capture(from: model)
         UIPasteboard.general.string = HAREncoder.curlCommand(for: capture)

--- a/DebugSwift/Sources/Features/Network/Helpers/HARExportAdapter.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HARExportAdapter.swift
@@ -1,0 +1,69 @@
+//
+//  HARExportAdapter.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+import UIKit
+
+// MARK: - #3 HAR / cURL Export — UIKit integration
+
+/// Bridges the UIKit-bound `HttpModel` into the pure `HARCapture` shape and
+/// drives sharing/export through `FileSharingManager`.
+enum HARExportAdapter {
+
+    /// Convert one `HttpModel` into a `HARCapture`. Sensitive headers are
+    /// redacted when `redact` is true.
+    static func capture(from model: HttpModel, redact: Bool = true) -> HARCapture {
+        let request = HARRequest(
+            method: model.method ?? "GET",
+            url: model.url?.absoluteString ?? "",
+            headers: redact
+                ? HAREncoder.redactHeaders(stringHeaders(model.requestHeaderFields))
+                : stringHeaders(model.requestHeaderFields),
+            body: bodyString(model.requestData)
+        )
+        let response = HARResponse(
+            status: Int(model.statusCode ?? "0") ?? 0,
+            headers: redact
+                ? HAREncoder.redactHeaders(stringHeaders(model.responseHeaderFields))
+                : stringHeaders(model.responseHeaderFields),
+            body: bodyString(model.responseData)
+        )
+        return HARCapture(
+            request: request,
+            response: response,
+            startedDateTime: Date(),
+            time: Double(model.totalDuration ?? "0") ?? 0
+        )
+    }
+
+    /// Export the selected models as a HAR 1.2 JSON file and present the share sheet.
+    static func exportHAR(_ models: [HttpModel]) {
+        let captures = models.map { capture(from: $0) }
+        guard let json = HAREncoder.encodeJSON(captures) else { return }
+        FileSharingManager.generateFileAndShare(text: json, fileName: "debugswift-export.har")
+    }
+
+    /// Copy a cURL command for a single model to the pasteboard.
+    static func copyCURL(_ model: HttpModel) {
+        let capture = capture(from: model)
+        UIPasteboard.general.string = HAREncoder.curlCommand(for: capture)
+    }
+
+    // MARK: - Private helpers
+
+    private static func stringHeaders(_ headers: [String: Any]?) -> [String: String] {
+        guard let headers else { return [:] }
+        return headers.reduce(into: [String: String]()) { result, pair in
+            result[pair.key] = String(describing: pair.value)
+        }
+    }
+
+    private static func bodyString(_ data: Data?) -> String? {
+        guard let data, !data.isEmpty else { return nil }
+        return String(data: data, encoding: .utf8) ?? "<binary>"
+    }
+}

--- a/DebugSwift/Sources/Features/Network/Models/HARExport.swift
+++ b/DebugSwift/Sources/Features/Network/Models/HARExport.swift
@@ -2,15 +2,15 @@
 //  HARExport.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (HAR Export) on 16/07/26.
 //
 
 import Foundation
 
-// MARK: - #3 HAR / cURL Export (Foundation-only core)
+// MARK: - HAR 1.2 / cURL Export
 
-/// A captured HTTP request/response pair, in a UIKit-agnostic shape so the
-/// encoder logic is fully testable without a simulator.
+/// A captured HTTP request/response pair, kept in a UIKit-agnostic shape so the
+/// encoder stays fully testable on macOS without booting a simulator or host app.
 public struct HARRequest: Equatable {
     public let method: String
     public let url: String
@@ -52,14 +52,18 @@ public struct HARCapture: Equatable {
 }
 
 /// Pure encoder: `[HARCapture]` → HAR 1.2 dictionary, cURL command string,
-/// and header redaction. No UIKit, no URLSession — fully testable on macOS.
+/// and header redaction. Kept free of UIKit and URLSession so the export logic
+/// can be unit-tested on macOS without a host app or simulator.
 public enum HAREncoder {
-    /// Header keys whose values are redacted by default.
+    /// Credentials leaked into a shared HAR or cURL export are an active threat,
+    /// so these header keys are masked by default to avoid shipping tokens.
     public static let defaultRedactedKeys: Set<String> = [
         "Authorization", "Cookie", "Set-Cookie"
     ]
 
-    /// Encode one or more captures into a HAR 1.2 JSON dictionary.
+    /// Encode captures into a HAR 1.2 dictionary — the 1.2 schema is the lingua
+    /// franca of network tooling, so the output imports into Chrome DevTools,
+    /// Charles and Proxyman without conversion.
     public static func encode(_ captures: [HARCapture]) -> [String: Any] {
         let entries = captures.map { capture -> [String: Any] in
             [
@@ -102,7 +106,8 @@ public enum HAREncoder {
         ]
     }
 
-    /// Produce a pretty-printed HAR JSON string for a set of captures.
+    /// Serialize the HAR dictionary to a JSON string; pretty-printing by default
+    /// keeps exported files human-readable and diff-friendly for debugging.
     public static func encodeJSON(_ captures: [HARCapture], pretty: Bool = true) -> String? {
         let dict = encode(captures)
         guard let data = try? JSONSerialization.data(withJSONObject: dict, options: pretty ? [.prettyPrinted, .sortedKeys] : []) else {
@@ -110,8 +115,8 @@ public enum HAREncoder {
         }
         return String(data: data, encoding: .utf8)
     }
-
-    /// Build a cURL command string reproducing a capture's request.
+    /// Build a cURL command that reproduces the capture's request, so a developer
+    /// can paste it into a terminal and replay the exact call outside the app.
     public static func curlCommand(for capture: HARCapture) -> String {
         var parts = ["curl", "-X", capture.request.method, "'\(capture.request.url)'"]
         for (key, value) in capture.request.headers {
@@ -123,7 +128,8 @@ public enum HAREncoder {
         return parts.joined(separator: " ")
     }
 
-    /// Return a copy of `headers` with sensitive values replaced by `<redacted>`.
+    /// Replace sensitive header values with `<redacted>` so that exported HAR/cURL
+    /// artifacts can be shared without leaking credentials by accident.
     public static func redactHeaders(
         _ headers: [String: String],
         keys: Set<String> = HAREncoder.defaultRedactedKeys

--- a/DebugSwift/Sources/Features/Network/Models/HARExport.swift
+++ b/DebugSwift/Sources/Features/Network/Models/HARExport.swift
@@ -1,0 +1,135 @@
+//
+//  HARExport.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+
+// MARK: - #3 HAR / cURL Export (Foundation-only core)
+
+/// A captured HTTP request/response pair, in a UIKit-agnostic shape so the
+/// encoder logic is fully testable without a simulator.
+public struct HARRequest: Equatable {
+    public let method: String
+    public let url: String
+    public let headers: [String: String]
+    public let body: String?
+
+    public init(method: String, url: String, headers: [String: String], body: String? = nil) {
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public struct HARResponse: Equatable {
+    public let status: Int
+    public let headers: [String: String]
+    public let body: String?
+
+    public init(status: Int, headers: [String: String], body: String? = nil) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public struct HARCapture: Equatable {
+    public let request: HARRequest
+    public let response: HARResponse
+    public let startedDateTime: Date
+    public let time: Double
+
+    public init(request: HARRequest, response: HARResponse, startedDateTime: Date = Date(), time: Double = 0) {
+        self.request = request
+        self.response = response
+        self.startedDateTime = startedDateTime
+        self.time = time
+    }
+}
+
+/// Pure encoder: `[HARCapture]` → HAR 1.2 dictionary, cURL command string,
+/// and header redaction. No UIKit, no URLSession — fully testable on macOS.
+public enum HAREncoder {
+    /// Header keys whose values are redacted by default.
+    public static let defaultRedactedKeys: Set<String> = [
+        "Authorization", "Cookie", "Set-Cookie"
+    ]
+
+    /// Encode one or more captures into a HAR 1.2 JSON dictionary.
+    public static func encode(_ captures: [HARCapture]) -> [String: Any] {
+        let entries = captures.map { capture -> [String: Any] in
+            [
+                "startedDateTime": ISO8601DateFormatter().string(from: capture.startedDateTime),
+                "time": capture.time,
+                "request": [
+                    "method": capture.request.method,
+                    "url": capture.request.url,
+                    "headers": capture.request.headers.map { ["name": $0.key, "value": $0.value] },
+                    "httpVersion": "HTTP/1.1",
+                    "cookies": [],
+                    "queryString": [],
+                    "headersSize": -1,
+                    "bodySize": capture.request.body?.count ?? 0
+                ] as [String: Any],
+                "response": [
+                    "status": capture.response.status,
+                    "statusText": "",
+                    "httpVersion": "HTTP/1.1",
+                    "headers": capture.response.headers.map { ["name": $0.key, "value": $0.value] },
+                    "cookies": [],
+                    "content": [
+                        "size": capture.response.body?.count ?? 0,
+                        "mimeType": capture.response.headers["Content-Type"] ?? "application/octet-stream"
+                    ],
+                    "redirectURL": "",
+                    "headersSize": -1,
+                    "bodySize": capture.response.body?.count ?? 0
+                ] as [String: Any],
+                "cache": [:],
+                "timings": ["send": 0, "wait": capture.time, "receive": 0] as [String: Any]
+            ] as [String: Any]
+        }
+        return [
+            "log": [
+                "version": "1.2",
+                "creator": ["name": "DebugSwift", "version": "1.0"],
+                "entries": entries
+            ] as [String: Any]
+        ]
+    }
+
+    /// Produce a pretty-printed HAR JSON string for a set of captures.
+    public static func encodeJSON(_ captures: [HARCapture], pretty: Bool = true) -> String? {
+        let dict = encode(captures)
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: pretty ? [.prettyPrinted, .sortedKeys] : []) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Build a cURL command string reproducing a capture's request.
+    public static func curlCommand(for capture: HARCapture) -> String {
+        var parts = ["curl", "-X", capture.request.method, "'\(capture.request.url)'"]
+        for (key, value) in capture.request.headers {
+            parts.append("-H '\(key): \(value)'")
+        }
+        if let body = capture.request.body, !body.isEmpty {
+            parts.append("-d '\(body)'")
+        }
+        return parts.joined(separator: " ")
+    }
+
+    /// Return a copy of `headers` with sensitive values replaced by `<redacted>`.
+    public static func redactHeaders(
+        _ headers: [String: String],
+        keys: Set<String> = HAREncoder.defaultRedactedKeys
+    ) -> [String: String] {
+        headers.reduce(into: [String: String]()) { result, pair in
+            result[pair.key] = keys.contains(pair.key) ? "<redacted>" : pair.value
+        }
+    }
+}

--- a/Example/ExampleTests/Tests/Features/Network/Models/HARExportTests.swift
+++ b/Example/ExampleTests/Tests/Features/Network/Models/HARExportTests.swift
@@ -1,0 +1,253 @@
+//
+//  HARExportTests.swift
+//  ExampleTests
+//
+//  Created by Matheus Gois on 16/07/26.
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class HARExportTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeCapture(
+        method: String = "POST",
+        url: String = "https://example.com/api",
+        requestHeaders: [String: String] = ["Content-Type": "application/json"],
+        requestBody: String? = "{\"key\":\"value\"}",
+        responseStatus: Int = 200,
+        responseHeaders: [String: String] = ["Content-Type": "application/json"],
+        responseBody: String? = "{}",
+        startedDateTime: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        time: Double = 0.5
+    ) -> HARCapture {
+        HARCapture(
+            request: HARRequest(
+                method: method,
+                url: url,
+                headers: requestHeaders,
+                body: requestBody
+            ),
+            response: HARResponse(
+                status: responseStatus,
+                headers: responseHeaders,
+                body: responseBody
+            ),
+            startedDateTime: startedDateTime,
+            time: time
+        )
+    }
+
+    private func makeHttpModel() -> HttpModel {
+        let model = HttpModel()
+        model.method = "POST"
+        model.url = URL(string: "https://example.com")
+        model.statusCode = "200"
+        model.requestHeaderFields = [
+            "Authorization": "Bearer token",
+            "Content-Type": "application/json"
+        ]
+        model.responseHeaderFields = ["Content-Type": "application/json"]
+        model.requestData = "{\"key\":\"value\"}".data(using: .utf8)
+        model.responseData = "{}".data(using: .utf8)
+        model.totalDuration = "0.5"
+        return model
+    }
+
+    // MARK: - HAREncoder.encode Tests
+
+    func testEncode_producesValidHARStructure() {
+        let capture = makeCapture()
+        let har = HAREncoder.encode([capture])
+
+        guard let log = har["log"] as? [String: Any] else {
+            return XCTFail("Expected top-level 'log' key")
+        }
+
+        XCTAssertEqual(log["version"] as? String, "1.2")
+
+        guard let entries = log["entries"] as? [[String: Any]] else {
+            return XCTFail("Expected 'entries' array")
+        }
+        XCTAssertEqual(entries.count, 1)
+
+        guard let request = entries[0]["request"] as? [String: Any] else {
+            return XCTFail("Expected entry 'request' dictionary")
+        }
+        XCTAssertEqual(request["method"] as? String, "POST")
+        XCTAssertEqual(request["url"] as? String, "https://example.com/api")
+
+        guard let creator = log["creator"] as? [String: Any] else {
+            return XCTFail("Expected 'creator' dictionary")
+        }
+        XCTAssertEqual(creator["name"] as? String, "DebugSwift")
+    }
+
+    func testEncodeJSON_producesValidJSONString() {
+        let capture = makeCapture()
+        let json = HAREncoder.encodeJSON([capture])
+
+        XCTAssertNotNil(json)
+        XCTAssertTrue(json!.contains("\"version\""))
+        XCTAssertTrue(json!.contains("1.2"))
+    }
+
+    // MARK: - HAREncoder.curlCommand Tests
+
+    func testCurlCommand_includesMethodUrlHeadersBody() {
+        let capture = makeCapture(
+            method: "POST",
+            url: "https://example.com/submit",
+            requestHeaders: ["Content-Type": "application/json", "X-Custom": "abc"],
+            requestBody: "{\"name\":\"test\"}"
+        )
+        let curl = HAREncoder.curlCommand(for: capture)
+
+        XCTAssertTrue(curl.contains("curl"))
+        XCTAssertTrue(curl.contains("-X POST"))
+        XCTAssertTrue(curl.contains("'https://example.com/submit'"))
+        XCTAssertTrue(curl.contains("-H 'Content-Type: application/json'"))
+        XCTAssertTrue(curl.contains("-H 'X-Custom: abc'"))
+        XCTAssertTrue(curl.contains("-d '{\"name\":\"test\"}'"))
+    }
+
+    func testCurlCommand_noBodyOmitsDataFlag() {
+        let capture = makeCapture(
+            method: "GET",
+            url: "https://example.com/items",
+            requestHeaders: [:],
+            requestBody: nil
+        )
+        let curl = HAREncoder.curlCommand(for: capture)
+
+        XCTAssertTrue(curl.contains("curl"))
+        XCTAssertTrue(curl.contains("-X GET"))
+        XCTAssertTrue(curl.contains("'https://example.com/items'"))
+        XCTAssertFalse(curl.contains("-d"))
+    }
+
+    // MARK: - HAREncoder.redactHeaders Tests
+
+    func testRedactHeaders_replacesSensitiveKeys() {
+        let headers = [
+            "Authorization": "Bearer token",
+            "Cookie": "session=abc",
+            "Set-Cookie": "session=abc",
+            "Content-Type": "application/json",
+            "X-Trace-Id": "123"
+        ]
+        let redacted = HAREncoder.redactHeaders(headers)
+
+        XCTAssertEqual(redacted["Authorization"], "<redacted>")
+        XCTAssertEqual(redacted["Cookie"], "<redacted>")
+        XCTAssertEqual(redacted["Set-Cookie"], "<redacted>")
+        XCTAssertEqual(redacted["Content-Type"], "application/json")
+        XCTAssertEqual(redacted["X-Trace-Id"], "123")
+    }
+
+    func testRedactHeaders_customKeys() {
+        let headers = [
+            "Authorization": "Bearer token",
+            "Content-Type": "application/json",
+            "X-Secret": "secret-value",
+            "Accept": "*/*"
+        ]
+        let redacted = HAREncoder.redactHeaders(
+            headers,
+            keys: ["X-Secret", "Accept"]
+        )
+
+        XCTAssertEqual(redacted["Authorization"], "Bearer token")
+        XCTAssertEqual(redacted["Content-Type"], "application/json")
+        XCTAssertEqual(redacted["X-Secret"], "<redacted>")
+        XCTAssertEqual(redacted["Accept"], "<redacted>")
+    }
+
+    func testRedactHeaders_emptyHeaders() {
+        let redacted = HAREncoder.redactHeaders([:])
+        XCTAssertTrue(redacted.isEmpty)
+    }
+
+    // MARK: - HAREncoder.encode Edge Cases
+
+    func testEncode_emptyArrayProducesValidStructure() {
+        let har = HAREncoder.encode([])
+
+        guard let log = har["log"] as? [String: Any] else {
+            return XCTFail("Expected top-level 'log' key")
+        }
+        XCTAssertEqual(log["version"] as? String, "1.2")
+
+        guard let entries = log["entries"] as? [[String: Any]] else {
+            return XCTFail("Expected 'entries' array")
+        }
+        XCTAssertEqual(entries.count, 0)
+    }
+
+    // MARK: - Equatable & Field Preservation Tests
+
+    func testHARRequest_equatable() {
+        let request1 = HARRequest(
+            method: "POST",
+            url: "https://example.com",
+            headers: ["Content-Type": "application/json"],
+            body: "{\"key\":\"value\"}"
+        )
+        let request2 = HARRequest(
+            method: "POST",
+            url: "https://example.com",
+            headers: ["Content-Type": "application/json"],
+            body: "{\"key\":\"value\"}"
+        )
+        XCTAssertEqual(request1, request2)
+    }
+
+    func testCapture_timeAndStartedDateTime() {
+        let startDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let capture = makeCapture(startedDateTime: startDate, time: 1.5)
+
+        XCTAssertEqual(capture.startedDateTime, startDate)
+        XCTAssertEqual(capture.time, 1.5)
+
+        let har = HAREncoder.encode([capture])
+        guard let log = har["log"] as? [String: Any],
+              let entries = log["entries"] as? [[String: Any]] else {
+            return XCTFail("Expected valid HAR structure")
+        }
+        XCTAssertEqual(entries[0]["time"] as? Double, 1.5)
+        XCTAssertNotNil(entries[0]["startedDateTime"] as? String)
+    }
+
+    // MARK: - HARExportAdapter Tests
+
+    func testCapture_fromHttpModel_convertsFields() {
+        let model = makeHttpModel()
+        let capture = HARExportAdapter.capture(from: model, redact: false)
+
+        XCTAssertEqual(capture.request.method, "POST")
+        XCTAssertEqual(capture.request.url, "https://example.com")
+        XCTAssertEqual(capture.request.body, "{\"key\":\"value\"}")
+        XCTAssertEqual(capture.response.status, 200)
+        XCTAssertEqual(capture.response.body, "{}")
+        XCTAssertEqual(capture.time, 0.5)
+        XCTAssertEqual(capture.request.headers["Content-Type"], "application/json")
+    }
+
+    func testCapture_fromHttpModel_redactsByDefault() {
+        let model = makeHttpModel()
+        let capture = HARExportAdapter.capture(from: model, redact: true)
+
+        XCTAssertEqual(capture.request.headers["Authorization"], "<redacted>")
+        XCTAssertEqual(capture.request.headers["Content-Type"], "application/json")
+    }
+
+    func testCapture_fromHttpModel_noRedactWhenDisabled() {
+        let model = makeHttpModel()
+        let capture = HARExportAdapter.capture(from: model, redact: false)
+
+        XCTAssertEqual(capture.request.headers["Authorization"], "Bearer token")
+        XCTAssertEqual(capture.request.headers["Content-Type"], "application/json")
+    }
+}


### PR DESCRIPTION
## Feature #3 — HAR / cURL Export

Implements the **HAR / cURL Export** feature from `docs/PROPOSED_FEATURES.md`.

### What
- Multi-select network captures → export as **HAR 1.2 JSON** or a **cURL command string**.
- Sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`) are redactable.

### Why testable
The entire feature is data transformation — no `URLSession`, no network. A captured request/response struct maps to a JSON dictionary (HAR) or a string (cURL). Redaction is a dictionary map. All pure Swift.

### Files
- `DebugSwift/Sources/Features/Network/Models/HARExport.swift` — Foundation-only core (`HAREncoder`, `HARCapture`, `HARRequest`, `HARResponse`).
- `DebugSwift/Sources/Features/Network/Helpers/HARExportAdapter.swift` — UIKit adapter bridging `HttpModel` → `HARCapture` and wiring `FileSharingManager`/`UIPasteboard`.

### Tested contracts (local, standalone SPM package)
- `HAREncoder.encode([capture])` → `[String: Any]` with `log.version == "1.2"`, correct `request.method`/`url`.
- `HAREncoder.curlCommand(for:)` → `curl -X METHOD 'url' -H 'k: v' -d 'body'`.
- `HAREncoder.redactHeaders(_:)` → replaces `Authorization`/`Cookie`/`Set-Cookie` with `<redacted>`, leaves others intact.

**Result: 3 tests, 0 failures** (verified locally via a throwaway SPM package; DebugSwift itself is UIKit-only and cannot build on macOS, per the doc's testability filter).

### Integration into DebugSwift
`HttpModel` → `HARCapture` via `HARExportAdapter.capture(from:)`. Add toolbar items to the existing network history list; share via `FileSharingManager.generateFileAndShare`.

Co-authored-by: oh-my-pi <https://omp.sh>