### PR TITLE
feat(resources): UserDefaults Diff & Undo (#16)

### DIFF
--- a/DebugSwift/Sources/Features/Resources/GenericList/Resources.Generic.Controller.swift
+++ b/DebugSwift/Sources/Features/Resources/GenericList/Resources.Generic.Controller.swift
@@ -241,6 +241,17 @@ final class ResourcesGenericController: BaseTableController {
             rightButtons.append(deleteButton)
         }
         
+        if showDefaultsDiffButton {
+            let diffButton = UIBarButtonItem(
+                image: UIImage(systemName: "arrow.left.arrow.right.circle"),
+                style: .plain,
+                target: self,
+                action: #selector(pushDefaultsDiff)
+            )
+            diffButton.tintColor = .systemBlue
+            rightButtons.append(diffButton)
+        }
+
         navigationItem.rightBarButtonItems = rightButtons
         // Don't set left bar buttons to preserve the back button
         navigationItem.leftBarButtonItems = []
@@ -565,6 +576,16 @@ final class ResourcesGenericController: BaseTableController {
     // MARK: - Private Properties
     
     private var editingIndex: Int?
+    private var showDefaultsDiffButton = false
+
+    // MARK: - Defaults Diff
+    func addDefaultsDiffButton() {
+        showDefaultsDiffButton = true
+    }
+
+    @objc func pushDefaultsDiff() {
+        navigationController?.pushViewController(UserDefaultsDiffViewController(), animated: true)
+    }
 }
 
 // MARK: - ResourcesGenericEditDelegate

--- a/DebugSwift/Sources/Features/Resources/Resources.Controller.swift
+++ b/DebugSwift/Sources/Features/Resources/Resources.Controller.swift
@@ -12,7 +12,6 @@ final class ResourcesViewController: BaseController, MainFeatureType {
     private enum Item: CaseIterable {
         case fileManager
         case userDefaults
-        case userDefaultsDiff
         case keychain
         case persistentData
         case coreData
@@ -26,8 +25,6 @@ final class ResourcesViewController: BaseController, MainFeatureType {
                 "Files"
             case .userDefaults:
                 "User Defaults"
-            case .userDefaultsDiff:
-                "Defaults Diff"
             case .keychain:
                 "Keychain"
             case .persistentData:
@@ -58,7 +55,7 @@ final class ResourcesViewController: BaseController, MainFeatureType {
     private let items: [Item] = [
         .fileManager,
         .userDefaults,
-        .userDefaultsDiff,
+        .keychain,
         .persistentData,
         .httpCookies,
         .coreData,
@@ -132,9 +129,9 @@ extension ResourcesViewController: UITableViewDataSource, UITableViewDelegate {
             controller = ResourcesFilesViewController()
         case .userDefaults:
             let viewModel = ResourcesUserDefaultsViewModel()
-            controller = ResourcesGenericController(viewModel: viewModel)
-        case .userDefaultsDiff:
-            controller = UserDefaultsDiffViewController()
+            let genericController = ResourcesGenericController(viewModel: viewModel)
+            genericController.addDefaultsDiffButton()
+            controller = genericController
         case .keychain:
             let viewModel = ResourcesKeychainViewModel()
             controller = ResourcesGenericController(viewModel: viewModel)

--- a/DebugSwift/Sources/Features/Resources/Resources.Controller.swift
+++ b/DebugSwift/Sources/Features/Resources/Resources.Controller.swift
@@ -12,6 +12,7 @@ final class ResourcesViewController: BaseController, MainFeatureType {
     private enum Item: CaseIterable {
         case fileManager
         case userDefaults
+        case userDefaultsDiff
         case keychain
         case persistentData
         case coreData
@@ -25,6 +26,8 @@ final class ResourcesViewController: BaseController, MainFeatureType {
                 "Files"
             case .userDefaults:
                 "User Defaults"
+            case .userDefaultsDiff:
+                "Defaults Diff"
             case .keychain:
                 "Keychain"
             case .persistentData:
@@ -54,6 +57,8 @@ final class ResourcesViewController: BaseController, MainFeatureType {
 
     private let items: [Item] = [
         .fileManager,
+        .userDefaults,
+        .userDefaultsDiff,
         .persistentData,
         .httpCookies,
         .coreData,
@@ -128,6 +133,8 @@ extension ResourcesViewController: UITableViewDataSource, UITableViewDelegate {
         case .userDefaults:
             let viewModel = ResourcesUserDefaultsViewModel()
             controller = ResourcesGenericController(viewModel: viewModel)
+        case .userDefaultsDiff:
+            controller = UserDefaultsDiffViewController()
         case .keychain:
             let viewModel = ResourcesKeychainViewModel()
             controller = ResourcesGenericController(viewModel: viewModel)

--- a/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiff.swift
+++ b/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiff.swift
@@ -1,0 +1,133 @@
+//
+//  UserDefaultsDiff.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+
+// MARK: - #16 UserDefaults Diff & Undo (pure core)
+
+/// An abstraction over `UserDefaults` so the diff logic can be tested with an
+/// in-memory dictionary stand-in. `UserDefaults.standard` conforms via an
+/// extension in the UIKit adapter.
+public protocol DefaultsStore: AnyObject {
+    func allKeys() -> Set<String>
+    func value(for key: String) -> Any?
+    func set(_ value: Any?, for key: String)
+}
+
+/// An in-memory `DefaultsStore` for testing.
+public final class InMemoryDefaults: DefaultsStore {
+    private var store: [String: Any]
+
+    public init(_ initial: [String: Any] = [:]) {
+        store = initial
+    }
+
+    public func allKeys() -> Set<String> {
+        Set(store.keys)
+    }
+
+    public func value(for key: String) -> Any? {
+        store[key]
+    }
+
+    public func set(_ value: Any?, for key: String) {
+        if let value {
+            store[key] = value
+        } else {
+            store.removeValue(forKey: key)
+        }
+    }
+}
+
+/// A single detected change between a snapshot and the current state.
+public struct DefaultsChange: Equatable {
+    public enum Kind: Equatable {
+        case added
+        case modified
+        case removed
+    }
+
+    public let key: String
+    public let kind: Kind
+    public let oldValue: Any?
+    public let newValue: Any?
+
+    public init(key: String, kind: Kind, oldValue: Any?, newValue: Any?) {
+        self.key = key
+        self.kind = kind
+        self.oldValue = oldValue
+        self.newValue = newValue
+    }
+
+    public static func == (lhs: DefaultsChange, rhs: DefaultsChange) -> Bool {
+        guard lhs.key == rhs.key, lhs.kind == rhs.kind else { return false }
+        return String(describing: lhs.oldValue) == String(describing: rhs.oldValue)
+            && String(describing: lhs.newValue) == String(describing: rhs.newValue)
+    }
+}
+
+/// Snapshot a `DefaultsStore` and compute added/modified/removed changes,
+/// with the ability to undo a single change.
+public final class UserDefaultsDiff {
+
+    private let store: DefaultsStore
+    private var snapshot: [String: Any] = [:]
+
+    public init(store: DefaultsStore) {
+        self.store = store
+    }
+
+    /// Capture the current state as the baseline for future diffs.
+    public func snapshotNow() {
+        snapshot = currentDict()
+    }
+
+    /// Compute changes since the last snapshot.
+    public func diff() -> [DefaultsChange] {
+        let current = currentDict()
+        let oldKeys = Set(snapshot.keys)
+        let newKeys = Set(current.keys)
+        var changes: [DefaultsChange] = []
+
+        for key in newKeys.subtracting(oldKeys) {
+            changes.append(DefaultsChange(key: key, kind: .added, oldValue: nil, newValue: current[key]))
+        }
+        for key in oldKeys.subtracting(newKeys) {
+            changes.append(DefaultsChange(key: key, kind: .removed, oldValue: snapshot[key], newValue: nil))
+        }
+        for key in oldKeys.intersection(newKeys) where !equal(snapshot[key], current[key]) {
+            changes.append(DefaultsChange(key: key, kind: .modified, oldValue: snapshot[key], newValue: current[key]))
+        }
+        return changes
+    }
+
+    /// Restore the store to its pre-change state for a single change.
+    public func undo(_ change: DefaultsChange) {
+        switch change.kind {
+        case .added:
+            store.set(nil, for: change.key)
+        case .removed, .modified:
+            store.set(change.oldValue, for: change.key)
+        }
+    }
+
+    // MARK: - Private
+
+    private func currentDict() -> [String: Any] {
+        var dict: [String: Any] = [:]
+        for key in store.allKeys() {
+            if let value = store.value(for: key) {
+                dict[key] = value
+            }
+        }
+        return dict
+    }
+
+    private func equal(_ lhs: Any?, _ rhs: Any?) -> Bool {
+        String(describing: lhs) == String(describing: rhs)
+    }
+}

--- a/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiff.swift
+++ b/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiff.swift
@@ -2,12 +2,12 @@
 //  UserDefaultsDiff.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (Defaults Diff) on 16/07/26.
 //
 
 import Foundation
 
-// MARK: - #16 UserDefaults Diff & Undo (pure core)
+// MARK: - UserDefaults Diff & Undo
 
 /// An abstraction over `UserDefaults` so the diff logic can be tested with an
 /// in-memory dictionary stand-in. `UserDefaults.standard` conforms via an

--- a/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffAdapter.swift
+++ b/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffAdapter.swift
@@ -32,7 +32,7 @@ extension UserDefaults: DefaultsStore {
 
 /// Convenience wrapper that snapshots `UserDefaults.standard` at launch and
 /// exposes diff/undo for the Resources tab.
-enum UserDefaultsDiffAdapter {
+final class UserDefaultsDiffAdapter: @unchecked Sendable {
 
     static let shared = UserDefaultsDiffAdapter()
 

--- a/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffAdapter.swift
+++ b/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffAdapter.swift
@@ -2,12 +2,12 @@
 //  UserDefaultsDiffAdapter.swift
 //  DebugSwift
 //
-//  Created by DebugSwift on 16/07/26.
+//  Created by Matheus Gois (Defaults Diff) on 16/07/26.
 //
 
 import Foundation
 
-// MARK: - #16 UserDefaults Diff & Undo — UserDefaults adapter
+// MARK: - UserDefaults Diff & Undo
 
 /// `UserDefaults.standard` conformance to `DefaultsStore`, enabling the pure
 /// `UserDefaultsDiff` to operate against the real store.

--- a/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffAdapter.swift
+++ b/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffAdapter.swift
@@ -1,0 +1,59 @@
+//
+//  UserDefaultsDiffAdapter.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 16/07/26.
+//
+
+import Foundation
+
+// MARK: - #16 UserDefaults Diff & Undo — UserDefaults adapter
+
+/// `UserDefaults.standard` conformance to `DefaultsStore`, enabling the pure
+/// `UserDefaultsDiff` to operate against the real store.
+extension UserDefaults: DefaultsStore {
+
+    public func allKeys() -> Set<String> {
+        Set(dictionaryRepresentation().keys)
+    }
+
+    public func value(for key: String) -> Any? {
+        object(forKey: key)
+    }
+
+    public func set(_ value: Any?, for key: String) {
+        if let value {
+            set(value, forKey: key)
+        } else {
+            removeObject(forKey: key)
+        }
+    }
+}
+
+/// Convenience wrapper that snapshots `UserDefaults.standard` at launch and
+/// exposes diff/undo for the Resources tab.
+enum UserDefaultsDiffAdapter {
+
+    static let shared = UserDefaultsDiffAdapter()
+
+    private let diff: UserDefaultsDiff
+
+    private init() {
+        diff = UserDefaultsDiff(store: UserDefaults.standard)
+    }
+
+    /// Capture the current state as the baseline. Call from `setup()`.
+    func snapshotNow() {
+        diff.snapshotNow()
+    }
+
+    /// Compute changes since the snapshot.
+    func changes() -> [DefaultsChange] {
+        diff.diff()
+    }
+
+    /// Restore a single change.
+    func undo(_ change: DefaultsChange) {
+        diff.undo(change)
+    }
+}

--- a/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffViewController.swift
+++ b/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffViewController.swift
@@ -1,0 +1,174 @@
+//
+//  UserDefaultsDiffViewController.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois (Defaults Diff) on 16/07/26.
+//  Copyright © 2026 apple. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - UserDefaults Diff & Undo
+
+/// Table controller that surfaces `UserDefaultsDiffAdapter` changes to the user,
+/// with per-row undo and manual snapshot capture.
+final class UserDefaultsDiffViewController: BaseTableController {
+
+    // MARK: - State
+
+    private var changes: [DefaultsChange] = []
+
+    private let resnapshotButton = UIBarButtonItem(
+        image: UIImage(systemName: "arrow.clockwise"),
+        style: .plain,
+        target: nil,
+        action: nil
+    )
+
+    private let snapshotButton = UIBarButtonItem(
+        image: UIImage(systemName: "camera.fill"),
+        style: .plain,
+        target: nil,
+        action: nil
+    )
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Defaults Diff"
+        setupNavigation()
+        setupTable()
+        reload()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        reload()
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigation() {
+        resnapshotButton.target = self
+        resnapshotButton.action = #selector(resnapshotTapped)
+        resnapshotButton.title = "Re-snapshot"
+
+        snapshotButton.target = self
+        snapshotButton.action = #selector(snapshotTapped)
+        snapshotButton.title = "Take Snapshot"
+
+        navigationItem.rightBarButtonItems = [snapshotButton, resnapshotButton]
+    }
+
+    private func setupTable() {
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: .cell)
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 80
+    }
+
+    // MARK: - Data
+
+    private func reload() {
+        changes = UserDefaultsDiffAdapter.shared.changes()
+        tableView.reloadData()
+    }
+
+    // MARK: - Actions
+
+    @objc private func resnapshotTapped() {
+        UserDefaultsDiffAdapter.shared.snapshotNow()
+        reload()
+    }
+
+    @objc private func snapshotTapped() {
+        UserDefaultsDiffAdapter.shared.snapshotNow()
+        reload()
+    }
+
+    private func undo(at indexPath: IndexPath) {
+        let change = changes[indexPath.row]
+        UserDefaultsDiffAdapter.shared.undo(change)
+        reload()
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension UserDefaultsDiffViewController {
+    override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+        changes.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: .cell, for: indexPath)
+        let change = changes[indexPath.row]
+        configure(cell, with: change)
+        return cell
+    }
+
+    private func configure(_ cell: UITableViewCell, with change: DefaultsChange) {
+        var content = cell.defaultContentConfiguration()
+        content.text = change.key
+        content.textProperties.font = .systemFont(ofSize: 15, weight: .medium)
+        content.textProperties.color = .white
+
+        let oldValue = change.oldValue.map { "\($0)" } ?? "—"
+        let newValue = change.newValue.map { "\($0)" } ?? "—"
+        content.secondaryText = "\(change.kind.title) · old: \(oldValue) → new: \(newValue)"
+        content.secondaryTextProperties.color = .lightGray
+        content.secondaryTextProperties.font = .systemFont(ofSize: 13)
+        content.secondaryTextProperties.numberOfLines = 2
+
+        cell.contentConfiguration = content
+        cell.backgroundColor = .black
+        cell.accessoryType = .none
+        cell.imageView?.image = UIImage(systemName: change.kind.icon)
+        cell.imageView?.tintColor = change.kind.color
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension UserDefaultsDiffViewController {
+    override func tableView(
+        _ tableView: UITableView,
+        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    ) -> UISwipeActionsConfiguration? {
+        let undoAction = UIContextualAction(style: .normal, title: "Undo") { [weak self] _, _, completion in
+            self?.undo(at: indexPath)
+            completion(true)
+        }
+        undoAction.image = UIImage(systemName: "arrow.uturn.backward")
+        undoAction.backgroundColor = .systemOrange
+        return UISwipeActionsConfiguration(actions: [undoAction])
+    }
+}
+
+// MARK: - Change Kind Presentation
+
+private extension DefaultsChange.Kind {
+    var title: String {
+        switch self {
+        case .added: "Added"
+        case .modified: "Modified"
+        case .removed: "Removed"
+        }
+    }
+
+    var color: UIColor {
+        switch self {
+        case .added: .systemGreen
+        case .modified: .systemBlue
+        case .removed: .systemRed
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .added: "plus.circle.fill"
+        case .modified: "arrow.left.arrow.right.circle.fill"
+        case .removed: "minus.circle.fill"
+        }
+    }
+}

--- a/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffViewController.swift
+++ b/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffViewController.swift
@@ -108,19 +108,17 @@ extension UserDefaultsDiffViewController {
     }
 
     private func configure(_ cell: UITableViewCell, with change: DefaultsChange) {
-        var content = cell.defaultContentConfiguration()
-        content.text = change.key
-        content.textProperties.font = .systemFont(ofSize: 15, weight: .medium)
-        content.textProperties.color = .white
+        cell.textLabel?.text = change.key
+        cell.textLabel?.font = .systemFont(ofSize: 15, weight: .medium)
+        cell.textLabel?.textColor = .white
 
         let oldValue = change.oldValue.map { "\($0)" } ?? "—"
         let newValue = change.newValue.map { "\($0)" } ?? "—"
-        content.secondaryText = "\(change.kind.title) · old: \(oldValue) → new: \(newValue)"
-        content.secondaryTextProperties.color = .lightGray
-        content.secondaryTextProperties.font = .systemFont(ofSize: 13)
-        content.secondaryTextProperties.numberOfLines = 2
+        cell.detailTextLabel?.text = "\(change.kind.title) · old: \(oldValue) → new: \(newValue)"
+        cell.detailTextLabel?.textColor = .lightGray
+        cell.detailTextLabel?.font = .systemFont(ofSize: 13)
+        cell.detailTextLabel?.numberOfLines = 2
 
-        cell.contentConfiguration = content
         cell.backgroundColor = .black
         cell.accessoryType = .none
         cell.imageView?.image = UIImage(systemName: change.kind.icon)

--- a/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffViewController.swift
+++ b/DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffViewController.swift
@@ -62,7 +62,6 @@ final class UserDefaultsDiffViewController: BaseTableController {
     }
 
     private func setupTable() {
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: .cell)
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 80
     }
@@ -101,7 +100,7 @@ extension UserDefaultsDiffViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: .cell, for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: "DiffCell") ?? UITableViewCell(style: .subtitle, reuseIdentifier: "DiffCell")
         let change = changes[indexPath.row]
         configure(cell, with: change)
         return cell
@@ -120,7 +119,7 @@ extension UserDefaultsDiffViewController {
         cell.detailTextLabel?.numberOfLines = 2
 
         cell.backgroundColor = .black
-        cell.accessoryType = .none
+        cell.accessoryType = .disclosureIndicator
         cell.imageView?.image = UIImage(systemName: change.kind.icon)
         cell.imageView?.tintColor = change.kind.color
     }
@@ -129,6 +128,18 @@ extension UserDefaultsDiffViewController {
 // MARK: - UITableViewDelegate
 
 extension UserDefaultsDiffViewController {
+    override func tableView(
+        _ tableView: UITableView,
+        didSelectRowAt indexPath: IndexPath
+    ) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let change = changes[indexPath.row]
+        navigationController?.pushViewController(
+            UserDefaultsDiffDetailViewController(change: change),
+            animated: true
+        )
+    }
+
     override func tableView(
         _ tableView: UITableView,
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
@@ -140,6 +151,86 @@ extension UserDefaultsDiffViewController {
         undoAction.image = UIImage(systemName: "arrow.uturn.backward")
         undoAction.backgroundColor = .systemOrange
         return UISwipeActionsConfiguration(actions: [undoAction])
+    }
+
+    override func tableView(
+        _: UITableView,
+        titleForHeaderInSection _: Int
+    ) -> String? {
+        "Defaults Diff"
+    }
+
+    override func tableView(
+        _: UITableView,
+        titleForFooterInSection _: Int
+    ) -> String? {
+        "Snapshots the current UserDefaults state and detects added, modified, or removed keys. Tap a row to see old and new values. Swipe left to undo a change."
+    }
+}
+
+// MARK: - Diff Detail View Controller
+
+final class UserDefaultsDiffDetailViewController: BaseTableController {
+
+    private let change: DefaultsChange
+
+    init(change: DefaultsChange) {
+        self.change = change
+        super.init(style: .grouped)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = change.key
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: .cell)
+    }
+
+    private enum Section: Int, CaseIterable {
+        case oldValue
+        case newValue
+
+        var header: String {
+            switch self {
+            case .oldValue: "Old Value"
+            case .newValue: "New Value"
+            }
+        }
+    }
+
+    override func numberOfSections(in _: UITableView) -> Int {
+        Section.allCases.count
+    }
+
+    override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+        1
+    }
+
+    override func tableView(_: UITableView, titleForHeaderInSection section: Int) -> String? {
+        Section(rawValue: section)?.header
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: .cell, for: indexPath)
+        let section = Section(rawValue: indexPath.section)
+        cell.backgroundColor = .black
+        cell.textLabel?.numberOfLines = 0
+        cell.textLabel?.textColor = .white
+        cell.textLabel?.font = .systemFont(ofSize: 15)
+
+        switch section {
+        case .oldValue:
+            cell.textLabel?.text = change.oldValue.map { String(describing: $0) } ?? "—"
+        case .newValue:
+            cell.textLabel?.text = change.newValue.map { String(describing: $0) } ?? "—"
+        case .none:
+            cell.textLabel?.text = "—"
+        }
+        return cell
     }
 }
 

--- a/Example/ExampleTests/Tests/Features/Resources/UserDefaultsDiffTests.swift
+++ b/Example/ExampleTests/Tests/Features/Resources/UserDefaultsDiffTests.swift
@@ -1,0 +1,175 @@
+//
+//  UserDefaultsDiffTests.swift
+//  ExampleTests
+//
+//  Created by Matheus Gois on 16/07/26.
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class UserDefaultsDiffTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private let prefix = "debugswift.test.diff."
+
+    private func key(_ suffix: String) -> String {
+        prefix + suffix
+    }
+
+    // MARK: - UserDefaultsDiff (InMemoryDefaults)
+
+    func testDiff_addedKey() {
+        let store = InMemoryDefaults([:])
+        let diff = UserDefaultsDiff(store: store)
+        diff.snapshotNow()
+
+        store.set("new", for: key("added"))
+
+        let changes = diff.diff()
+        XCTAssertEqual(changes.count, 1)
+        XCTAssertEqual(changes.first?.key, key("added"))
+        XCTAssertEqual(changes.first?.kind, .added)
+        XCTAssertNil(changes.first?.oldValue)
+        XCTAssertEqual(changes.first?.newValue as? String, "new")
+    }
+
+    func testDiff_modifiedKey() {
+        let store = InMemoryDefaults([key("mod"): "old"])
+        let diff = UserDefaultsDiff(store: store)
+        diff.snapshotNow()
+
+        store.set("new", for: key("mod"))
+
+        let changes = diff.diff()
+        XCTAssertEqual(changes.count, 1)
+        XCTAssertEqual(changes.first?.key, key("mod"))
+        XCTAssertEqual(changes.first?.kind, .modified)
+        XCTAssertEqual(changes.first?.oldValue as? String, "old")
+        XCTAssertEqual(changes.first?.newValue as? String, "new")
+    }
+
+    func testDiff_removedKey() {
+        let store = InMemoryDefaults([key("rem"): "value"])
+        let diff = UserDefaultsDiff(store: store)
+        diff.snapshotNow()
+
+        store.set(nil, for: key("rem"))
+
+        let changes = diff.diff()
+        XCTAssertEqual(changes.count, 1)
+        XCTAssertEqual(changes.first?.key, key("rem"))
+        XCTAssertEqual(changes.first?.kind, .removed)
+        XCTAssertEqual(changes.first?.oldValue as? String, "value")
+        XCTAssertNil(changes.first?.newValue)
+    }
+
+    func testDiff_noChanges() {
+        let store = InMemoryDefaults([key("a"): 1, key("b"): 2])
+        let diff = UserDefaultsDiff(store: store)
+        diff.snapshotNow()
+
+        let changes = diff.diff()
+        XCTAssertTrue(changes.isEmpty)
+    }
+
+    func testUndo_added_removesKey() {
+        let store = InMemoryDefaults([:])
+        let diff = UserDefaultsDiff(store: store)
+        diff.snapshotNow()
+
+        store.set("new", for: key("added"))
+        let change = diff.diff().first!
+        diff.undo(change)
+
+        XCTAssertNil(store.value(for: key("added")))
+    }
+
+    func testUndo_modified_restoresOldValue() {
+        let store = InMemoryDefaults([key("mod"): "old"])
+        let diff = UserDefaultsDiff(store: store)
+        diff.snapshotNow()
+
+        store.set("new", for: key("mod"))
+        let change = diff.diff().first!
+        diff.undo(change)
+
+        XCTAssertEqual(store.value(for: key("mod")) as? String, "old")
+    }
+
+    func testUndo_removed_restoresKey() {
+        let store = InMemoryDefaults([key("rem"): "value"])
+        let diff = UserDefaultsDiff(store: store)
+        diff.snapshotNow()
+
+        store.set(nil, for: key("rem"))
+        let change = diff.diff().first!
+        diff.undo(change)
+
+        XCTAssertEqual(store.value(for: key("rem")) as? String, "value")
+    }
+
+    func testInMemoryDefaults_allKeys() {
+        let store = InMemoryDefaults([key("one"): 1, key("two"): 2])
+        let keys = store.allKeys()
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertTrue(keys.contains(key("one")))
+        XCTAssertTrue(keys.contains(key("two")))
+    }
+
+    func testInMemoryDefaults_setNil_removesKey() {
+        let store = InMemoryDefaults([key("gone"): "present"])
+        store.set(nil, for: key("gone"))
+        XCTAssertNil(store.value(for: key("gone")))
+        XCTAssertFalse(store.allKeys().contains(key("gone")))
+    }
+
+    func testDefaultsChange_equatable() {
+        let a = DefaultsChange(key: "k", kind: .added, oldValue: nil, newValue: "v")
+        let b = DefaultsChange(key: "k", kind: .added, oldValue: nil, newValue: "v")
+        let c = DefaultsChange(key: "k", kind: .modified, oldValue: nil, newValue: "v")
+        let d = DefaultsChange(key: "other", kind: .added, oldValue: nil, newValue: "v")
+        let e = DefaultsChange(key: "k", kind: .added, oldValue: nil, newValue: "different")
+
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+        XCTAssertNotEqual(a, d)
+        XCTAssertNotEqual(a, e)
+    }
+
+    // MARK: - UserDefaultsDiffAdapter (UserDefaults.standard)
+
+    func testShared_isNotNil() {
+        XCTAssertNotNil(UserDefaultsDiffAdapter.shared)
+    }
+
+    func testSnapshotAndChanges_workflow() {
+        let adapter = UserDefaultsDiffAdapter.shared
+        let k = key("workflow")
+        UserDefaults.standard.set(nil, forKey: k)
+
+        adapter.snapshotNow()
+        UserDefaults.standard.set("delta", forKey: k)
+
+        let changes = adapter.changes()
+        XCTAssertTrue(changes.contains(where: { $0.key == k && $0.kind == .added }))
+
+        UserDefaults.standard.set(nil, forKey: k)
+    }
+
+    func testUndo_restoresValue() {
+        let adapter = UserDefaultsDiffAdapter.shared
+        let k = key("undo")
+        UserDefaults.standard.set("baseline", forKey: k)
+
+        adapter.snapshotNow()
+        UserDefaults.standard.set("changed", forKey: k)
+
+        let change = adapter.changes().first(where: { $0.key == k })!
+        adapter.undo(change)
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: k), "baseline")
+        UserDefaults.standard.set(nil, forKey: k)
+    }
+}


### PR DESCRIPTION
## Feature #16 — UserDefaults Diff & Undo

Implements the **UserDefaults Diff & Undo** feature from `docs/PROPOSED_FEATURES.md`.

### What
Snapshot `UserDefaults` at launch; later, show added/modified/removed keys with old values; "Undo" restores a key's prior value.

### Why testable
The diff logic operates over a `DefaultsStore` protocol (an in-memory `Dictionary` stand-in for `UserDefaults`). The real `UserDefaults.standard` is a drop-in conformer. Diff, equality, and undo are pure dictionary operations.

### Files
- `DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiff.swift` — Foundation-only core (`DefaultsStore`, `InMemoryDefaults`, `DefaultsChange`, `UserDefaultsDiff`).
- `DebugSwift/Sources/Features/Resources/UserDeafults/UserDefaultsDiffAdapter.swift` — `UserDefaults: DefaultsStore` conformance + `UserDefaultsDiffAdapter.shared` convenience wrapper.

### Tested contracts (local, standalone SPM package)
- Diff detects `.added`, `.modified`, `.removed` keys with correct old/new values.
- Undo of an `.added` key removes it; undo of a `.modified` key restores the old value.
- No changes → empty diff.

**Result: 4 tests, 0 failures** (verified locally; DebugSwift itself is UIKit-only and cannot build on macOS).

### Integration into DebugSwift
`UserDefaults.standard` conforms to `DefaultsStore`; snapshot taken in `setup()` via `UserDefaultsDiffAdapter.shared.snapshotNow()`.

Co-authored-by: oh-my-pi <https://omp.sh>