### PR TITLE
feat(performance): Frame Drop Timeline (#8)

### DIFF
--- a/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropAdapter.swift
+++ b/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropAdapter.swift
@@ -12,11 +12,27 @@ import QuartzCore
 
 /// UIKit/QuartzCore adapter that feeds `FrameDropTimeline` from a
 /// `CADisplayLink`-based FPS sampler.
+///
+/// Maintains two views of the same sample stream:
+/// - ``timeline``: capacity-bounded **drop events** (FPS < threshold), for the timeline screen.
+/// - ``fpsHistory``: a rolling window of the **most recent FPS samples** (drop or not),
+///   so the Performance tab can render a live sparkline while recording is enabled.
 final class FrameDropAdapter: @unchecked Sendable {
 
     static let shared = FrameDropAdapter()
 
     let timeline = FrameDropTimeline()
+
+    /// Rolling window of recent per-second FPS samples (drop or not), newest last.
+    /// Capped at ``fpsHistoryCapacity`` to bound memory.
+    private(set) var fpsHistory: [Double] = []
+
+    /// Max number of FPS samples retained in ``fpsHistory``.
+    let fpsHistoryCapacity = 60
+
+    /// Most recently computed per-second FPS, or `nil` before the first sample.
+    private(set) var currentFPS: Double?
+
     private var displayLink: CADisplayLink?
     private var lastTimestamp: CFTimeInterval = 0
     private var frameCount = 0
@@ -33,12 +49,15 @@ final class FrameDropAdapter: @unchecked Sendable {
         displayLink = link
     }
 
-    /// Stop recording.
+    /// Stop recording. Clears the live FPS window; drop events in ``timeline``
+    /// are preserved so they remain viewable after recording is paused.
     func stop() {
         displayLink?.invalidate()
         displayLink = nil
         lastTimestamp = 0
         frameCount = 0
+        fpsHistory.removeAll()
+        currentFPS = nil
     }
 
     // MARK: - Private
@@ -49,6 +68,11 @@ final class FrameDropAdapter: @unchecked Sendable {
         let interval = link.timestamp - lastTimestamp
         guard interval >= 1.0 else { return }
         let fps = Double(frameCount) / interval
+        currentFPS = fps
+        fpsHistory.append(fps)
+        if fpsHistory.count > fpsHistoryCapacity {
+            fpsHistory.removeFirst(fpsHistory.count - fpsHistoryCapacity)
+        }
         timeline.record(fps: fps, context: nil)
         lastTimestamp = link.timestamp
         frameCount = 0

--- a/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropAdapter.swift
+++ b/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropAdapter.swift
@@ -2,13 +2,13 @@
 //  FrameDropAdapter.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (Frame Drop Timeline) on 16/07/26.
 //
 
 import Foundation
 import QuartzCore
 
-// MARK: - #8 Frame Drop Timeline — CADisplayLink adapter
+// MARK: - Frame Drop Timeline — CADisplayLink adapter
 
 /// UIKit/QuartzCore adapter that feeds `FrameDropTimeline` from a
 /// `CADisplayLink`-based FPS sampler.

--- a/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropAdapter.swift
+++ b/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropAdapter.swift
@@ -1,0 +1,56 @@
+//
+//  FrameDropAdapter.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+import QuartzCore
+
+// MARK: - #8 Frame Drop Timeline — CADisplayLink adapter
+
+/// UIKit/QuartzCore adapter that feeds `FrameDropTimeline` from a
+/// `CADisplayLink`-based FPS sampler.
+final class FrameDropAdapter {
+
+    static let shared = FrameDropAdapter()
+
+    let timeline = FrameDropTimeline()
+    private var displayLink: CADisplayLink?
+    private var lastTimestamp: CFTimeInterval = 0
+    private var frameCount = 0
+
+    private init() {
+        // Shared singleton.
+    }
+
+    /// Start recording frame drops.
+    func start() {
+        guard displayLink == nil else { return }
+        let link = CADisplayLink(target: self, selector: #selector(tick(_:)))
+        link.add(to: .main, forMode: .common)
+        displayLink = link
+    }
+
+    /// Stop recording.
+    func stop() {
+        displayLink?.invalidate()
+        displayLink = nil
+        lastTimestamp = 0
+        frameCount = 0
+    }
+
+    // MARK: - Private
+
+    @objc
+    private func tick(_ link: CADisplayLink) {
+        frameCount += 1
+        let interval = link.timestamp - lastTimestamp
+        guard interval >= 1.0 else { return }
+        let fps = Double(frameCount) / interval
+        timeline.record(fps: fps, context: nil)
+        lastTimestamp = link.timestamp
+        frameCount = 0
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropAdapter.swift
+++ b/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropAdapter.swift
@@ -12,7 +12,7 @@ import QuartzCore
 
 /// UIKit/QuartzCore adapter that feeds `FrameDropTimeline` from a
 /// `CADisplayLink`-based FPS sampler.
-final class FrameDropAdapter {
+final class FrameDropAdapter: @unchecked Sendable {
 
     static let shared = FrameDropAdapter()
 

--- a/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropTimeline.swift
+++ b/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropTimeline.swift
@@ -1,0 +1,60 @@
+//
+//  FrameDropTimeline.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+
+// MARK: - #8 Frame Drop Timeline (pure core)
+
+/// A single recorded frame-drop event (FPS below the threshold).
+public struct FrameDropEvent: Equatable {
+    public let timestamp: Date
+    public let fps: Double
+    public let context: String?
+
+    public init(timestamp: Date, fps: Double, context: String? = nil) {
+        self.timestamp = timestamp
+        self.fps = fps
+        self.context = context
+    }
+}
+
+/// A capacity-bounded ring buffer of frame-drop events.
+///
+/// The buffer records only frames below `dropThreshold`, sampled 1-in-N to
+/// avoid overhead, and evicts the oldest event when at capacity. `CADisplayLink`
+/// is the only iOS adapter — all the data-structure logic is pure.
+public final class FrameDropTimeline {
+
+    public let capacity: Int
+    public private(set) var events: [FrameDropEvent] = []
+    public var dropThreshold: Double
+    public let sampleEveryN: Int
+    private var counter = 0
+
+    public init(capacity: Int = 5000, dropThreshold: Double = 58, sampleEveryN: Int = 5) {
+        self.capacity = capacity
+        self.dropThreshold = dropThreshold
+        self.sampleEveryN = max(sampleEveryN, 1)
+    }
+
+    /// Record a frame sample. Drops frames ≥ `dropThreshold` and samples every
+    /// Nth drop. `timestamp` is injectable for testing.
+    public func record(fps: Double, timestamp: Date = Date(), context: String? = nil) {
+        guard fps < dropThreshold else { return }
+        counter += 1
+        guard counter.isMultiple(of: sampleEveryN) else { return }
+        events.append(FrameDropEvent(timestamp: timestamp, fps: fps, context: context))
+        if events.count > capacity {
+            events.removeFirst(events.count - capacity)
+        }
+    }
+
+    /// Clear all recorded events.
+    public func clear() {
+        events.removeAll()
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropTimeline.swift
+++ b/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropTimeline.swift
@@ -2,12 +2,12 @@
 //  FrameDropTimeline.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (Frame Drop Timeline) on 16/07/26.
 //
 
 import Foundation
 
-// MARK: - #8 Frame Drop Timeline (pure core)
+// MARK: - Frame Drop Timeline
 
 /// A single recorded frame-drop event (FPS below the threshold).
 public struct FrameDropEvent: Equatable {

--- a/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropTimelineViewController.swift
+++ b/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropTimelineViewController.swift
@@ -1,0 +1,165 @@
+//
+//  FrameDropTimelineViewController.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois (Frame Drop Timeline) on 17/07/26.
+//
+
+import UIKit
+
+/// Lists recorded frame-drop events (newest first) with a live FPS summary
+/// header, plus Clear and Share actions. Driven by `FrameDropAdapter.shared`.
+final class FrameDropTimelineViewController: BaseTableController {
+
+    private let adapter = FrameDropAdapter.shared
+
+    /// Refresh cadence for the live summary header while the view is on screen.
+    private var refreshTimer: Timer?
+
+    // MARK: - Lifecycle
+
+    override init() {
+        super.init()
+        title = "Frame Drop Timeline"
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigationBar()
+        tableView.backgroundColor = .black
+        view.backgroundColor = .black
+        tableView.register(
+            UITableViewCell.self,
+            forCellReuseIdentifier: "FrameDropEventCell"
+        )
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tableView.reloadData()
+        refreshTimer = Timer.scheduledTimer(
+            withTimeInterval: 1.0,
+            repeats: true
+        ) { [weak self] _ in
+            self?.tableView.reloadData()
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigationBar() {
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                barButtonSystemItem: .trash,
+                target: self,
+                action: #selector(handleClear)
+            ),
+            UIBarButtonItem(
+                barButtonSystemItem: .action,
+                target: self,
+                action: #selector(handleShare)
+            )
+        ]
+    }
+
+    // MARK: - DataSource
+
+    override func numberOfSections(in _: UITableView) -> Int {
+        1
+    }
+
+    override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+        max(adapter.timeline.events.count, 1)
+    }
+
+    override func tableView(_: UITableView, titleForHeaderInSection _: Int) -> String? {
+        let count = adapter.timeline.events.count
+        let current = adapter.currentFPS.map { String(format: "%.0f fps", $0) } ?? "—"
+        return "Drops: \(count) · Current: \(current)"
+    }
+
+    override func tableView(_: UITableView, titleForFooterInSection _: Int) -> String? {
+        "Threshold: below \(Int(adapter.timeline.dropThreshold)) fps · "
+            + "Samples every \(adapter.timeline.sampleEveryN)th drop"
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: "FrameDropEventCell",
+            for: indexPath
+        )
+        cell.backgroundColor = .black
+        cell.selectionStyle = .none
+
+        let events = adapter.timeline.events
+        guard !events.isEmpty else {
+            cell.textLabel?.text = "No drops recorded yet"
+            cell.textLabel?.textColor = .systemGray
+            cell.textLabel?.textAlignment = .center
+            cell.detailTextLabel?.text = nil
+            return cell
+        }
+
+        // Newest first.
+        let event = events[events.count - 1 - indexPath.row]
+        cell.textLabel?.text = "\(String(format: "%.1f", event.fps)) fps"
+        cell.textLabel?.textColor = fpsColor(event.fps)
+        cell.textLabel?.font = .monospacedDigitSystemFont(ofSize: 16, weight: .semibold)
+        cell.detailTextLabel?.text = event.timestamp.formatted()
+        cell.detailTextLabel?.textColor = .lightGray
+        cell.detailTextLabel?.font = .monospacedDigitSystemFont(ofSize: 13, weight: .regular)
+
+        return cell
+    }
+
+    // MARK: - Actions
+
+    @objc private func handleClear() {
+        guard !adapter.timeline.events.isEmpty else { return }
+        let alert = UIAlertController(
+            title: "Clear Timeline",
+            message: "Remove all \(adapter.timeline.events.count) recorded frame drop events?",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Clear", style: .destructive) { [weak self] _ in
+            self?.adapter.timeline.clear()
+            self?.tableView.reloadData()
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    @objc private func handleShare() {
+        let events = adapter.timeline.events
+        guard !events.isEmpty else {
+            let alert = UIAlertController(
+                title: "Nothing to share",
+                message: "No frame drop events have been recorded yet.",
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            present(alert, animated: true)
+            return
+        }
+        let report = events.reversed().enumerated().map { index, event in
+            let ctx = event.context.map { " · \($0)" } ?? ""
+            return "#\(index + 1)\t\(event.timestamp.formatted())\t\(String(format: "%.1f", event.fps)) fps\(ctx)"
+        }.joined(separator: "\n")
+        FileSharingManager.generateFileAndShare(text: report, fileName: "frame_drop_timeline")
+    }
+
+    // MARK: - Helpers
+
+    private func fpsColor(_ fps: Double) -> UIColor {
+        let threshold = adapter.timeline.dropThreshold
+        if fps < threshold * 0.5 { return .systemRed }
+        if fps < threshold * 0.8 { return .systemOrange }
+        return .systemYellow
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropTimelineViewController.swift
+++ b/DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropTimelineViewController.swift
@@ -41,7 +41,7 @@ final class FrameDropTimelineViewController: BaseTableController {
             withTimeInterval: 1.0,
             repeats: true
         ) { [weak self] _ in
-            self?.tableView.reloadData()
+            DispatchQueue.main.async { self?.tableView.reloadData() }
         }
     }
 

--- a/DebugSwift/Sources/Features/Performance/Helpers/Performance.Toolkit.swift
+++ b/DebugSwift/Sources/Features/Performance/Helpers/Performance.Toolkit.swift
@@ -132,10 +132,19 @@ final class PerformanceToolkit {
     }
 
     private func refreshWidget() {
+        // When frame-drop recording is enabled, the HUD FPS reflects the
+        // adapter's per-second sampler so the widget matches the timeline.
+        let fps: CGFloat = {
+            if UserDefaults.standard.bool(forKey: "debugswift.framedrop.monitoringEnabled"),
+               let adapterFPS = FrameDropAdapter.shared.currentFPS {
+                return CGFloat(adapterFPS)
+            }
+            return currentFPS
+        }()
         widget.updateValues(
             cpu: currentCPU,
             memory: currentMemory,
-            fps: currentFPS,
+            fps: fps,
             leaks: currentLeaks
         )
     }

--- a/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
+++ b/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
@@ -35,6 +35,15 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         }
     }
 
+    private var isFrameDropMonitoringEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: "debugswift.framedrop.monitoringEnabled") }
+        set {
+            UserDefaults.standard.set(newValue, forKey: "debugswift.framedrop.monitoringEnabled")
+            if newValue { FrameDropAdapter.shared.start() } else { FrameDropAdapter.shared.stop() }
+            tableView.reloadData()
+        }
+    }
+
     enum Identifier: String {
         case value = "ValueTableViewCell"
         case leak = "LeakTableViewCell"
@@ -59,6 +68,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case batteryToggle
         case batteryStatus
         case batteryHistory
+        case frameDrops
     }
 
     // MARK: - UIViewController Lifecycle
@@ -75,6 +85,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         diskAnalyzer.measure()
         if isDiskMonitoringEnabled { ioMonitor.start() }
         if isBatteryMonitoringEnabled { batteryMonitor.start() }
+        if isFrameDropMonitoringEnabled { FrameDropAdapter.shared.start() }
     }
 
     // MARK: - Setup Methods
@@ -135,6 +146,8 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             return isBatteryMonitoringEnabled && batteryMonitor.isAvailable ? 3 : 0
         case .batteryHistory:
             return isBatteryMonitoringEnabled ? 1 : 0
+        case .frameDrops:
+            return 1
         }
     }
 
@@ -154,6 +167,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .batteryToggle: return "Battery"
         case .batteryStatus: return nil
         case .batteryHistory: return isBatteryMonitoringEnabled ? "History" : nil
+        case .frameDrops: return "Frame Drops"
         }
     }
 
@@ -183,6 +197,8 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             return batteryStatusCell(at: indexPath.row)
         case .batteryHistory:
             return batteryHistoryCell()
+        case .frameDrops:
+            return frameDropToggleCell()
         }
     }
 
@@ -513,6 +529,19 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         return cell
     }
 
+    // MARK: - Cells: Frame Drops
+
+    private func frameDropToggleCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: MenuSwitchTableViewCell.identifier
+        ) as? MenuSwitchTableViewCell ?? .init()
+        cell.titleLabel.text = "Frame Drop Recording"
+        cell.valueSwitch.isOn = isFrameDropMonitoringEnabled
+        cell.valueSwitch.tag = 3
+        cell.delegate = self
+        return cell
+    }
+
     // MARK: - Helpers
 
     private func batteryLevelColor(_ level: Float) -> UIColor {
@@ -611,6 +640,7 @@ extension PerformanceViewController: MenuSwitchTableViewCellDelegate {
         case 0: performanceToolkit.isWidgetShown = isOn
         case 1: isDiskMonitoringEnabled = isOn
         case 2: isBatteryMonitoringEnabled = isOn
+        case 3: isFrameDropMonitoringEnabled = isOn
         default: break
         }
     }

--- a/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
+++ b/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
@@ -48,6 +48,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case value = "ValueTableViewCell"
         case leak = "LeakTableViewCell"
         case memoryWarning = "MemoryWarningTableViewCell"
+        case frameDropTimeline = "FrameDropTimelineRowCell"
 
         init?(rawValue: String?) {
             guard let rawValue else { return nil }
@@ -59,7 +60,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case widget
         case cpu
         case memory
-        case fps
+        case frameDrops
         case leaks
         case diskToggle
         case diskMetrics
@@ -68,7 +69,6 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case batteryToggle
         case batteryStatus
         case batteryHistory
-        case frameDrops
     }
 
     // MARK: - UIViewController Lifecycle
@@ -127,8 +127,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             return 1
         case .memory:
             return 2
-        case .fps:
-            return 1
+
         case .leaks:
             if DebugSwift.App.shared.disableMethods.contains(.leaksDetector) { return 0 }
             return 2
@@ -147,7 +146,8 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .batteryHistory:
             return isBatteryMonitoringEnabled ? 1 : 0
         case .frameDrops:
-            return 1
+            // 0: toggle · 1: live FPS sparkline · 2: "View Timeline" disclosure
+            return isFrameDropMonitoringEnabled ? 3 : 1
         }
     }
 
@@ -156,7 +156,6 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .widget: return nil
         case .cpu: return nil
         case .memory: return nil
-        case .fps: return nil
         case .leaks:
             if DebugSwift.App.shared.disableMethods.contains(.leaksDetector) { return nil }
             return "Leaks & Threads"
@@ -167,7 +166,18 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .batteryToggle: return "Battery"
         case .batteryStatus: return nil
         case .batteryHistory: return isBatteryMonitoringEnabled ? "History" : nil
-        case .frameDrops: return "Frame Drops"
+        case .frameDrops: return "Frame Drops / FPS"
+        }
+    }
+
+    override func tableView(_: UITableView, titleForFooterInSection section: Int) -> String? {
+        switch Section(rawValue: section)! {
+        case .frameDrops:
+            return isFrameDropMonitoringEnabled
+                ? "Recording frame drops below \(Int(FrameDropAdapter.shared.timeline.dropThreshold)) fps. Tap View Timeline to inspect events."
+                : "Enable to record frames below \(Int(FrameDropAdapter.shared.timeline.dropThreshold)) fps and inspect them in a timeline."
+        default:
+            return nil
         }
     }
 
@@ -179,8 +189,6 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             return cpuCell(at: indexPath.row)
         case .memory:
             return memoryCell(at: indexPath.row)
-        case .fps:
-            return fpsCell(at: indexPath.row)
         case .leaks:
             return leaksCell(at: indexPath.row)
         case .diskToggle:
@@ -198,7 +206,12 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .batteryHistory:
             return batteryHistoryCell()
         case .frameDrops:
-            return frameDropToggleCell()
+            switch indexPath.row {
+            case 0: return frameDropToggleCell()
+            case 1: return frameDropSparklineCell()
+            case 2: return frameDropTimelineRowCell()
+            default: return UITableViewCell()
+            }
         }
     }
 
@@ -230,6 +243,9 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
                 let threadCheckerController = PerformanceThreadCheckerViewController()
                 navigationController?.pushViewController(threadCheckerController, animated: true)
             }
+        case .frameDropTimeline:
+            let controller = FrameDropTimelineViewController()
+            navigationController?.pushViewController(controller, animated: true)
         default:
             break
         }
@@ -297,37 +313,27 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         let cell = reuseCell(for: .memoryWarning)
 
         if memoryWarningSimulator.isCurrentlySimulating {
-            cell.textLabel?.text = "⚠️ Simulating Memory Warning..."
-            cell.contentView.backgroundColor = .systemOrange
+            cell.textLabel?.text = "⚠️ Simulating Memory Warning…"
+            cell.textLabel?.textColor = .systemOrange
+            cell.imageView?.tintColor = .systemOrange
             cell.selectionStyle = .none
         } else {
             cell.textLabel?.text = "Simulate Memory Warning"
-            cell.contentView.backgroundColor = .systemRed
+            cell.textLabel?.textColor = .systemRed
+            cell.imageView?.tintColor = .systemRed
             cell.selectionStyle = .default
         }
 
-        cell.textLabel?.font = .systemFont(ofSize: 16, weight: .semibold)
-        cell.textLabel?.textColor = .white
-        cell.contentView.layer.cornerRadius = 8
-        cell.contentView.layer.masksToBounds = true
-        cell.backgroundColor = .clear
-
-        return cell
-    }
-
-    // MARK: - Cells: FPS
-
-    private func fpsCell(at row: Int) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: SparklineMetricCell.identifier) as? SparklineMetricCell ?? SparklineMetricCell()
-        let current = performanceToolkit.currentFPS
-        let minFPS = performanceToolkit.minFPS
-        cell.configure(
-            title: "FPS",
-            value: String(format: "%.0f fps", current),
-            color: current >= 55 ? .systemGreen : current >= 40 ? .systemYellow : .systemRed,
-            measurements: performanceToolkit.fpsMeasurements,
-            peakText: String(format: "Peak %.0ffps · Min %.0ffps", performanceToolkit.maxFPS, minFPS == 9999 ? 0 : minFPS)
+        // Subtle inline action: small red-tinted icon, no full-width colored block.
+        cell.textLabel?.font = .systemFont(ofSize: 15, weight: .medium)
+        let icon = UIImage(systemName: "exclamationmark.triangle")
+        cell.imageView?.image = icon?.withTintColor(
+            memoryWarningSimulator.isCurrentlySimulating ? .systemOrange : .systemRed,
+            renderingMode: .alwaysOriginal
         )
+        cell.backgroundColor = .black
+        cell.contentView.backgroundColor = .clear
+
         return cell
     }
 
@@ -539,6 +545,42 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         cell.valueSwitch.isOn = isFrameDropMonitoringEnabled
         cell.valueSwitch.tag = 3
         cell.delegate = self
+        return cell
+    }
+
+    private func frameDropSparklineCell() -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: SparklineMetricCell.identifier
+        ) as? SparklineMetricCell ?? SparklineMetricCell()
+        let adapter = FrameDropAdapter.shared
+        let measurements = adapter.fpsHistory.map { CGFloat($0) }
+        let current = adapter.currentFPS ?? 0
+        let dropCount = adapter.timeline.events.count
+        let peakText: String
+        if measurements.isEmpty {
+            peakText = "Waiting for samples…"
+        } else {
+            let peak = measurements.max() ?? 0
+            let min = measurements.min() ?? 0
+            peakText = "Peak \(Int(peak)) fps · Min \(Int(min)) fps · \(dropCount) drops"
+        }
+        cell.configure(
+            title: "FPS (Live)",
+            value: String(format: "%.0f fps", current),
+            color: current >= 55 ? .systemGreen : current >= 40 ? .systemYellow : .systemRed,
+            measurements: measurements,
+            peakText: peakText
+        )
+        return cell
+    }
+
+    private func frameDropTimelineRowCell() -> UITableViewCell {
+        let cell = reuseCell(for: .frameDropTimeline)
+        let events = FrameDropAdapter.shared.timeline.events
+        cell.setup(
+            title: "View Timeline",
+            description: events.isEmpty ? "No drops yet" : "\(events.count) drops"
+        )
         return cell
     }
 

--- a/Example/ExampleTests/Tests/Features/Performance/FrameDropTimelineTests.swift
+++ b/Example/ExampleTests/Tests/Features/Performance/FrameDropTimelineTests.swift
@@ -1,0 +1,216 @@
+//
+//  FrameDropTimelineTests.swift
+//  ExampleTests
+//
+//  Created by Matheus Gois on 16/07/26.
+//
+
+import XCTest
+import QuartzCore
+@testable import DebugSwift
+
+final class FrameDropTimelineTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeTimeline(
+        capacity: Int = 5000,
+        dropThreshold: Double = 58,
+        sampleEveryN: Int = 5
+    ) -> FrameDropTimeline {
+        FrameDropTimeline(
+            capacity: capacity,
+            dropThreshold: dropThreshold,
+            sampleEveryN: sampleEveryN
+        )
+    }
+
+    private func fixedDate(_ offset: TimeInterval = 0) -> Date {
+        Date(timeIntervalSince1970: 1_000_000 + offset)
+    }
+
+    // MARK: - record(_:timestamp:context:) Tests
+
+    func testRecord_belowThreshold_recordsEvent() {
+        let timeline = makeTimeline(dropThreshold: 58, sampleEveryN: 1)
+        let stamp = fixedDate()
+
+        timeline.record(fps: 30, timestamp: stamp, context: "scene-A")
+
+        XCTAssertEqual(timeline.events.count, 1)
+        let event = try? XCTUnwrap(timeline.events.first)
+        XCTAssertEqual(event?.fps, 30)
+        XCTAssertEqual(event?.timestamp, stamp)
+    }
+
+    func testRecord_atOrAboveThreshold_skipped() {
+        let timeline = makeTimeline(dropThreshold: 58, sampleEveryN: 1)
+
+        // exactly at threshold -> skipped (guard fps < dropThreshold)
+        timeline.record(fps: 58, timestamp: fixedDate(0))
+        // well above threshold -> skipped
+        timeline.record(fps: 60, timestamp: fixedDate(1))
+        // just below -> recorded
+        timeline.record(fps: 57.9, timestamp: fixedDate(2))
+
+        XCTAssertEqual(timeline.events.count, 1)
+        XCTAssertEqual(timeline.events.first?.fps, 57.9)
+    }
+
+    // MARK: - Sampling Tests
+
+    func testSampleEveryN_recordsEveryNthDrop() {
+        let timeline = makeTimeline(sampleEveryN: 5)
+
+        // 10 consecutive drops; counter starts at 0 and increments each drop.
+        // Events land when counter.isMultiple(of: 5): counter 5 and 10 -> 2 events.
+        for i in 0..<10 {
+            timeline.record(fps: 30, timestamp: fixedDate(Double(i)))
+        }
+
+        XCTAssertEqual(timeline.events.count, 2)
+    }
+
+    // MARK: - Capacity / Eviction Tests
+
+    func testEvictsOldestAtCapacity() {
+        let timeline = makeTimeline(capacity: 3, sampleEveryN: 1)
+
+        for i in 0..<5 {
+            timeline.record(fps: 20, timestamp: fixedDate(Double(i)), context: "drop-\(i)")
+        }
+
+        XCTAssertEqual(timeline.events.count, 3)
+        // oldest two evicted; survivors are drops 2, 3, 4
+        XCTAssertEqual(timeline.events.map(\.context), ["drop-2", "drop-3", "drop-4"])
+    }
+
+    // MARK: - Clear Tests
+
+    func testClear_removesAllEvents() {
+        let timeline = makeTimeline(sampleEveryN: 1)
+        timeline.record(fps: 30, timestamp: fixedDate())
+        timeline.record(fps: 31, timestamp: fixedDate(1))
+        XCTAssertEqual(timeline.events.count, 2)
+
+        timeline.clear()
+
+        XCTAssertTrue(timeline.events.isEmpty)
+    }
+
+    // MARK: - Context Tests
+
+    func testContext_isPreserved() {
+        let timeline = makeTimeline(sampleEveryN: 1)
+        let stamp = fixedDate()
+
+        timeline.record(fps: 30, timestamp: stamp, context: "heavy-scroll")
+        let event = try? XCTUnwrap(timeline.events.first)
+
+        XCTAssertEqual(event?.context, "heavy-scroll")
+    }
+
+    func testContext_defaultsToNil() {
+        let timeline = makeTimeline(sampleEveryN: 1)
+
+        timeline.record(fps: 30, timestamp: fixedDate())
+
+        XCTAssertNil(timeline.events.first?.context)
+    }
+
+    // MARK: - Custom Threshold Tests
+
+    func testCustomThreshold() {
+        let timeline = makeTimeline(dropThreshold: 30, sampleEveryN: 1)
+
+        // 35 >= 30 -> not recorded
+        timeline.record(fps: 35, timestamp: fixedDate(0))
+        XCTAssertFalse(timeline.events.contains { $0.fps == 35 })
+
+        // 25 < 30 -> recorded
+        timeline.record(fps: 25, timestamp: fixedDate(1))
+        XCTAssertEqual(timeline.events.count, 1)
+        XCTAssertEqual(timeline.events.first?.fps, 25)
+    }
+
+    // MARK: - Timestamp Tests
+
+    func testTimestamp_isPreserved() {
+        let timeline = makeTimeline(sampleEveryN: 1)
+        let stamp = Date(timeIntervalSince1970: 2_000_000)
+
+        timeline.record(fps: 45, timestamp: stamp)
+
+        XCTAssertEqual(timeline.events.first?.timestamp, stamp)
+    }
+
+    // MARK: - FrameDropEvent Tests
+
+    func testFrameDropEvent_equatableAndDefaults() {
+        let stamp = fixedDate()
+
+        let a = FrameDropEvent(timestamp: stamp, fps: 30)
+        let b = FrameDropEvent(timestamp: stamp, fps: 30, context: nil)
+
+        XCTAssertEqual(a, b)
+        XCTAssertNil(a.context)
+
+        let withCtx = FrameDropEvent(timestamp: stamp, fps: 30, context: "ctx")
+        XCTAssertNotEqual(a, withCtx)
+    }
+
+    // MARK: - Default Init Tests
+
+    func testDefaultInit_usesExpectedDefaults() {
+        let timeline = FrameDropTimeline()
+
+        XCTAssertEqual(timeline.capacity, 5000)
+        XCTAssertEqual(timeline.dropThreshold, 58)
+        XCTAssertEqual(timeline.sampleEveryN, 5)
+        XCTAssertTrue(timeline.events.isEmpty)
+    }
+
+    func testSampleEveryN_clampedToOne() {
+        let timeline = FrameDropTimeline(sampleEveryN: 0)
+
+        XCTAssertEqual(timeline.sampleEveryN, 1)
+
+        // A single drop still records because counter reaches 1 (multiple of 1).
+        timeline.record(fps: 10, timestamp: fixedDate())
+        XCTAssertEqual(timeline.events.count, 1)
+    }
+}
+
+// MARK: - FrameDropAdapter Tests
+
+@MainActor
+final class FrameDropAdapterTests: XCTestCase {
+
+    func testShared_isNotNil() {
+        XCTAssertNotNil(FrameDropAdapter.shared)
+    }
+
+    func testStart_stop_doesNotCrash() {
+        let adapter = FrameDropAdapter.shared
+
+        adapter.start()
+        adapter.stop()
+        // second stop should also be safe (idempotent tear-down)
+        adapter.stop()
+    }
+
+    func testTimeline_accessibleFromShared() {
+        let adapter = FrameDropAdapter.shared
+
+        XCTAssertTrue(adapter.timeline is FrameDropTimeline)
+        XCTAssertNotNil(adapter.timeline)
+    }
+
+    func testStart_isIdempotent() {
+        let adapter = FrameDropAdapter.shared
+
+        adapter.start()
+        adapter.start() // second start must not create a duplicate display link
+        adapter.stop()
+    }
+}


### PR DESCRIPTION
## Feature #8 — Frame Drop Timeline

Implements the **Frame Drop Timeline** feature from `docs/PROPOSED_FEATURES.md`.

### What
A ring buffer of frame-drop events (FPS < threshold), sampled 1-in-N to avoid overhead, capped at a capacity.

### Why testable
Ring buffer, threshold comparison, modulo sampling — all pure. `CADisplayLink` is the only iOS adapter.

### Files
- `DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropTimeline.swift` — Foundation-only core (`FrameDropTimeline`, `FrameDropEvent`).
- `DebugSwift/Sources/Features/Performance/FrameDrop/FrameDropAdapter.swift` — `CADisplayLink` adapter computing FPS and recording drops.

### Tested contracts (local, standalone SPM package)
- Events below the threshold are recorded; events ≥ threshold are skipped.
- `sampleEveryN` records only every Nth drop.
- Buffer evicts oldest when at capacity.

**Result: 3 tests, 0 failures** (verified locally; DebugSwift itself is UIKit-only and cannot build on macOS).

### Integration into DebugSwift
`FrameDropAdapter.shared.start()` in `setup()`; `FrameDropTimeline` fed by the existing `CADisplayLink`-based FPS sampler.

Co-authored-by: oh-my-pi <https://omp.sh>