### PR TITLE
feat(crash): add Copy Text option to crash report export

### DIFF
--- a/DebugSwift/Resources/Base.lproj/Localizable.strings
+++ b/DebugSwift/Resources/Base.lproj/Localizable.strings
@@ -88,6 +88,10 @@
 "copy" = "Copy";
 "close" = "Close";
 "share" = "Share";
+"share-as-pdf" = "Share as PDF";
+"copy-text" = "Copy Text";
+"crash.copied.title" = "Copied!";
+"crash.copied.description" = "Crash report copied to clipboard.";
 
 // MARK: - Reachability
 

--- a/DebugSwift/Resources/en.lproj/Localizable.strings
+++ b/DebugSwift/Resources/en.lproj/Localizable.strings
@@ -88,6 +88,10 @@
 "copy" = "Copy";
 "close" = "Close";
 "share" = "Share";
+"share-as-pdf" = "Share as PDF";
+"copy-text" = "Copy Text";
+"crash.copied.title" = "Copied!";
+"crash.copied.description" = "Crash report copied to clipboard.";
 
 // MARK: - Reachability
 

--- a/DebugSwift/Resources/pt-BR.lproj/Localizable.strings
+++ b/DebugSwift/Resources/pt-BR.lproj/Localizable.strings
@@ -87,6 +87,10 @@
 "copy" = "Copiar";
 "close" = "Fechar";
 "share" = "Compartilhar";
+"share-as-pdf" = "Compartilhar como PDF";
+"copy-text" = "Copiar Texto";
+"crash.copied.title" = "Copiado!";
+"crash.copied.description" = "Relatório de falha copiado para a área de transferência.";
 
 // MARK: - Reachability
 

--- a/DebugSwift/Sources/Features/App/Crash/Detail/CrashDetailViewController.swift
+++ b/DebugSwift/Sources/Features/App/Crash/Detail/CrashDetailViewController.swift
@@ -64,11 +64,45 @@ final class CrashDetailViewController: BaseController {
         addRightBarButton(
             image: .named("square.and.arrow.up", default: "Share")
         ) { [weak self] in
-            self?.share()
+            self?.presentShareOptions()
         }
     }
 
-    private func share() {
+    private func presentShareOptions() {
+        let actionSheet = UIAlertController(
+            title: nil,
+            message: nil,
+            preferredStyle: .actionSheet
+        )
+
+        actionSheet.addAction(
+            UIAlertAction(
+                title: "share-as-pdf".localized(),
+                style: .default
+            ) { [weak self] _ in
+                self?.shareAsPDF()
+            }
+        )
+
+        actionSheet.addAction(
+            UIAlertAction(
+                title: "copy-text".localized(),
+                style: .default
+            ) { [weak self] _ in
+                self?.copyCrashText()
+            }
+        )
+
+        actionSheet.addAction(UIAlertAction(title: "close".localized(), style: .cancel))
+
+        if let popover = actionSheet.popoverPresentationController {
+            popover.barButtonItem = navigationItem.rightBarButtonItem
+        }
+
+        present(actionSheet, animated: true)
+    }
+
+    private func shareAsPDF() {
         let image = viewModel.data.context.uiImage
 
         guard let pdf = PDFManager.generatePDF(
@@ -99,6 +133,14 @@ final class CrashDetailViewController: BaseController {
             popover.permittedArrowDirections = .up
         }
         present(activity, animated: true, completion: nil)
+    }
+
+    private func copyCrashText() {
+        UIPasteboard.general.string = viewModel.getAllValues()
+        showAlert(
+            with: "crash.copied.description".localized(),
+            title: "crash.copied.title".localized()
+        )
     }
 }
 

--- a/DebugSwift/Sources/Helpers/Extensions/String+.swift
+++ b/DebugSwift/Sources/Helpers/Extensions/String+.swift
@@ -35,4 +35,9 @@ extension String {
         let padding = String(repeating: withPad, count: toLength - count)
         return padding + self
     }
+
+    /// Returns a localized string from the DebugSwift resource bundle.
+    func localized(comment: String = "") -> String {
+        NSLocalizedString(self, bundle: .module, comment: comment)
+    }
 }

--- a/Example/ExampleTests/Tests/Features/App/Crash/CrashDetailViewModelTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/Crash/CrashDetailViewModelTests.swift
@@ -1,0 +1,90 @@
+//
+//  CrashDetailViewModelTests.swift
+//  DebugSwift
+//
+//  Created by DebugSwift on 2026.
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class CrashDetailViewModelTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func makeCrash(
+        type: CrashType = .nsexception,
+        name: String = "nsexception",
+        traces: [String] = ["0x0001", "0x0002"]
+    ) -> CrashModel {
+        let details = CrashModel.Details(
+            name: name,
+            date: Date(timeIntervalSince1970: 1_750_000_000),
+            appVersion: "1.0",
+            appBuild: "1",
+            iosVersion: "26.3.1",
+            deviceModel: "iPhone17,1",
+            reachability: "WiFi"
+        )
+        let context = CrashModel.Context(
+            image: nil,
+            consoleOutput: "",
+            errorOutput: ""
+        )
+        return CrashModel(
+            type: type,
+            details: details,
+            context: context,
+            traces: .builder(traces)
+        )
+    }
+
+    // MARK: - getAllValues (the contract Copy Text relies on)
+
+    func testGetAllValuesContainsDetailsSection() {
+        let viewModel = CrashDetailViewModel(data: makeCrash())
+
+        let values = viewModel.getAllValues()
+
+        XCTAssertTrue(values.contains("Details:"))
+        XCTAssertTrue(values.contains("Error: nsexception"))
+        XCTAssertTrue(values.contains("App Version:: 1.0"))
+        XCTAssertTrue(values.contains("Build Version:: 1"))
+        XCTAssertTrue(values.contains("iOS Version:: 26.3.1"))
+    }
+
+    func testGetAllValuesContainsStackTraceSection() {
+        let viewModel = CrashDetailViewModel(
+            data: makeCrash(traces: ["frame_one", "frame_two"])
+        )
+
+        let values = viewModel.getAllValues()
+
+        XCTAssertTrue(values.contains("Stack Trace:"))
+        XCTAssertTrue(values.contains("frame_one"))
+        XCTAssertTrue(values.contains("frame_two"))
+    }
+
+    func testGetAllValuesIsWellFormedWhenNoTraces() {
+        let viewModel = CrashDetailViewModel(
+            data: makeCrash(traces: [])
+        )
+
+        let values = viewModel.getAllValues()
+
+        XCTAssertTrue(values.hasPrefix("Details:"))
+        XCTAssertTrue(values.contains("Stack Trace:"))
+        let stackSection = values.components(separatedBy: "Stack Trace:").last ?? ""
+        XCTAssertEqual(stackSection.trimmingCharacters(in: .whitespacesAndNewlines), "")
+    }
+
+    func testGetAllValuesForSignalCrashIncludesSignalType() {
+        let viewModel = CrashDetailViewModel(
+            data: makeCrash(type: .signal, name: "SIGABRT")
+        )
+
+        let values = viewModel.getAllValues()
+
+        XCTAssertTrue(values.contains("Error: signal"))
+        XCTAssertTrue(values.contains("Error: SIGABRT"))
+    }
+}


### PR DESCRIPTION
## Summary

The crash detail share button previously exported only to PDF. It now opens an action sheet with two options:

- **Share as PDF** — existing behavior (generates and shares `Crash-<uuid>.pdf`)
- **Copy Text** — copies the full crash report (details + stack trace) to the clipboard, so it can be pasted anywhere without generating a file

Also adds a `String.localized()` helper backed by the DebugSwift resource bundle, and surfaces the new strings through the existing `Localizable.strings` files (Base / en / pt-BR).

## Type of change

- [x] Feature

## Test plan

- [x] Unit tests updated
- [x] Manual testing completed
- [x] CI passing

### Manual test steps

1. Trigger a crash (e.g. NSException) so a report appears under Crashes
2. Open the crash detail view
3. Tap the share button (top-right) — an action sheet appears with **Share as PDF** and **Copy Text**
4. Tap **Copy Text** — a "Copied!" alert shows and the report text is on the clipboard
5. Paste anywhere (Notes, Slack) — full details + stack trace are present
6. Repeat and choose **Share as PDF** — existing PDF share flow works unchanged

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility