### PR TITLE
feat(performance): Hangs / ANR Detection (#5)

### DIFF
--- a/DebugSwift/Sources/Features/Performance/Hang/HangDetector.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangDetector.swift
@@ -1,0 +1,83 @@
+//
+//  HangDetector.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+
+// MARK: - #5 Hangs / ANR Detection (pure watchdog logic)
+
+/// A hang event reported by `HangDetector` when the main thread stops
+/// heartbeating within the configured threshold (after the grace period).
+public struct HangEvent: Equatable {
+    public let timestamp: Date
+    public let duration: Double
+    public let backtrace: [String]
+
+    public init(timestamp: Date = Date(), duration: Double, backtrace: [String] = []) {
+        self.timestamp = timestamp
+        self.duration = duration
+        self.backtrace = backtrace
+    }
+}
+
+/// Pure hang/ANR detection logic.
+///
+/// The detection core — threshold comparison, grace-period gating,
+/// last-ping tracking — is pure date arithmetic. The real
+/// `DispatchSource.timer` and `Thread.callStackSymbols` are thin adapters
+/// around this logic, supplied by `HangDetectorRunner`. Tests inject
+/// `Date` values directly.
+public final class HangDetector {
+
+    /// Minimum main-thread stall (seconds) considered a hang.
+    public var threshold: Double
+
+    /// Seconds after `start()` during which no hang is reported, to allow
+    /// for app launch.
+    public var gracePeriod: Double
+
+    private var lastPing = Date()
+    private var startedAt: Date?
+    private var hangHandler: ((HangEvent) -> Void)?
+
+    public init(threshold: Double = 0.25, gracePeriod: Double = 10) {
+        self.threshold = threshold
+        self.gracePeriod = gracePeriod
+    }
+
+    /// Register a callback invoked when a hang is detected.
+    public func onHang(_ handler: @escaping (HangEvent) -> Void) {
+        hangHandler = handler
+    }
+
+    /// Begin monitoring. `now` is injectable for testing.
+    public func start(now: Date = Date()) {
+        startedAt = now
+        lastPing = now
+    }
+
+    /// Called from the main thread to record a heartbeat. `now` is injectable
+    /// for testing.
+    public func mainThreadDidHeartbeat(now: Date = Date()) {
+        lastPing = now
+    }
+
+    /// Called periodically (e.g. by a `DispatchSource.timer`) to check whether
+    /// the main thread has stalled. `now` and `backtrace` are injectable for
+    /// testing.
+    public func watchdogTick(now: Date, backtrace: [String] = []) {
+        guard let started = startedAt, now.timeIntervalSince(started) > gracePeriod else { return }
+        let elapsed = now.timeIntervalSince(lastPing)
+        if elapsed >= threshold {
+            hangHandler?(HangEvent(timestamp: now, duration: elapsed, backtrace: backtrace))
+        }
+    }
+
+    /// Stop monitoring and clear state.
+    public func stop() {
+        startedAt = nil
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Hang/HangDetector.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangDetector.swift
@@ -2,15 +2,18 @@
 //  HangDetector.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (ANR Detection) on 16/07/26.
 //
 
 import Foundation
 
-// MARK: - #5 Hangs / ANR Detection (pure watchdog logic)
+// MARK: - Hangs / ANR Detection
 
 /// A hang event reported by `HangDetector` when the main thread stops
-/// heartbeating within the configured threshold (after the grace period).
+/// heartbeating within the configured threshold.
+///
+/// Carrying the backtrace lets the UI surface *where* the main thread
+/// was stuck, not just that it was.
 public struct HangEvent: Equatable, Sendable {
     public let timestamp: Date
     public let duration: Double
@@ -23,20 +26,19 @@ public struct HangEvent: Equatable, Sendable {
     }
 }
 
-/// Pure hang/ANR detection logic.
+/// Pure hang/ANR detection logic — the threshold comparison, grace-period
+/// gating and last-ping tracking are plain date arithmetic.
 ///
-/// The detection core — threshold comparison, grace-period gating,
-/// last-ping tracking — is pure date arithmetic. The real
-/// `DispatchSource.timer` and `Thread.callStackSymbols` are thin adapters
-/// around this logic, supplied by `HangDetectorRunner`. Tests inject
-/// `Date` values directly.
+/// Keeping this core free of `DispatchSource` and `Thread.callStackSymbols`
+/// makes it trivially testable: tests inject `Date` values directly, and the
+/// real timer/stack-symbols are supplied by `HangDetectorRunner` as adapters.
 public final class HangDetector {
 
     /// Minimum main-thread stall (seconds) considered a hang.
     public var threshold: Double
 
-    /// Seconds after `start()` during which no hang is reported, to allow
-    /// for app launch.
+    /// Seconds after `start()` during which no hang is reported, so that
+    /// launch-time main-thread work does not produce false positives.
     public var gracePeriod: Double
 
     private var lastPing = Date()
@@ -48,27 +50,30 @@ public final class HangDetector {
         self.gracePeriod = gracePeriod
     }
 
-    /// Register a callback invoked when a hang is detected.
+    /// Register a callback invoked once a hang is detected.
     public func onHang(_ handler: @escaping (HangEvent) -> Void) {
         hangHandler = handler
     }
 
-    /// Begin monitoring. `now` is injectable for testing.
+    /// Begin monitoring. `now` is injectable so tests can simulate the
+    /// passage of time without real delays.
     public func start(now: Date = Date()) {
         startedAt = now
         lastPing = now
     }
 
     /// Called from the main thread to record a heartbeat. `now` is injectable
-    /// for testing.
+    /// so tests can advance the clock between beats.
     public func mainThreadDidHeartbeat(now: Date = Date()) {
         lastPing = now
     }
 
     /// Called periodically (e.g. by a `DispatchSource.timer`) to check whether
-    /// the main thread has stalled. `now` and `backtrace` are injectable for
-    /// testing.
+    /// the main thread has stalled. `now` and `backtrace` are injectable so
+    /// tests can assert both the threshold boundary and the reported stack.
     public func watchdogTick(now: Date, backtrace: [String] = []) {
+        // Stay silent during the grace period: startup main-thread work would
+        // otherwise look like a hang.
         guard let started = startedAt, now.timeIntervalSince(started) > gracePeriod else { return }
         let elapsed = now.timeIntervalSince(lastPing)
         if elapsed >= threshold {
@@ -76,7 +81,7 @@ public final class HangDetector {
         }
     }
 
-    /// Stop monitoring and clear state.
+    /// Stop monitoring and clear state so a later `start()` is clean.
     public func stop() {
         startedAt = nil
     }

--- a/DebugSwift/Sources/Features/Performance/Hang/HangDetector.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangDetector.swift
@@ -11,7 +11,7 @@ import Foundation
 
 /// A hang event reported by `HangDetector` when the main thread stops
 /// heartbeating within the configured threshold (after the grace period).
-public struct HangEvent: Equatable {
+public struct HangEvent: Equatable, Sendable {
     public let timestamp: Date
     public let duration: Double
     public let backtrace: [String]

--- a/DebugSwift/Sources/Features/Performance/Hang/HangDetectorRunner.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangDetectorRunner.swift
@@ -2,16 +2,20 @@
 //  HangDetectorRunner.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (ANR Detection) on 16/07/26.
 //
 
 import Foundation
 import UIKit
 
-// MARK: - #5 Hangs / ANR Detection — DispatchSource adapter
+// MARK: - Hangs / ANR Detection — DispatchSource adapter
 
-/// UIKit/Dispatch adapter that drives the pure `HangDetector` with a
-/// background `DispatchSource.timer` watchdog and a main-thread heartbeat.
+/// UIKit/Dispatch adapter that drives the pure `HangDetector`.
+///
+/// A background `DispatchSource.timer` acts as the watchdog that checks for
+/// main-thread stalls, while a fast main-queue timer supplies the heartbeat
+/// the detector compares against. Keeping the I/O here leaves the detection
+/// logic in `HangDetector` fully testable.
 final class HangDetectorRunner: @unchecked Sendable {
 
     static let shared = HangDetectorRunner()
@@ -22,21 +26,23 @@ final class HangDetectorRunner: @unchecked Sendable {
     private let queue = DispatchQueue(label: "debugswift.hang-detector")
 
     private init() {
-        // Shared singleton.
+        // Singleton — no external instances; `shared` is the only entry point.
     }
 
-    /// Recorded hang events, capped to avoid unbounded growth.
+    /// Recorded hang events, capped to avoid unbounded growth in long-running
+    /// debug sessions.
     private(set) var events: [HangEvent] = []
     private let maxEvents = 500
 
-    /// Begin monitoring. Hangs are reported to `onHang`.
+    /// Begin monitoring. Hangs are reported through the `onHang` callback.
     func start() {
         detector.onHang { [weak self] event in
             self?.record(event)
         }
         detector.start()
 
-        // Watchdog: tick on a background queue every `threshold` seconds.
+        // Watchdog: tick on a background queue every `threshold` seconds so
+        // the main thread gets a chance to stall before we sample it.
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now(), repeating: detector.threshold)
         timer.setEventHandler { [weak self] in
@@ -45,7 +51,8 @@ final class HangDetectorRunner: @unchecked Sendable {
         timer.activate()
         self.timer = timer
 
-        // Heartbeat: ping from the main thread at a fast interval.
+        // Heartbeat: ping from the main thread at a faster interval than the
+        // threshold so a healthy main thread always refreshes `lastPing`.
         let heartbeat = DispatchSource.makeTimerSource(queue: .main)
         heartbeat.schedule(deadline: .now(), repeating: 0.05)
         heartbeat.setEventHandler { [weak self] in
@@ -54,6 +61,7 @@ final class HangDetectorRunner: @unchecked Sendable {
         heartbeat.activate()
         self.heartbeatTimer = heartbeat
     }
+
 
     /// Stop monitoring and tear down timers.
     func stop() {

--- a/DebugSwift/Sources/Features/Performance/Hang/HangDetectorRunner.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangDetectorRunner.swift
@@ -1,0 +1,76 @@
+//
+//  HangDetectorRunner.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+import UIKit
+
+// MARK: - #5 Hangs / ANR Detection — DispatchSource adapter
+
+/// UIKit/Dispatch adapter that drives the pure `HangDetector` with a
+/// background `DispatchSource.timer` watchdog and a main-thread heartbeat.
+final class HangDetectorRunner {
+
+    static let shared = HangDetectorRunner()
+
+    private let detector = HangDetector(threshold: 0.25, gracePeriod: 10)
+    private var timer: DispatchSourceTimer?
+    private var heartbeatTimer: DispatchSourceTimer?
+    private let queue = DispatchQueue(label: "debugswift.hang-detector")
+
+    private init() {
+        // Shared singleton.
+    }
+
+    /// Recorded hang events, capped to avoid unbounded growth.
+    private(set) var events: [HangEvent] = []
+    private let maxEvents = 500
+
+    /// Begin monitoring. Hangs are reported to `onHang`.
+    func start() {
+        detector.onHang { [weak self] event in
+            self?.record(event)
+        }
+        detector.start()
+
+        // Watchdog: tick on a background queue every `threshold` seconds.
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now(), repeating: detector.threshold)
+        timer.setEventHandler { [weak self] in
+            self?.detector.watchdogTick(now: Date(), backtrace: Thread.callStackSymbols)
+        }
+        timer.activate()
+        self.timer = timer
+
+        // Heartbeat: ping from the main thread at a fast interval.
+        let heartbeat = DispatchSource.makeTimerSource(queue: .main)
+        heartbeat.schedule(deadline: .now(), repeating: 0.05)
+        heartbeat.setEventHandler { [weak self] in
+            self?.detector.mainThreadDidHeartbeat()
+        }
+        heartbeat.activate()
+        self.heartbeatTimer = heartbeat
+    }
+
+    /// Stop monitoring and tear down timers.
+    func stop() {
+        timer?.cancel()
+        timer = nil
+        heartbeatTimer?.cancel()
+        heartbeatTimer = nil
+        detector.stop()
+    }
+
+    private func record(_ event: HangEvent) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.events.append(event)
+            if self.events.count > self.maxEvents {
+                self.events.removeFirst(self.events.count - self.maxEvents)
+            }
+        }
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Hang/HangDetectorRunner.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangDetectorRunner.swift
@@ -12,7 +12,7 @@ import UIKit
 
 /// UIKit/Dispatch adapter that drives the pure `HangDetector` with a
 /// background `DispatchSource.timer` watchdog and a main-thread heartbeat.
-final class HangDetectorRunner {
+final class HangDetectorRunner: @unchecked Sendable {
 
     static let shared = HangDetectorRunner()
 

--- a/DebugSwift/Sources/Features/Performance/Hang/HangDetectorRunner.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangDetectorRunner.swift
@@ -81,4 +81,11 @@ final class HangDetectorRunner: @unchecked Sendable {
             }
         }
     }
+
+    /// Clear all recorded hang events.
+    func clearEvents() {
+        DispatchQueue.main.async { [weak self] in
+            self?.events.removeAll()
+        }
+    }
 }

--- a/DebugSwift/Sources/Features/Performance/Hang/HangEventsViewController.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangEventsViewController.swift
@@ -33,7 +33,7 @@ final class HangEventsViewController: BaseTableController {
         super.viewWillAppear(animated)
         tableView.reloadData()
         refreshTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.tableView.reloadData()
+            DispatchQueue.main.async { self?.tableView.reloadData() }
         }
     }
 

--- a/DebugSwift/Sources/Features/Performance/Hang/HangEventsViewController.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangEventsViewController.swift
@@ -1,0 +1,207 @@
+//
+//  HangEventsViewController.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois (ANR Detection) on 17/07/26.
+//
+
+import UIKit
+
+/// Lists recorded hang/ANR events (newest first) with timestamp, duration,
+/// and the main-thread backtrace captured at the stall. Driven by
+/// `HangDetectorRunner.shared`.
+final class HangEventsViewController: BaseTableController {
+
+    private let runner = HangDetectorRunner.shared
+
+    private var refreshTimer: Timer?
+
+    override init() {
+        super.init()
+        title = "Hang Events"
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigationBar()
+        tableView.backgroundColor = .black
+        view.backgroundColor = .black
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "HangEventCell")
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tableView.reloadData()
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.tableView.reloadData()
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigationBar() {
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                barButtonSystemItem: .trash,
+                target: self,
+                action: #selector(handleClear)
+            ),
+            UIBarButtonItem(
+                barButtonSystemItem: .action,
+                target: self,
+                action: #selector(handleShare)
+            )
+        ]
+    }
+
+    // MARK: - DataSource
+
+    override func numberOfSections(in _: UITableView) -> Int {
+        1
+    }
+
+    override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+        max(runner.events.count, 1)
+    }
+
+    override func tableView(_: UITableView, titleForHeaderInSection _: Int) -> String? {
+        let count = runner.events.count
+        let total = runner.events.reduce(0.0) { $0 + $1.duration }
+        return "Hangs: \(count) · Total stall: \(String(format: "%.2f", total))s"
+    }
+
+    override func tableView(_: UITableView, titleForFooterInSection _: Int) -> String? {
+        "Fires when the main thread stalls ≥ 0.25s past the 10s grace period."
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "HangEventCell", for: indexPath)
+        cell.backgroundColor = .black
+        cell.selectionStyle = .none
+
+        let events = runner.events
+        guard !events.isEmpty else {
+            cell.textLabel?.text = "No hangs detected yet"
+            cell.textLabel?.textColor = .systemGray
+            cell.textLabel?.textAlignment = .center
+            cell.detailTextLabel?.text = nil
+            return cell
+        }
+
+        // Newest first.
+        let event = events[events.count - 1 - indexPath.row]
+        let topFrame = event.backtrace.first ?? "<no backtrace>"
+        cell.textLabel?.text = "\(String(format: "%.2f", event.duration))s · \(event.timestamp.formatted())"
+        cell.textLabel?.textColor = .systemRed
+        cell.textLabel?.font = .monospacedDigitSystemFont(ofSize: 14, weight: .semibold)
+        cell.textLabel?.numberOfLines = 2
+        cell.detailTextLabel?.text = topFrame
+        cell.detailTextLabel?.textColor = .lightGray
+        cell.detailTextLabel?.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        cell.detailTextLabel?.numberOfLines = 0
+        return cell
+    }
+
+    override func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let events = runner.events
+        guard !events.isEmpty else { return }
+        let event = events[events.count - 1 - indexPath.row]
+        let detail = HangDetailViewController(event: event)
+        navigationController?.pushViewController(detail, animated: true)
+    }
+
+    // MARK: - Actions
+
+    @objc private func handleClear() {
+        guard !runner.events.isEmpty else { return }
+        let alert = UIAlertController(
+            title: "Clear Hangs",
+            message: "Remove all \(runner.events.count) recorded hang events?",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Clear", style: .destructive) { [weak self] _ in
+            self?.runner.clearEvents()
+            self?.tableView.reloadData()
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    @objc private func handleShare() {
+        let events = runner.events
+        guard !events.isEmpty else {
+            let alert = UIAlertController(
+                title: "Nothing to share",
+                message: "No hang events have been recorded yet.",
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            present(alert, animated: true)
+            return
+        }
+        let report = events.reversed().enumerated().map { index, event in
+            let frames = event.backtrace.enumerated()
+                .map { idx, frame in "  \(idx): \(frame)" }
+                .joined(separator: "\n")
+            let header = "#\(index + 1)\t\(event.timestamp.formatted())\t"
+                + "\(String(format: "%.2f", event.duration))s"
+            return "\(header)\n\(frames)"
+        }.joined(separator: "\n\n")
+        FileSharingManager.generateFileAndShare(text: report, fileName: "hang_events")
+    }
+}
+
+// MARK: - Hang Detail
+
+/// Shows the full backtrace for one hang event.
+final class HangDetailViewController: BaseTableController {
+    private let event: HangEvent
+
+    init(event: HangEvent) {
+        self.event = event
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Hang · \(String(format: "%.2f", event.duration))s"
+        tableView.backgroundColor = .black
+        view.backgroundColor = .black
+    }
+
+    override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+        max(event.backtrace.count, 1)
+    }
+
+    override func tableView(_: UITableView, titleForHeaderInSection _: Int) -> String? {
+        "Backtrace · \(event.timestamp.formatted())"
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "FrameCell") ?? UITableViewCell(
+            style: .default, reuseIdentifier: "FrameCell"
+        )
+        cell.backgroundColor = .black
+        cell.selectionStyle = .none
+        if event.backtrace.isEmpty {
+            cell.textLabel?.text = "<no backtrace captured>"
+            cell.textLabel?.textColor = .systemGray
+            cell.textLabel?.textAlignment = .center
+        } else {
+            cell.textLabel?.text = "\(indexPath.row): \(event.backtrace[indexPath.row])"
+            cell.textLabel?.textColor = .lightGray
+            cell.textLabel?.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
+            cell.textLabel?.numberOfLines = 0
+        }
+        return cell
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Hang/HangEventsViewController.swift
+++ b/DebugSwift/Sources/Features/Performance/Hang/HangEventsViewController.swift
@@ -176,6 +176,48 @@ final class HangDetailViewController: BaseTableController {
         title = "Hang · \(String(format: "%.2f", event.duration))s"
         tableView.backgroundColor = .black
         view.backgroundColor = .black
+        setupNavigationBar()
+    }
+
+    private func setupNavigationBar() {
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                image: UIImage(systemName: "doc.on.doc"),
+                style: .plain,
+                target: self,
+                action: #selector(handleCopy)
+            ),
+            UIBarButtonItem(
+                barButtonSystemItem: .action,
+                target: self,
+                action: #selector(handleShare)
+            )
+        ]
+    }
+
+    private func reportText() -> String {
+        let header = "Hang · \(String(format: "%.2f", event.duration))s · "
+            + event.timestamp.formatted()
+        let frames = event.backtrace.enumerated()
+            .map { idx, frame in "\(idx): \(frame)" }
+            .joined(separator: "\n")
+        return "\(header)\n\n\(frames)"
+    }
+
+    @objc private func handleCopy() {
+        UIPasteboard.general.string = reportText()
+        let toast = UIAlertController(title: nil, message: "Backtrace copied", preferredStyle: .alert)
+        present(toast, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            toast.dismiss(animated: true)
+        }
+    }
+
+    @objc private func handleShare() {
+        FileSharingManager.generateFileAndShare(
+            text: reportText(),
+            fileName: "hang_backtrace"
+        )
     }
 
     override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {

--- a/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
+++ b/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
@@ -48,6 +48,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case value = "ValueTableViewCell"
         case leak = "LeakTableViewCell"
         case memoryWarning = "MemoryWarningTableViewCell"
+        case hangEvents = "HangEventsRowCell"
 
         init?(rawValue: String?) {
             guard let rawValue else { return nil }
@@ -147,7 +148,8 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .batteryHistory:
             return isBatteryMonitoringEnabled ? 1 : 0
         case .hangDetection:
-            return 1
+            // 0: toggle · 1: "View Hangs" disclosure
+            return isHangDetectionEnabled ? 2 : 1
         }
     }
 
@@ -168,6 +170,17 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .batteryStatus: return nil
         case .batteryHistory: return isBatteryMonitoringEnabled ? "History" : nil
         case .hangDetection: return "Hang Detection"
+        }
+    }
+
+    override func tableView(_: UITableView, titleForFooterInSection section: Int) -> String? {
+        switch Section(rawValue: section)! {
+        case .hangDetection:
+            return isHangDetectionEnabled
+                ? "Fires when the main thread stalls ≥ 0.25s. Tap View Hangs to inspect events."
+                : "Enable to detect main-thread hangs (ANR) and capture their backtraces."
+        default:
+            return nil
         }
     }
 
@@ -198,7 +211,11 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .batteryHistory:
             return batteryHistoryCell()
         case .hangDetection:
-            return hangToggleCell()
+            switch indexPath.row {
+            case 0: return hangToggleCell()
+            case 1: return hangEventsRowCell()
+            default: return UITableViewCell()
+            }
         }
     }
 
@@ -230,6 +247,10 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
                 let threadCheckerController = PerformanceThreadCheckerViewController()
                 navigationController?.pushViewController(threadCheckerController, animated: true)
             }
+        case .hangEvents:
+            let controller = HangEventsViewController()
+            navigationController?.pushViewController(controller, animated: true)
+            break
         default:
             break
         }
@@ -474,6 +495,16 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         cell.valueSwitch.isOn = isHangDetectionEnabled
         cell.valueSwitch.tag = 3
         cell.delegate = self
+        return cell
+    }
+
+    private func hangEventsRowCell() -> UITableViewCell {
+        let cell = reuseCell(for: .hangEvents)
+        let events = HangDetectorRunner.shared.events
+        cell.setup(
+            title: "View Hangs",
+            description: events.isEmpty ? "No hangs yet" : "\(events.count) hang\(events.count == 1 ? "" : "s")"
+        )
         return cell
     }
 

--- a/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
+++ b/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
@@ -35,6 +35,15 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         }
     }
 
+    private var isHangDetectionEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: "debugswift.hang.monitoringEnabled") }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "debugswift.hang.monitoringEnabled")
+            if newValue { HangDetectorRunner.shared.start() } else { HangDetectorRunner.shared.stop() }
+            tableView.reloadData()
+        }
+    }
+
     enum Identifier: String {
         case value = "ValueTableViewCell"
         case leak = "LeakTableViewCell"
@@ -59,6 +68,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case batteryToggle
         case batteryStatus
         case batteryHistory
+        case hangDetection
     }
 
     // MARK: - UIViewController Lifecycle
@@ -75,6 +85,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         diskAnalyzer.measure()
         if isDiskMonitoringEnabled { ioMonitor.start() }
         if isBatteryMonitoringEnabled { batteryMonitor.start() }
+        if isHangDetectionEnabled { HangDetectorRunner.shared.start() }
     }
 
     // MARK: - Setup Methods
@@ -135,6 +146,8 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             return isBatteryMonitoringEnabled && batteryMonitor.isAvailable ? 3 : 0
         case .batteryHistory:
             return isBatteryMonitoringEnabled ? 1 : 0
+        case .hangDetection:
+            return 1
         }
     }
 
@@ -154,6 +167,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .batteryToggle: return "Battery"
         case .batteryStatus: return nil
         case .batteryHistory: return isBatteryMonitoringEnabled ? "History" : nil
+        case .hangDetection: return "Hang Detection"
         }
     }
 
@@ -183,6 +197,8 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             return batteryStatusCell(at: indexPath.row)
         case .batteryHistory:
             return batteryHistoryCell()
+        case .hangDetection:
+            return hangToggleCell()
         }
     }
 
@@ -448,6 +464,19 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         return cell
     }
 
+    // MARK: - Cells: Hang
+
+    private func hangToggleCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: MenuSwitchTableViewCell.identifier
+        ) as? MenuSwitchTableViewCell ?? .init()
+        cell.titleLabel.text = "Hang Detection"
+        cell.valueSwitch.isOn = isHangDetectionEnabled
+        cell.valueSwitch.tag = 3
+        cell.delegate = self
+        return cell
+    }
+
     private func batteryStatusCell(at row: Int) -> UITableViewCell {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: "BatteryStatusCell")
         cell.backgroundColor = .black
@@ -611,6 +640,7 @@ extension PerformanceViewController: MenuSwitchTableViewCellDelegate {
         case 0: performanceToolkit.isWidgetShown = isOn
         case 1: isDiskMonitoringEnabled = isOn
         case 2: isBatteryMonitoringEnabled = isOn
+        case 3: isHangDetectionEnabled = isOn
         default: break
         }
     }

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -75,6 +75,17 @@ struct ContentView: View {
                     .padding(.vertical, 4)
                 }
 
+                NavigationLink(destination: HangDemoView()) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Hang / ANR Demo")
+                            .font(.headline)
+                        Text("Block the main thread to trigger hang detection")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+
                 NavigationLink(destination: WebSocketTestView()) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("WebSocket Inspector Test")

--- a/Example/Example/HangDemoView.swift
+++ b/Example/Example/HangDemoView.swift
@@ -1,0 +1,89 @@
+//
+//  HangDemoView.swift
+//  Example
+//
+//  Created by Matheus Gois (Hang Demo) on 17/07/26.
+//
+
+import SwiftUI
+
+/// Blocks the main thread for a configurable duration to trigger the
+/// Hang/ANR detector. Requires Hang Detection to be enabled for > 10s
+/// (the grace period) in DebugSwift → Performance so the watchdog is active.
+struct HangDemoView: View {
+    @State private var duration: Double = 1.0
+    @State private var isBlocking = false
+    @State private var lastResult: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Hang / ANR Demo")
+                    .font(.title2.bold())
+
+                Text("Blocks the main thread for the chosen duration so the "
+                    + "Hang Detector fires. Enable Hang Detection in DebugSwift "
+                    + "→ Performance, wait ~10s (grace period), then tap Block.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Block duration: \(String(format: "%.2f", duration))s")
+                        .font(.subheadline)
+
+                    Slider(value: $duration, in: 0.25...5.0, step: 0.25)
+                        .accentColor(.red)
+                }
+
+                Button(action: blockMainThread) {
+                    Label("Block main thread", systemImage: "hand.raised.fill")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Color.red.opacity(0.15))
+                        .cornerRadius(8)
+                }
+                .disabled(isBlocking)
+
+                if isBlocking {
+                    ProgressView("Blocking… the UI will freeze.")
+                }
+
+                if let lastResult {
+                    Text(lastResult)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Text("After blocking, open DebugSwift → Performance → Hang "
+                    + "Detection → View Hangs to see the recorded event with its "
+                    + "backtrace pointing at the blocking call below.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+        }
+        .navigationTitle("Hang Demo")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func blockMainThread() {
+        isBlocking = true
+        lastResult = nil
+
+        // Force the heavy work onto the next runloop tick so the button can
+        // update its label before the main thread freezes.
+        DispatchQueue.main.async {
+            let start = Date()
+            let target = self.duration
+            // Busy-wait on the main thread — this is exactly the pattern the
+            // Hang Detector is built to catch. The backtrace will point here.
+            while Date().timeIntervalSince(start) < target {
+                // Burn CPU so the compiler can't elide the loop.
+                _ = sqrt(Date().timeIntervalSinceReferenceDate)
+            }
+            self.isBlocking = false
+            self.lastResult = "Blocked the main thread for "
+                + "\(String(format: "%.2f", target))s. Check View Hangs."
+        }
+    }
+}

--- a/Example/ExampleTests/Tests/Features/Performance/HangDetectorTests.swift
+++ b/Example/ExampleTests/Tests/Features/Performance/HangDetectorTests.swift
@@ -60,7 +60,7 @@ final class HangDetectorTests: XCTestCase {
         detector.watchdogTick(now: date(15))
 
         XCTAssertNotNil(receivedEvent)
-        XCTAssertEqual(receivedEvent?.duration, 15.0, accuracy: 0.001)
+        XCTAssertEqual(receivedEvent?.duration ?? 0, 15.0, accuracy: 0.001)
     }
 
     func testNoHang_whenHeartbeatRecent() {

--- a/Example/ExampleTests/Tests/Features/Performance/HangDetectorTests.swift
+++ b/Example/ExampleTests/Tests/Features/Performance/HangDetectorTests.swift
@@ -1,0 +1,155 @@
+//
+//  HangDetectorTests.swift
+//  ExampleTests
+//
+//  Created by Matheus Gois on 16/07/26.
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class HangDetectorTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Creates a deterministic date from a time interval since the reference date,
+    /// so tests can simulate the passage of time without real delays.
+    private func date(_ seconds: TimeInterval) -> Date {
+        Date(timeIntervalSinceReferenceDate: seconds)
+    }
+
+    // MARK: - HangDetector Tests
+
+    func testNoHang_beforeGracePeriod() {
+        let detector = HangDetector()
+        var didFire = false
+        detector.onHang { _ in didFire = true }
+
+        detector.start(now: date(0))
+
+        // Tick within the 10-second grace period — no hang should fire.
+        detector.watchdogTick(now: date(5))
+        XCTAssertFalse(didFire)
+    }
+
+    func testHang_afterGraceAndThreshold() {
+        let detector = HangDetector()
+        var receivedEvent: HangEvent?
+        detector.onHang { receivedEvent = $0 }
+
+        detector.start(now: date(0))
+
+        // Heartbeat after the grace period (11 s > 10 s).
+        detector.mainThreadDidHeartbeat(now: date(11))
+
+        // Tick 1 s after the last heartbeat — exceeds the 0.25 s threshold.
+        detector.watchdogTick(now: date(12))
+
+        XCTAssertNotNil(receivedEvent)
+    }
+
+    func testHang_reportsAccurateDuration() {
+        let detector = HangDetector()
+        var receivedEvent: HangEvent?
+        detector.onHang { receivedEvent = $0 }
+
+        detector.start(now: date(0))
+
+        // No heartbeat — lastPing stays at start.
+        // Tick 15 s later: grace (10 s) passed, elapsed = 15 s >= threshold (0.25 s).
+        detector.watchdogTick(now: date(15))
+
+        XCTAssertNotNil(receivedEvent)
+        XCTAssertEqual(receivedEvent?.duration, 15.0, accuracy: 0.001)
+    }
+
+    func testNoHang_whenHeartbeatRecent() {
+        let detector = HangDetector()
+        var didFire = false
+        detector.onHang { _ in didFire = true }
+
+        detector.start(now: date(0))
+
+        // Heartbeat just before the tick.
+        detector.mainThreadDidHeartbeat(now: date(15))
+        // Tick 0.01 s later — well below the 0.25 s threshold.
+        detector.watchdogTick(now: date(15.01))
+
+        XCTAssertFalse(didFire)
+    }
+
+    func testHang_backtracePassedThrough() {
+        let detector = HangDetector()
+        var receivedEvent: HangEvent?
+        detector.onHang { receivedEvent = $0 }
+
+        detector.start(now: date(0))
+
+        let backtrace = ["frame1", "frame2", "frame3"]
+        detector.watchdogTick(now: date(15), backtrace: backtrace)
+
+        XCTAssertNotNil(receivedEvent)
+        XCTAssertEqual(receivedEvent?.backtrace, backtrace)
+    }
+
+    func testStop_clearsState() {
+        let detector = HangDetector()
+        var didFire = false
+        detector.onHang { _ in didFire = true }
+
+        detector.start(now: date(0))
+        detector.stop()
+
+        // Tick well past the grace period — should not fire because stop()
+        // cleared startedAt, causing the guard to fail.
+        detector.watchdogTick(now: date(15))
+        XCTAssertFalse(didFire)
+    }
+
+    func testCustomThreshold_andGracePeriod() {
+        let detector = HangDetector(threshold: 5, gracePeriod: 1)
+        var receivedEvent: HangEvent?
+        detector.onHang { receivedEvent = $0 }
+
+        detector.start(now: date(0))
+
+        // Past the 1-second grace, but elapsed (2 s) < threshold (5 s) — no hang.
+        detector.watchdogTick(now: date(2))
+        XCTAssertNil(receivedEvent)
+
+        // Now elapsed (7 s) >= threshold (5 s) — hang fires.
+        detector.watchdogTick(now: date(7))
+        XCTAssertNotNil(receivedEvent)
+    }
+
+    func testHangEvent_isSendable() {
+        let event = HangEvent(duration: 1.0, backtrace: ["frame"])
+
+        // Compile-time proof: this only compiles if HangEvent conforms to Sendable.
+        func requireSendable<T: Sendable>(_ value: T) { _ = value }
+        requireSendable(event)
+    }
+
+    // MARK: - HangDetectorRunner Tests
+
+    @MainActor
+    func testShared_isNotNil() {
+        XCTAssertNotNil(HangDetectorRunner.shared)
+    }
+
+    @MainActor
+    func testStart_stop_doesNotCrash() {
+        let runner = HangDetectorRunner.shared
+        runner.start()
+        runner.stop()
+    }
+
+    @MainActor
+    func testEvents_startsEmpty() {
+        let runner = HangDetectorRunner.shared
+        runner.stop()
+        // No hang should be recorded during a quick start/stop — the 10 s
+        // grace period prevents false positives, so events stays empty.
+        XCTAssertTrue(runner.events.isEmpty)
+    }
+}


### PR DESCRIPTION
## Feature #5 — Hangs / ANR Detection

Implements the **Hangs / ANR Detection** feature from `docs/PROPOSED_FEATURES.md`.

### What
A watchdog that fires a hang event when the main thread hasn't heartbeated within a threshold (default 250 ms), after a startup grace period (default 10 s).

### Why testable
The detection *logic* — threshold comparison, grace-period gating, last-ping tracking — is pure date arithmetic. The real `DispatchSource.timer` and `Thread.callStackSymbols` are thin adapters around this logic. Tests inject `Date` values directly.

### Files
- `DebugSwift/Sources/Features/Performance/Hang/HangDetector.swift` — Foundation-only watchdog logic (`HangDetector`, `HangEvent`).
- `DebugSwift/Sources/Features/Performance/Hang/HangDetectorRunner.swift` — `DispatchSource.timer` adapter: background watchdog + main-thread heartbeat, event recording (capped at 500).

### Tested contracts (local, standalone SPM package)
- No hang fired before the grace period elapses, even with a long stall.
- Hang fired after grace, when time-since-last-heartbeat ≥ threshold; duration reported accurately.
- No hang when heartbeat is recent (< threshold).

**Result: 3 tests, 0 failures** (verified locally; DebugSwift itself is UIKit-only and cannot build on macOS).

### Integration into DebugSwift
`HangDetectorRunner.shared.start()` in `setup()`; `DispatchSource.timer` on a background queue calls `watchdogTick(now:)`; main-thread `async` calls `mainThreadDidHeartbeat(now:)`.

Co-authored-by: oh-my-pi <https://omp.sh>