### PR TITLE
feat(app): Event Timeline (EventBus) (#13)

### DIFF
--- a/DebugSwift/Sources/Features/App/App.Controller.swift
+++ b/DebugSwift/Sources/Features/App/App.Controller.swift
@@ -214,6 +214,9 @@ extension AppViewController: UITableViewDataSource, UITableViewDelegate {
             case .deepLink:
                 let controller = DeepLinkViewController()
                 navigationController?.pushViewController(controller, animated: true)
+            case .eventTimeline:
+                let controller = EventTimelineViewController()
+                navigationController?.pushViewController(controller, animated: true)
             }
         default:
             break
@@ -313,6 +316,7 @@ extension AppViewController {
         case loadedLibraries
         case pushNotifications
         case deepLink
+        case eventTimeline
 
         var title: String {
             switch self {
@@ -330,6 +334,8 @@ extension AppViewController {
                 return "Push Notifications"
             case .deepLink:
                 return "Deep Links"
+            case .eventTimeline:
+                return "Event Timeline"
             }
         }
 

--- a/DebugSwift/Sources/Features/App/EventBus/EventBus.swift
+++ b/DebugSwift/Sources/Features/App/EventBus/EventBus.swift
@@ -2,12 +2,12 @@
 //  EventBus.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (Event Timeline) on 16/07/26.
 //
 
 import Foundation
 
-// MARK: - #13 Event Timeline (EventBus) — pure core
+// MARK: - Event Timeline
 
 /// The debug domain an event belongs to.
 public enum DebugDomain: String, Equatable, CaseIterable {

--- a/DebugSwift/Sources/Features/App/EventBus/EventBus.swift
+++ b/DebugSwift/Sources/Features/App/EventBus/EventBus.swift
@@ -1,0 +1,80 @@
+//
+//  EventBus.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+
+// MARK: - #13 Event Timeline (EventBus) — pure core
+
+/// The debug domain an event belongs to.
+public enum DebugDomain: String, Equatable, CaseIterable {
+    case network
+    case performance
+    case interface
+    case app
+    case resources
+    case security
+}
+
+/// A single debug event collected by the event bus.
+public struct DebugEvent: Equatable {
+    public let id: UUID
+    public let timestamp: Date
+    public let domain: DebugDomain
+    public let summary: String
+
+    public init(id: UUID = UUID(), timestamp: Date, domain: DebugDomain, summary: String) {
+        self.id = id
+        self.timestamp = timestamp
+        self.domain = domain
+        self.summary = summary
+    }
+}
+
+/// A unified, in-memory event bus collecting events from all debug domains
+/// (network, performance, app, etc.) with filtering by domain, text, and
+/// time; capacity-bounded.
+///
+/// The bus is an array of `DebugEvent` structs with append/filter/slice
+/// operations — pure data-structure logic. The `Combine`/UI integration is
+/// a thin subscriber on top (`EventBusSubscriber`).
+public final class EventBus {
+
+    public let capacity: Int
+    public private(set) var events: [DebugEvent] = []
+
+    public init(capacity: Int = 5000) {
+        self.capacity = capacity
+    }
+
+    /// Publish an event, evicting the oldest if at capacity.
+    public func publish(_ event: DebugEvent) {
+        events.append(event)
+        if events.count > capacity {
+            events.removeFirst(events.count - capacity)
+        }
+    }
+
+    /// Filter events by domain.
+    public func filtered(by domain: DebugDomain) -> [DebugEvent] {
+        events.filter { $0.domain == domain }
+    }
+
+    /// Filter events by case-insensitive summary text.
+    public func filtered(by text: String) -> [DebugEvent] {
+        events.filter { $0.summary.localizedCaseInsensitiveContains(text) }
+    }
+
+    /// Events at or after the given date.
+    public func eventsSince(_ date: Date) -> [DebugEvent] {
+        events.filter { $0.timestamp >= date }
+    }
+
+    /// Remove all events.
+    public func clear() {
+        events.removeAll()
+    }
+}

--- a/DebugSwift/Sources/Features/App/EventBus/EventBusSubscriber.swift
+++ b/DebugSwift/Sources/Features/App/EventBus/EventBusSubscriber.swift
@@ -2,12 +2,12 @@
 //  EventBusSubscriber.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (Event Timeline) on 16/07/26.
 //
 
 import Foundation
 
-// MARK: - #13 Event Timeline — Combine-friendly subscriber
+// MARK: - Event Timeline
 
 /// A thin subscriber on top of the pure `EventBus`, exposing a closure-based
 /// notification API that the existing managers (`NetworkMonitor`,

--- a/DebugSwift/Sources/Features/App/EventBus/EventBusSubscriber.swift
+++ b/DebugSwift/Sources/Features/App/EventBus/EventBusSubscriber.swift
@@ -1,0 +1,44 @@
+//
+//  EventBusSubscriber.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+
+// MARK: - #13 Event Timeline — Combine-friendly subscriber
+
+/// A thin subscriber on top of the pure `EventBus`, exposing a closure-based
+/// notification API that the existing managers (`NetworkMonitor`,
+/// `StdoutCapture`, `HangDetector`, etc.) can publish into and that
+/// `EventTimelineViewController` can observe.
+final class EventBusSubscriber {
+
+    static let shared = EventBusSubscriber()
+
+    let bus = EventBus()
+    private var listeners: [(DebugEvent) -> Void] = []
+
+    private init() {
+        // Shared singleton.
+    }
+
+    /// Publish an event and notify all listeners.
+    func publish(_ event: DebugEvent) {
+        bus.publish(event)
+        for listener in listeners {
+            listener(event)
+        }
+    }
+
+    /// Register a listener invoked for every published event.
+    func subscribe(_ listener: @escaping (DebugEvent) -> Void) {
+        listeners.append(listener)
+    }
+
+    /// Remove all listeners.
+    func unsubscribeAll() {
+        listeners.removeAll()
+    }
+}

--- a/DebugSwift/Sources/Features/App/EventBus/EventBusSubscriber.swift
+++ b/DebugSwift/Sources/Features/App/EventBus/EventBusSubscriber.swift
@@ -13,7 +13,7 @@ import Foundation
 /// notification API that the existing managers (`NetworkMonitor`,
 /// `StdoutCapture`, `HangDetector`, etc.) can publish into and that
 /// `EventTimelineViewController` can observe.
-final class EventBusSubscriber {
+final class EventBusSubscriber: @unchecked Sendable {
 
     static let shared = EventBusSubscriber()
 

--- a/DebugSwift/Sources/Features/App/EventBus/EventTimelineViewController.swift
+++ b/DebugSwift/Sources/Features/App/EventBus/EventTimelineViewController.swift
@@ -1,0 +1,222 @@
+//
+//  EventTimelineViewController.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois (Event Timeline) on 16/07/26.
+//
+
+import UIKit
+
+/// Displays the live stream of debug events collected by `EventBusSubscriber`,
+/// with a domain filter and a clear action so the timeline can be inspected
+/// while exercising other debug features.
+final class EventTimelineViewController: BaseTableController {
+
+    // MARK: - Properties
+
+    private let subscriber = EventBusSubscriber.shared
+
+    /// Currently displayed events, kept in sync with the bus and filtered by
+    /// the active segmented-control selection.
+    private var displayedEvents: [DebugEvent] = []
+
+    private lazy var filterControl: UISegmentedControl = {
+        let control = UISegmentedControl(items: Filter.allTitles)
+        control.selectedSegmentIndex = 0
+        control.addTarget(self, action: #selector(filterChanged), for: .valueChanged)
+        return control
+    }()
+
+    private lazy var clearButton: UIBarButtonItem = {
+        UIBarButtonItem(
+            title: "Clear",
+            style: .plain,
+            target: self,
+            action: #selector(clearEvents)
+        )
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+        subscribeToBus()
+        refreshDisplayedEvents()
+    }
+
+    // MARK: - Setup
+
+    private func setup() {
+        title = "Event Timeline"
+        navigationItem.rightBarButtonItem = clearButton
+        navigationItem.titleView = filterControl
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: .cell)
+    }
+
+    /// Reload from the bus on every publish so the timeline stays current
+    /// without a manual refresh while other features publish into the bus.
+    private func subscribeToBus() {
+        subscriber.subscribe { [weak self] _ in
+            DispatchQueue.main.async { self?.refreshDisplayedEvents() }
+        }
+    }
+
+    private func refreshDisplayedEvents() {
+        let all = subscriber.bus.events
+        let selected = Filter(rawValue: filterControl.selectedSegmentIndex) ?? .all
+        displayedEvents = selected.filter(all)
+        tableView.reloadData()
+    }
+
+    // MARK: - Actions
+
+    @objc private func filterChanged() {
+        refreshDisplayedEvents()
+    }
+
+    @objc private func clearEvents() {
+        subscriber.bus.clear()
+        displayedEvents = []
+        tableView.reloadData()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+        displayedEvents.count
+    }
+
+    override func tableView(
+        _ tableView: UITableView,
+        cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: .cell, for: indexPath)
+        let event = displayedEvents[indexPath.row]
+        configure(cell, with: event)
+        return cell
+    }
+
+    // MARK: - UITableViewDelegate
+
+    override func tableView(_: UITableView, heightForRowAt _: IndexPath) -> CGFloat {
+        80.0
+    }
+
+    // MARK: - Cell configuration
+
+    private func configure(_ cell: UITableViewCell, with event: DebugEvent) {
+        let badge = badgeView(for: event.domain)
+        let timeLabel = UILabel()
+        timeLabel.text = formatted(timestamp: event.timestamp)
+        timeLabel.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
+        timeLabel.textColor = .lightGray
+
+        let summaryLabel = UILabel()
+        summaryLabel.text = event.summary
+        summaryLabel.font = .systemFont(ofSize: 15)
+        summaryLabel.textColor = .white
+        summaryLabel.numberOfLines = 0
+
+        let stack = UIStackView(arrangedSubviews: [timeLabel, badge, summaryLabel])
+        stack.axis = .vertical
+        stack.spacing = 4
+        stack.alignment = .leading
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.tag = 111
+
+        cell.contentView.subviews.filter { $0.tag == 111 }.forEach { $0.removeFromSuperview() }
+        cell.contentView.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: cell.contentView.topAnchor, constant: 12),
+            stack.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor, constant: -12),
+            stack.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor, constant: -16),
+        ])
+
+        cell.backgroundColor = .clear
+        cell.selectionStyle = .none
+    }
+
+    /// Compact colored pill identifying the event's domain at a glance.
+    private func badgeView(for domain: DebugDomain) -> UIView {
+        let label = UILabel()
+        label.text = domain.rawValue.capitalized
+        label.font = .systemFont(ofSize: 11, weight: .semibold)
+        label.textColor = .white
+        label.textAlignment = .center
+        label.backgroundColor = color(for: domain).withAlphaComponent(0.25)
+        label.layer.cornerRadius = 4
+        label.layer.masksToBounds = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: container.topAnchor),
+            label.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            label.heightAnchor.constraint(equalToConstant: 18),
+            label.widthAnchor.constraint(greaterThanOrEqualToConstant: 56),
+        ])
+        return container
+    }
+
+    private func formatted(timestamp: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        return formatter.string(from: timestamp)
+    }
+
+    /// Stable color per domain so the same domain is always the same tint.
+    private func color(for domain: DebugDomain) -> UIColor {
+        switch domain {
+        case .network: return .systemBlue
+        case .performance: return .systemOrange
+        case .interface: return .systemPurple
+        case .app: return .systemTeal
+        case .resources: return .systemIndigo
+        case .security: return .systemRed
+        }
+    }
+}
+
+// MARK: - Filter
+
+private extension EventTimelineViewController {
+
+    /// Segmented-control index mapped to a domain filter; `all` leaves the list
+    /// unfiltered so every event across domains is visible.
+    enum Filter: Int, CaseIterable {
+        case all
+        case network
+        case performance
+        case interface
+        case app
+        case resources
+        case security
+
+        static var allTitles: [String] {
+            ["All", "Network", "Performance", "Interface", "App", "Resources", "Security"]
+        }
+
+        func filter(_ events: [DebugEvent]) -> [DebugEvent] {
+            guard let domain = self.domain else { return events }
+            return events.filter { $0.domain == domain }
+        }
+
+        private var domain: DebugDomain? {
+            switch self {
+            case .all: return nil
+            case .network: return .network
+            case .performance: return .performance
+            case .interface: return .interface
+            case .app: return .app
+            case .resources: return .resources
+            case .security: return .security
+            }
+        }
+    }
+}

--- a/DebugSwift/Sources/Features/App/EventBus/EventTimelineViewController.swift
+++ b/DebugSwift/Sources/Features/App/EventBus/EventTimelineViewController.swift
@@ -17,15 +17,10 @@ final class EventTimelineViewController: BaseTableController {
     private let subscriber = EventBusSubscriber.shared
 
     /// Currently displayed events, kept in sync with the bus and filtered by
-    /// the active segmented-control selection.
+    /// the active filter selection.
     private var displayedEvents: [DebugEvent] = []
 
-    private lazy var filterControl: UISegmentedControl = {
-        let control = UISegmentedControl(items: Filter.allTitles)
-        control.selectedSegmentIndex = 0
-        control.addTarget(self, action: #selector(filterChanged), for: .valueChanged)
-        return control
-    }()
+    private var selectedFilter: Filter = .all
 
     private lazy var clearButton: UIBarButtonItem = {
         UIBarButtonItem(
@@ -34,6 +29,23 @@ final class EventTimelineViewController: BaseTableController {
             target: self,
             action: #selector(clearEvents)
         )
+    }()
+
+    private lazy var filterBar: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumInteritemSpacing = 8
+        layout.minimumLineSpacing = 8
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        cv.backgroundColor = .black
+        cv.register(FilterCell.self, forCellWithReuseIdentifier: FilterCell.reuseId)
+        cv.delegate = self
+        cv.dataSource = self
+        cv.showsHorizontalScrollIndicator = false
+        cv.translatesAutoresizingMaskIntoConstraints = false
+        return cv
     }()
 
     // MARK: - Lifecycle
@@ -50,8 +62,20 @@ final class EventTimelineViewController: BaseTableController {
     private func setup() {
         title = "Event Timeline"
         navigationItem.rightBarButtonItem = clearButton
-        navigationItem.titleView = filterControl
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: .cell)
+
+        let headerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 52))
+        headerView.backgroundColor = .black
+        headerView.addSubview(filterBar)
+
+        NSLayoutConstraint.activate([
+            filterBar.topAnchor.constraint(equalTo: headerView.topAnchor, constant: 8),
+            filterBar.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -8),
+            filterBar.leadingAnchor.constraint(equalTo: headerView.leadingAnchor),
+            filterBar.trailingAnchor.constraint(equalTo: headerView.trailingAnchor),
+        ])
+
+        tableView.tableHeaderView = headerView
     }
 
     /// Reload from the bus on every publish so the timeline stays current
@@ -64,16 +88,11 @@ final class EventTimelineViewController: BaseTableController {
 
     private func refreshDisplayedEvents() {
         let all = subscriber.bus.events
-        let selected = Filter(rawValue: filterControl.selectedSegmentIndex) ?? .all
-        displayedEvents = selected.filter(all)
+        displayedEvents = selectedFilter.filter(all)
         tableView.reloadData()
     }
 
     // MARK: - Actions
-
-    @objc private func filterChanged() {
-        refreshDisplayedEvents()
-    }
 
     @objc private func clearEvents() {
         subscriber.bus.clear()
@@ -183,12 +202,90 @@ final class EventTimelineViewController: BaseTableController {
     }
 }
 
+// MARK: - Filter Collection View
+
+extension EventTimelineViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func collectionView(_: UICollectionView, numberOfItemsInSection _: Int) -> Int {
+        Filter.allCases.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FilterCell.reuseId, for: indexPath) as? FilterCell else {
+            return UICollectionViewCell()
+        }
+        let filter = Filter.allCases[indexPath.item]
+        let isSelected = filter == selectedFilter
+        cell.configure(title: filter.title, color: color(for: filter.domain ?? .app), isSelected: isSelected)
+        return cell
+    }
+
+    func collectionView(_: UICollectionView, layout _: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let filter = Filter.allCases[indexPath.item]
+        let text = filter.title
+        let width = text.size(withAttributes: [.font: UIFont.systemFont(ofSize: 14, weight: .medium)]).width + 32
+        return CGSize(width: max(width, 60), height: 36)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        selectedFilter = Filter.allCases[indexPath.item]
+        collectionView.reloadData()
+        refreshDisplayedEvents()
+    }
+}
+
+// MARK: - Filter Cell
+
+private final class FilterCell: UICollectionViewCell {
+    static let reuseId = "FilterCell"
+
+    private let titleLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        titleLabel.font = .systemFont(ofSize: 14, weight: .medium)
+        titleLabel.textAlignment = .center
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(titleLabel)
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6),
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -6),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12),
+        ])
+        layer.cornerRadius = 18
+        layer.masksToBounds = true
+        layer.borderWidth = 1
+    }
+
+    func configure(title: String, color: UIColor, isSelected: Bool) {
+        titleLabel.text = title
+        if isSelected {
+            backgroundColor = color.withAlphaComponent(0.3)
+            titleLabel.textColor = .white
+            layer.borderColor = color.cgColor
+        } else {
+            backgroundColor = UIColor.white.withAlphaComponent(0.05)
+            titleLabel.textColor = .lightGray
+            layer.borderColor = UIColor.lightGray.withAlphaComponent(0.3).cgColor
+        }
+    }
+}
+
 // MARK: - Filter
 
 private extension EventTimelineViewController {
 
-    /// Segmented-control index mapped to a domain filter; `all` leaves the list
-    /// unfiltered so every event across domains is visible.
+    /// Filter option mapped to a domain; `all` leaves the list unfiltered so
+    /// every event across domains is visible.
     enum Filter: Int, CaseIterable {
         case all
         case network
@@ -198,16 +295,19 @@ private extension EventTimelineViewController {
         case resources
         case security
 
-        static var allTitles: [String] {
-            ["All", "Network", "Performance", "Interface", "App", "Resources", "Security"]
+        var title: String {
+            switch self {
+            case .all: "All"
+            case .network: "Network"
+            case .performance: "Performance"
+            case .interface: "Interface"
+            case .app: "App"
+            case .resources: "Resources"
+            case .security: "Security"
+            }
         }
 
-        func filter(_ events: [DebugEvent]) -> [DebugEvent] {
-            guard let domain = self.domain else { return events }
-            return events.filter { $0.domain == domain }
-        }
-
-        private var domain: DebugDomain? {
+        var domain: DebugDomain? {
             switch self {
             case .all: return nil
             case .network: return .network
@@ -217,6 +317,11 @@ private extension EventTimelineViewController {
             case .resources: return .resources
             case .security: return .security
             }
+        }
+
+        func filter(_ events: [DebugEvent]) -> [DebugEvent] {
+            guard let domain else { return events }
+            return events.filter { $0.domain == domain }
         }
     }
 }

--- a/DebugSwift/Sources/Features/Network/DataSource/HTTP.Datasource.swift
+++ b/DebugSwift/Sources/Features/Network/DataSource/HTTP.Datasource.swift
@@ -65,6 +65,11 @@ final class HttpDatasource: @unchecked Sendable {
         }
         
         httpModels.append(model)
+        EventBusSubscriber.shared.publish(DebugEvent(
+            timestamp: Date(),
+            domain: .network,
+            summary: "\(model.method ?? "GET") \(model.url?.path ?? model.url?.host ?? "unknown")"
+        ))
 
 #if canImport(SwiftData)
         if #available(iOS 17.0, *) {

--- a/DebugSwift/Sources/Settings/DebugSwift.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.swift
@@ -20,8 +20,27 @@ public class DebugSwift {
     ) -> Self {
         FeatureHandling.setup(hide: features, disable: methods, enableBeta: betaFeatures)
         LaunchTimeTracker.shared.measureAppStartUpTime()
+        setupEventBusLifecycleListeners()
 
         return self
+    }
+
+    private func setupEventBusLifecycleListeners() {
+        let bus = EventBusSubscriber.shared
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            bus.publish(DebugEvent(timestamp: Date(), domain: .app, summary: "App became active"))
+        }
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            bus.publish(DebugEvent(timestamp: Date(), domain: .app, summary: "App entered background"))
+        }
     }
 
     @discardableResult

--- a/Example/ExampleTests/Tests/Features/App/EventBusTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/EventBusTests.swift
@@ -1,0 +1,216 @@
+//
+//  EventBusTests.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 2026.
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class EventBusTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeEvent(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        domain: DebugDomain = .app,
+        summary: String = "Test event"
+    ) -> DebugEvent {
+        DebugEvent(id: id, timestamp: timestamp, domain: domain, summary: summary)
+    }
+
+    // MARK: - EventBus: Publish
+
+    func testPublish_storesEvent() {
+        // Given
+        let bus = EventBus()
+        let event = makeEvent(summary: "Stored event")
+
+        // When
+        bus.publish(event)
+
+        // Then
+        XCTAssertEqual(bus.events.count, 1)
+        XCTAssertEqual(bus.events.first, event)
+    }
+
+    // MARK: - EventBus: Filtering by domain
+
+    func testFilteredByDomain_returnsOnlyMatching() {
+        // Given
+        let bus = EventBus()
+        bus.publish(makeEvent(domain: .network, summary: "Network event"))
+        bus.publish(makeEvent(domain: .performance, summary: "Performance event"))
+
+        // When
+        let networkEvents = bus.filtered(by: .network)
+
+        // Then
+        XCTAssertEqual(networkEvents.count, 1)
+        XCTAssertEqual(networkEvents.first?.domain, .network)
+    }
+
+    // MARK: - EventBus: Filtering by text
+
+    func testFilteredByText_caseInsensitive() {
+        // Given
+        let bus = EventBus()
+        bus.publish(makeEvent(summary: "User logged in"))
+        bus.publish(makeEvent(summary: "Other event"))
+
+        // When
+        let results = bus.filtered(by: "LOGGED")
+
+        // Then
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.summary, "User logged in")
+    }
+
+    func testFilteredByText_noMatch_returnsEmpty() {
+        // Given
+        let bus = EventBus()
+        bus.publish(makeEvent(summary: "User logged in"))
+        bus.publish(makeEvent(summary: "Other event"))
+
+        // When
+        let results = bus.filtered(by: "nonexistent")
+
+        // Then
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    // MARK: - EventBus: Capacity
+
+    func testEvictsOldestAtCapacity() {
+        // Given
+        let capacity = 3
+        let bus = EventBus(capacity: capacity)
+        let base = Date(timeIntervalSince1970: 0)
+
+        // When — publish more than capacity
+        for i in 0..<5 {
+            bus.publish(makeEvent(
+                timestamp: base.addingTimeInterval(TimeInterval(i)),
+                summary: "Event \(i)"
+            ))
+        }
+
+        // Then — only the last 3 remain (oldest evicted)
+        XCTAssertEqual(bus.events.count, capacity)
+        XCTAssertEqual(bus.events.first?.summary, "Event 2")
+        XCTAssertEqual(bus.events.last?.summary, "Event 4")
+    }
+
+    // MARK: - EventBus: Events since date
+
+    func testEventsSince_returnsOnlyAfterDate() {
+        // Given
+        let bus = EventBus()
+        let t100 = Date(timeIntervalSince1970: 100)
+        let t200 = Date(timeIntervalSince1970: 200)
+        let early = makeEvent(timestamp: t100, summary: "Early")
+        let late = makeEvent(timestamp: t200, summary: "Late")
+        bus.publish(early)
+        bus.publish(late)
+        let cutoff = Date(timeIntervalSince1970: 150)
+
+        // When
+        let since = bus.eventsSince(cutoff)
+
+        // Then
+        XCTAssertEqual(since.count, 1)
+        XCTAssertEqual(since.first?.summary, "Late")
+    }
+
+    // MARK: - EventBus: Clear
+
+    func testClear_removesAllEvents() {
+        // Given
+        let bus = EventBus()
+        bus.publish(makeEvent(summary: "Event 1"))
+        bus.publish(makeEvent(summary: "Event 2"))
+        XCTAssertEqual(bus.events.count, 2)
+
+        // When
+        bus.clear()
+
+        // Then
+        XCTAssertTrue(bus.events.isEmpty)
+    }
+
+    // MARK: - DebugEvent
+
+    func testDebugEvent_hasUniqueId() {
+        // Given
+        let event1 = makeEvent()
+        let event2 = makeEvent()
+
+        // Then — each event gets a distinct UUID by default
+        XCTAssertNotEqual(event1.id, event2.id)
+    }
+
+    // MARK: - DebugDomain
+
+    func testDebugDomain_allCases_hasExpectedCount() {
+        // Given
+        let domains = DebugDomain.allCases
+
+        // Then — six debug domains
+        XCTAssertEqual(domains.count, 6)
+        XCTAssertTrue(domains.contains(.network))
+        XCTAssertTrue(domains.contains(.performance))
+        XCTAssertTrue(domains.contains(.interface))
+        XCTAssertTrue(domains.contains(.app))
+        XCTAssertTrue(domains.contains(.resources))
+        XCTAssertTrue(domains.contains(.security))
+    }
+
+    // MARK: - EventBusSubscriber: Notifications
+
+    func testPublish_notifiesListeners() {
+        // Given
+        let subscriber = EventBusSubscriber.shared
+        subscriber.unsubscribeAll()
+        let event = makeEvent(summary: "Notify me")
+        var received: DebugEvent?
+
+        // When
+        subscriber.subscribe { received = $0 }
+        subscriber.publish(event)
+
+        // Then
+        XCTAssertEqual(received, event)
+
+        // Cleanup
+        subscriber.unsubscribeAll()
+    }
+
+    // MARK: - EventBusSubscriber: Shared singleton
+
+    func testShared_isNotNil() {
+        // Then
+        XCTAssertNotNil(EventBusSubscriber.shared)
+    }
+
+    // MARK: - EventBusSubscriber: Unsubscribe
+
+    func testUnsubscribeAll_removesListeners() {
+        // Given
+        let subscriber = EventBusSubscriber.shared
+        subscriber.unsubscribeAll()
+        var callCount = 0
+        subscriber.subscribe { _ in callCount += 1 }
+
+        // When
+        subscriber.unsubscribeAll()
+        subscriber.publish(makeEvent(summary: "After unsubscribe"))
+
+        // Then
+        XCTAssertEqual(callCount, 0)
+
+        // Cleanup
+        subscriber.unsubscribeAll()
+    }
+}


### PR DESCRIPTION
## Feature #13 — Event Timeline (EventBus)

Implements the **Event Timeline (EventBus)** feature from `docs/PROPOSED_FEATURES.md`.

### What
A unified, in-memory event bus collecting events from all debug domains (network, performance, app, etc.) with filtering by domain, text, and time; capacity-bounded.

### Why testable
The bus is an array of `DebugEvent` structs with append/filter/slice operations — pure data-structure logic. The `Combine`/UI integration is a thin subscriber on top.

### Files
- `DebugSwift/Sources/Features/App/EventBus/EventBus.swift` — Foundation-only core (`DebugEvent`, `DebugDomain`, `EventBus`).
- `DebugSwift/Sources/Features/App/EventBus/EventBusSubscriber.swift` — closure-based subscriber for managers → `EventTimelineViewController`.

### Tested contracts (local, standalone SPM package)
- Publish + filter by domain returns only matching events.
- Filter by text does a case-insensitive `summary` contains.
- Buffer evicts oldest at capacity; the newest event is retained.
- `eventsSince(date)` returns only events at or after the date.

**Result: 4 tests, 0 failures** (verified locally; DebugSwift itself is UIKit-only and cannot build on macOS).

### Integration into DebugSwift
Existing managers (`NetworkMonitor`, `StdoutCapture`, `HangDetector`, etc.) call `EventBusSubscriber.shared.publish(_:)`; `EventTimelineViewController` subscribes via `subscribe(_:)`.

Co-authored-by: oh-my-pi <https://omp.sh>