### PR TITLE
Add SwiftUI hierarchy support to view debugger

### DIFF
--- a/DebugSwift/Sources/Features/App/Crash/Detail/CrashDetailViewModel.swift
+++ b/DebugSwift/Sources/Features/App/Crash/Detail/CrashDetailViewModel.swift
@@ -129,7 +129,11 @@ final class CrashDetailViewModel: NSObject {
             }
         } else {
             for trace in data.traces {
-                result += "\(trace.info)\n"
+                // Print the human-readable frame text, not the raw struct
+                // description (which was "Info(title: \"…\", detail: \"…\")").
+                let frame = trace.info.title
+                let detail = trace.info.detail.isEmpty ? "" : " — \(trace.info.detail)"
+                result += "\(frame)\(detail)\n"
             }
         }
 

--- a/DebugSwift/Sources/Features/App/Crash/Detail/CrashDetailViewModel.swift
+++ b/DebugSwift/Sources/Features/App/Crash/Detail/CrashDetailViewModel.swift
@@ -117,9 +117,14 @@ final class CrashDetailViewModel: NSObject {
     }
 
     func getAllValues() -> String {
-        var result = "Details" + ":\n"
+        var result = "Details:\n"
         for detail in details {
-            result += "\(detail.title): \(detail.detail)\n"
+            // Some titles are authored with a trailing colon ("App Version:"),
+            // some without ("Error"). Strip it before joining so the copied
+            // output is consistent ("App Version: 1.11.3", not "App Version:: 1.11.3").
+            let title = detail.title
+            let normalized = title.hasSuffix(":") ? String(title.dropLast()) : title
+            result += "\(normalized): \(detail.detail)\n"
         }
 
         result += "\nStack Trace:\n"

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Configuration/SnapshotViewConfiguration.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Configuration/SnapshotViewConfiguration.swift
@@ -35,7 +35,7 @@ final class SnapshotViewConfiguration: NSObject {
     var scaleInterpolationQuality: CGInterpolationQuality = .high
 
     /// The spacing between layers along the z-axis.
-    var zSpacing: Float = 20.0
+    var zSpacing: Float = 3.0
 
     /// The minimum spacing between layers along the z-axis.
     var minimumZSpacing: Float = .zero

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/InAppViewDebugger.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/InAppViewDebugger.swift
@@ -34,9 +34,14 @@ final class InAppViewDebugger: NSObject {
             return
         }
 
-        let snapshot = Snapshot(element: ViewElement(view: window))
+        // Two parallel snapshots: the 3D snapshot uses the UIKit subview tree
+        // (real frames + pixel snapshots), the hierarchy uses the SwiftUI
+        // semantic tree (VStack, Text, Button, …) so it shows developer views.
+        let snapshotSnapshot = Snapshot(element: ViewElement(view: window, useSwiftUIHierarchy: false))
+        let hierarchySnapshot = Snapshot(element: ViewElement(view: window, useSwiftUIHierarchy: true))
         presentWithSnapshot(
-            snapshot,
+            snapshotSnapshot,
+            hierarchySnapshot: hierarchySnapshot,
             rootViewController: window.rootViewController,
             configuration: configuration,
             completion: completion
@@ -59,8 +64,15 @@ final class InAppViewDebugger: NSObject {
         guard let view else {
             return
         }
-        let snapshot = Snapshot(element: ViewElement(view: view))
-        presentWithSnapshot(snapshot, rootViewController: getNearestAncestorViewController(responder: view), configuration: configuration, completion: completion)
+        let snapshotSnapshot = Snapshot(element: ViewElement(view: view, useSwiftUIHierarchy: false))
+        let hierarchySnapshot = Snapshot(element: ViewElement(view: view, useSwiftUIHierarchy: true))
+        presentWithSnapshot(
+            snapshotSnapshot,
+            hierarchySnapshot: hierarchySnapshot,
+            rootViewController: getNearestAncestorViewController(responder: view),
+            configuration: configuration,
+            completion: completion
+        )
     }
 
     /// Takes a snapshot of the view of the specified view controller and presents
@@ -75,10 +87,16 @@ final class InAppViewDebugger: NSObject {
         guard let view = viewController?.view else {
             return
         }
-        let snapshot = Snapshot(element: ViewElement(view: view))
-        presentWithSnapshot(snapshot, rootViewController: viewController, configuration: configuration, completion: completion)
+        let snapshotSnapshot = Snapshot(element: ViewElement(view: view, useSwiftUIHierarchy: false))
+        let hierarchySnapshot = Snapshot(element: ViewElement(view: view, useSwiftUIHierarchy: true))
+        presentWithSnapshot(
+            snapshotSnapshot,
+            hierarchySnapshot: hierarchySnapshot,
+            rootViewController: viewController,
+            configuration: configuration,
+            completion: completion
+        )
     }
-
     /// Presents a view debugger for the a snapshot as a modal view controller on
     /// top of the specified root view controller.
     ///
@@ -91,12 +109,14 @@ final class InAppViewDebugger: NSObject {
     ///   been presented.
     final class func presentWithSnapshot(
         _ snapshot: Snapshot,
+        hierarchySnapshot: Snapshot? = nil,
         rootViewController _: UIViewController?,
         configuration: Configuration? = nil,
         completion: (() -> Void)? = nil
     ) {
         let debuggerViewController = ViewDebuggerViewController(
             snapshot: snapshot,
+            hierarchySnapshot: hierarchySnapshot ?? snapshot,
             configuration: configuration ?? Configuration()
         )
         let navigationController = UINavigationController(rootViewController: debuggerViewController)

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/Element.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/Element.swift
@@ -8,6 +8,7 @@
 
 import CoreGraphics
 import Foundation
+import UIKit
 
 /// Provides identifying information for an element that is displayed in the
 /// view debugger.
@@ -61,10 +62,15 @@ protocol Element {
 
     /// Whether the element is hidden from view or not.
     var isHidden: Bool { get }
-
     /// A snapshot image of the element in its current state.
     var snapshotImage: CGImage? { get }
 
     /// The child elements of the element.
     var children: [Element] { get }
+
+    /// The underlying `UIView` backing this element, if any.
+    /// Used to map selections between the UIKit snapshot tree and the
+    /// SwiftUI hierarchy tree — two nodes with the same `underlyingView`
+    /// represent the same on-screen view. SwiftUI semantic nodes return `nil`.
+    var underlyingView: UIView? { get }
 }

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/Snapshot.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/Snapshot.swift
@@ -9,6 +9,7 @@
 import CoreGraphics
 import Foundation
 import SwiftUI
+import UIKit
 
 /// A snapshot of the UI element tree in its current state.
 final class Snapshot: NSObject {
@@ -23,9 +24,13 @@ final class Snapshot: NSObject {
 
     /// Whether the element is hidden from view or not.
     let isHidden: Bool
-
     /// A snapshot image of the element in its current state.
     let snapshotImage: CGImage?
+
+    /// The underlying `UIView` backing this snapshot's element, if any.
+    /// Used to map selections between the UIKit snapshot tree and the
+    /// SwiftUI hierarchy tree.
+    let underlyingView: UIView?
 
     /// The child snapshots of the snapshot (one per child element).
     let children: [Snapshot]
@@ -44,6 +49,7 @@ final class Snapshot: NSObject {
         self.frame = element.frame
         self.isHidden = element.isHidden
         self.snapshotImage = element.snapshotImage
+        self.underlyingView = element.underlyingView
         self.children = element.children.map { Snapshot(element: $0) }
         self.element = element
     }

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
@@ -87,25 +87,76 @@ final class SwiftUIElement: NSObject, Element {
 
     var children: [Element] {
         // SwiftUI views don't expose real frames, so distribute this node's
-        // assigned frame among its children as non-overlapping slices. Without
-        // this, every sibling would share the parent frame and overlap at the
-        // same X/Y in the 3D scene (only separated by z-depth).
+        // assigned frame among its children as non-overlapping slices.
         //
-        // The distribution axis is inherited from the nearest layout container
-        // ancestor: a VStack sets `.vertical`, an HStack sets `.horizontal`,
-        // and transparent containers (TupleView, ModifiedContent, …) pass
-        // the inherited axis through so the real siblings — e.g. three Buttons
-        // nested under VStack → TupleView → Button×3 — get distributed along
-        // the VStack's vertical axis instead of falling back to a grid.
+        // Transparent SwiftUI wrappers (ScrollView, ModifiedContent, TupleView,
+        // Group, _ConditionalContent, AnyView, ForEach, raw tuples) don't lay
+        // out their content — they pass it through. If they each took a slice
+        // of the parent frame, the real layout container (VStack/HStack) would
+        // receive only a tiny fraction, and its buttons would be subdivided
+        // into degenerate ~0px slivers (ScrollView > VStack > ModifiedContent >
+        // VStack > TupleView > Button×6 divides 874px six ways → ~0px each).
+        //
+        // So: first flatten transparent wrappers — collect the real content
+        // nodes (Buttons) that live under them — then distribute the assigned
+        // frame among those real siblings. This way three buttons in a VStack
+        // (even nested under ScrollView > ModifiedContent > TupleView) each
+        // get a full vertical slice of the VStack's frame.
+        let flattened = SwiftUIElement.flattenedChildren(of: node)
         let childLayout = SwiftUIElement.childLayout(for: node, inherited: inheritedLayout)
         let childFrames = SwiftUIElement.distributeFrames(
-            count: node.children.count,
+            count: flattened.count,
             in: assignedFrame,
             layout: childLayout
         )
-        return zip(node.children, childFrames).map { child, frame in
+        return zip(flattened, childFrames).map { child, frame in
             SwiftUIElement(node: child, parentFrame: frame, inheritedLayout: childLayout)
         }
+    }
+
+    /// Recursively flattens transparent SwiftUI wrappers, returning the real
+    /// content nodes. A transparent wrapper's children replace it, and any of
+    /// those children that are themselves transparent are flattened too — so
+    // VStack > TupleView > Button×6 yields the six Buttons directly, and
+    // ScrollView > ModifiedContent > VStack yields the VStack.
+    static func flattenedChildren(of node: SwiftUIElementNode) -> [SwiftUIElementNode] {
+        var result: [SwiftUIElementNode] = []
+        for child in node.children {
+            if isTransparentWrapper(child.typeName) {
+                result.append(contentsOf: flattenedChildren(of: child))
+            } else {
+                result.append(child)
+            }
+        }
+        return result
+    }
+
+    /// Transparent SwiftUI wrappers that pass their content through without
+    /// laying it out. Their children are flattened into the parent so only the
+    /// real layout containers (VStack/HStack/ZStack) subdivide the frame.
+    static func isTransparentWrapper(_ typeName: String) -> Bool {
+        // True pass-through wrappers: they don't lay out content themselves.
+        // List/Form/LazyVStack/LazyHStack DO lay out content (vertically or
+        // horizontally) and are handled by childLayout, not flattened here.
+        // A raw Swift tuple "(A, B, C)" (the TupleView's unwrapped content)
+        // also just groups its elements — flatten it so its children become
+        // the enclosing layout container's direct children.
+        //
+        // Match by prefix/contains carefully: a VStack<TupleView<…>> or
+        // HStack<…, TupleView<…>> *contains* "TupleView" but is a real layout
+        // container, so use hasPrefix for TupleView and exclude the stack
+        // containers explicitly.
+        if typeName.contains("VStack") || typeName.contains("HStack") || typeName.contains("ZStack") {
+            return false
+        }
+        return typeName.contains("ScrollView") ||
+            typeName.contains("ModifiedContent") ||
+            typeName.hasPrefix("TupleView") ||
+            typeName.hasPrefix("(") ||
+            typeName.contains("Group") ||
+            typeName.contains("_ConditionalContent") ||
+            typeName.contains("AnyView") ||
+            typeName.contains("ForEach")
     }
 
     /// Builds the top-level SwiftUI element children for a reflected tree,
@@ -115,13 +166,17 @@ final class SwiftUIElement: NSObject, Element {
     /// (ViewElement hosting-view fallback) so top-level siblings don't all
     /// share the parent frame and overlap in the 3D scene.
     static func elements(for tree: SwiftUIElementNode, in frame: CGRect) -> [SwiftUIElement] {
+        // Flatten transparent wrappers at the root too, so the top-level
+        // siblings are the real content nodes (e.g. a ScrollView's buttons,
+        // not the ScrollView→ModifiedContent→VStack nesting).
+        let flattened = flattenedChildren(of: tree)
         let childLayout = childLayout(for: tree, inherited: .grid)
         let childFrames = distributeFrames(
-            count: tree.children.count,
+            count: flattened.count,
             in: frame,
             layout: childLayout
         )
-        return zip(tree.children, childFrames).map { child, childFrame in
+        return zip(flattened, childFrames).map { child, childFrame in
             SwiftUIElement(node: child, parentFrame: childFrame, inheritedLayout: childLayout)
         }
     }
@@ -154,6 +209,15 @@ final class SwiftUIElement: NSObject, Element {
         let typeName = node.typeName
         if typeName.contains("VStack") || typeName.contains("ZStack") { return .vertical }
         if typeName.contains("HStack") { return .horizontal }
+        // List / Form / LazyVStack lay content out vertically; LazyHStack
+        // horizontally. ScrollView content flows vertically by default (and
+        // its horizontal-scroll variant is rare); treat it as vertical so the
+        // buttons inside a ScrollView > VStack stack vertically even when the
+        // ScrollView is the root node passed to elements(for:).
+        if typeName.contains("List") || typeName.contains("Form") || typeName.contains("LazyVStack") || typeName.contains("ScrollView") {
+            return .vertical
+        }
+        if typeName.contains("LazyHStack") { return .horizontal }
         // Transparent containers pass the inherited layout through.
         return inherited
     }

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
@@ -38,10 +38,25 @@ final class SwiftUIElement: NSObject, Element {
     /// the ancestor chain.
     private let inheritedLayout: Layout
 
-    init(node: SwiftUIElementNode, parentFrame: CGRect = .zero, inheritedLayout: Layout = .grid) {
+    /// A screenshot of the hosting `_UIHostingView` in its own coordinate
+    /// space, captured once at the UIKit→SwiftUI boundary. Each SwiftUI node
+    /// crops this image to its `assignedFrame` so its 3D plane shows the real
+    /// rendered pixels for that region — instead of an empty white plane
+    /// (the previous behavior, since SwiftUI semantic nodes have no UIView
+    /// to `drawHierarchy`). `nil` when no hosting snapshot is available
+    /// (e.g. the hierarchy-table mode); nodes then render as white planes.
+    private let hostingSnapshot: CGImage?
+
+    init(
+        node: SwiftUIElementNode,
+        parentFrame: CGRect = .zero,
+        inheritedLayout: Layout = .grid,
+        hostingSnapshot: CGImage? = nil
+    ) {
         self.node = node
         self.assignedFrame = parentFrame
         self.inheritedLayout = inheritedLayout
+        self.hostingSnapshot = hostingSnapshot
         super.init()
     }
 
@@ -78,9 +93,18 @@ final class SwiftUIElement: NSObject, Element {
     }
 
     var snapshotImage: CGImage? {
-        // SwiftUI semantic nodes don't have individual pixel snapshots.
-        // The snapshot is taken from the hosting UIView (the parent ViewElement).
-        nil
+        // SwiftUI semantic nodes have no UIView to drawHierarchy, so crop the
+        // hosting view's screenshot (captured once at the boundary) to this
+        // node's assigned frame. The frame is in the hosting view's coordinate
+        // space, matching the screenshot's coordinate space. This gives each
+        // 3D plane real rendered pixels (the button's label/background) instead
+        // of an empty white plane.
+        guard let hostingSnapshot else { return nil }
+        let frame = assignedFrame.intersection(CGRect(origin: .zero, size: CGSize(
+            width: hostingSnapshot.width, height: hostingSnapshot.height
+        )))
+        guard !frame.isEmpty, frame.width > 1, frame.height > 1 else { return nil }
+        return hostingSnapshot.cropping(to: frame)
     }
 
     var underlyingView: UIView? { nil }
@@ -110,7 +134,7 @@ final class SwiftUIElement: NSObject, Element {
             layout: childLayout
         )
         return zip(flattened, childFrames).map { child, frame in
-            SwiftUIElement(node: child, parentFrame: frame, inheritedLayout: childLayout)
+            SwiftUIElement(node: child, parentFrame: frame, inheritedLayout: childLayout, hostingSnapshot: hostingSnapshot)
         }
     }
 
@@ -165,14 +189,23 @@ final class SwiftUIElement: NSObject, Element {
     /// vertical, HStack → horizontal, …). Used at the UIKit→SwiftUI boundary
     /// (ViewElement hosting-view fallback) so top-level siblings don't all
     /// share the parent frame and overlap in the 3D scene.
-    static func elements(for tree: SwiftUIElementNode, in frame: CGRect) -> [SwiftUIElement] {
+    static func elements(
+        for tree: SwiftUIElementNode,
+        in frame: CGRect,
+        hostingSnapshot: CGImage? = nil
+    ) -> [SwiftUIElement] {
         // The tree is the rootView's content (e.g. a NavigationView, a
         // ScrollView, or a single Button). Keep the root as the top-level
         // element — do NOT flatten it away — so a single-Button screen renders
         // the Button (with its Text child) rather than just the Text. Only
         // flatten transparent wrappers *inside* each child via `children`.
+        // The hosting view's screenshot is threaded down so every node can
+        // crop its assigned frame and render real pixels on its 3D plane.
         let childLayout = childLayout(for: tree, inherited: .grid)
-        return [SwiftUIElement(node: tree, parentFrame: frame, inheritedLayout: childLayout)]
+        return [SwiftUIElement(
+            node: tree, parentFrame: frame, inheritedLayout: childLayout,
+            hostingSnapshot: hostingSnapshot
+        )]
     }
 
     // MARK: - Frame distribution

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
@@ -1,0 +1,77 @@
+//
+//  SwiftUIElement.swift
+//  DebugSwift
+//
+//  Bridges the Mirror-based SwiftUI hierarchy (SwiftUIElementNode) into the
+//  existing Element protocol so the View Debugger can display SwiftUI views
+//  alongside UIKit views in the same hierarchy table and snapshot view.
+//
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+import UIKit
+
+/// An element that represents a SwiftUI view, conforming to the same `Element`
+/// protocol used by `ViewElement` (UIView-backed). This lets the existing
+/// `HierarchyTableViewController` and `SnapshotView` display SwiftUI nodes
+/// without any UI changes.
+@MainActor
+final class SwiftUIElement: NSObject, Element {
+    private let node: SwiftUIElementNode
+    private let parentFrame: CGRect
+
+    init(node: SwiftUIElementNode, parentFrame: CGRect = .zero) {
+        self.node = node
+        self.parentFrame = parentFrame
+        super.init()
+    }
+
+    var label: ElementLabel {
+        ElementLabel(
+            name: node.displayName,
+            classification: node.depth == 0 ? .important : .normal
+        )
+    }
+
+    var shortDescription: String {
+        var desc = "SwiftUI: \(node.typeName)"
+        if !node.properties.isEmpty {
+            let props = node.properties.prefix(5).map { "\($0.label): \($0.valueDescription)" }
+            desc += " {\(props.joined(separator: ", "))}"
+        }
+        return desc
+    }
+
+    var title: String {
+        node.typeName
+    }
+
+    nonisolated override var description: String {
+        MainActor.assumeIsolated { node.displayName }
+    }
+
+    var frame: CGRect {
+        // SwiftUI views don't expose their frame without a GeometryReader.
+        // Use the assigned frame — either the parent's frame or a slice
+        // distributed by the parent so children appear at different
+        // positions in the 3D snapshot view.
+        parentFrame
+    }
+
+    var isHidden: Bool {
+        false
+    }
+
+    var snapshotImage: CGImage? {
+        // SwiftUI semantic nodes don't have individual pixel snapshots.
+        // The snapshot is taken from the hosting UIView (the parent ViewElement).
+        nil
+    }
+
+    var underlyingView: UIView? { nil }
+
+    var children: [Element] {
+        node.children.map { SwiftUIElement(node: $0, parentFrame: parentFrame) }
+    }
+}

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
@@ -19,11 +19,29 @@ import UIKit
 @MainActor
 final class SwiftUIElement: NSObject, Element {
     private let node: SwiftUIElementNode
-    private let parentFrame: CGRect
 
-    init(node: SwiftUIElementNode, parentFrame: CGRect = .zero) {
+    /// The frame assigned to this node within its parent's coordinate space.
+    ///
+    /// SwiftUI semantic views don't expose their real frame without a
+    /// GeometryReader, so the hierarchy builder assigns each node a slice
+    /// of its parent's frame. This keeps siblings from overlapping in the
+    /// 3D snapshot view — e.g. three buttons in a VStack get three
+    /// non-overlapping vertical slices instead of all sharing the parent
+    /// frame and stacking on the same X/Y in SceneKit.
+    private let assignedFrame: CGRect
+
+    /// The layout axis inherited from the nearest enclosing layout container
+    /// (VStack/HStack/ZStack). Transparent SwiftUI containers (TupleView,
+    /// ModifiedContent, _ConditionalContent, Group, AnyView) pass this
+    /// through to their children so the real siblings get distributed along
+    /// the correct axis. Defaults to `.grid` when no layout container is in
+    /// the ancestor chain.
+    private let inheritedLayout: Layout
+
+    init(node: SwiftUIElementNode, parentFrame: CGRect = .zero, inheritedLayout: Layout = .grid) {
         self.node = node
-        self.parentFrame = parentFrame
+        self.assignedFrame = parentFrame
+        self.inheritedLayout = inheritedLayout
         super.init()
     }
 
@@ -52,11 +70,7 @@ final class SwiftUIElement: NSObject, Element {
     }
 
     var frame: CGRect {
-        // SwiftUI views don't expose their frame without a GeometryReader.
-        // Use the assigned frame — either the parent's frame or a slice
-        // distributed by the parent so children appear at different
-        // positions in the 3D snapshot view.
-        parentFrame
+        assignedFrame
     }
 
     var isHidden: Bool {
@@ -72,6 +86,135 @@ final class SwiftUIElement: NSObject, Element {
     var underlyingView: UIView? { nil }
 
     var children: [Element] {
-        node.children.map { SwiftUIElement(node: $0, parentFrame: parentFrame) }
+        // SwiftUI views don't expose real frames, so distribute this node's
+        // assigned frame among its children as non-overlapping slices. Without
+        // this, every sibling would share the parent frame and overlap at the
+        // same X/Y in the 3D scene (only separated by z-depth).
+        //
+        // The distribution axis is inherited from the nearest layout container
+        // ancestor: a VStack sets `.vertical`, an HStack sets `.horizontal`,
+        // and transparent containers (TupleView, ModifiedContent, …) pass
+        // the inherited axis through so the real siblings — e.g. three Buttons
+        // nested under VStack → TupleView → Button×3 — get distributed along
+        // the VStack's vertical axis instead of falling back to a grid.
+        let childLayout = SwiftUIElement.childLayout(for: node, inherited: inheritedLayout)
+        let childFrames = SwiftUIElement.distributeFrames(
+            count: node.children.count,
+            in: assignedFrame,
+            layout: childLayout
+        )
+        return zip(node.children, childFrames).map { child, frame in
+            SwiftUIElement(node: child, parentFrame: frame, inheritedLayout: childLayout)
+        }
+    }
+
+    /// Builds the top-level SwiftUI element children for a reflected tree,
+    /// distributing `frame` among the tree's children as non-overlapping
+    /// slices laid out along the axis inferred from `tree`'s type (VStack →
+    /// vertical, HStack → horizontal, …). Used at the UIKit→SwiftUI boundary
+    /// (ViewElement hosting-view fallback) so top-level siblings don't all
+    /// share the parent frame and overlap in the 3D scene.
+    static func elements(for tree: SwiftUIElementNode, in frame: CGRect) -> [SwiftUIElement] {
+        let childLayout = childLayout(for: tree, inherited: .grid)
+        let childFrames = distributeFrames(
+            count: tree.children.count,
+            in: frame,
+            layout: childLayout
+        )
+        return zip(tree.children, childFrames).map { child, childFrame in
+            SwiftUIElement(node: child, parentFrame: childFrame, inheritedLayout: childLayout)
+        }
+    }
+
+    // MARK: - Frame distribution
+
+    enum Layout {
+        case vertical   // VStack
+        case horizontal  // HStack
+        case grid        // unknown / mixed
+    }
+
+    /// Infers a distribution layout from the SwiftUI container type name.
+    static func inferredLayout(for typeName: String) -> Layout {
+        if typeName.contains("VStack") { return .vertical }
+        if typeName.contains("HStack") { return .horizontal }
+        if typeName.contains("ZStack") { return .vertical } // depth-stack: tile vertically
+        return .grid
+    }
+
+    /// Determines which layout to use for a node's *children*.
+    ///
+    /// A layout container (VStack/HStack/ZStack) sets the axis for its
+    /// children. Transparent SwiftUI containers (TupleView, ModifiedContent,
+    /// _ConditionalContent, Group, AnyView) don't impose a layout — they
+    /// pass the inherited axis through so the real siblings get distributed
+    /// along the enclosing container's axis. Anything else passes the
+    /// inherited axis through unchanged (defaults to `.grid`).
+    static func childLayout(for node: SwiftUIElementNode, inherited: Layout) -> Layout {
+        let typeName = node.typeName
+        if typeName.contains("VStack") || typeName.contains("ZStack") { return .vertical }
+        if typeName.contains("HStack") { return .horizontal }
+        // Transparent containers pass the inherited layout through.
+        return inherited
+    }
+
+    /// Splits `frame` into `count` non-overlapping sub-rectangles laid out
+    /// along the inferred axis. Returns the slices in order. For an empty or
+    /// single child the whole frame is returned (or an empty list when count
+    /// is zero). A small inset keeps sibling planes visually separated.
+    static func distributeFrames(
+        count: Int,
+        in frame: CGRect,
+        layout: Layout,
+        inset: CGFloat = 4
+    ) -> [CGRect] {
+        guard count > 0 else { return [] }
+        guard count > 1 else { return [frame] }
+
+        let spacing: CGFloat = inset
+        switch layout {
+        case .vertical:
+            let totalSpacing = spacing * CGFloat(count - 1)
+            let available = max(0, frame.height - totalSpacing)
+            let rowHeight = available / CGFloat(count)
+            return (0..<count).map { i in
+                let originY = frame.minY + (rowHeight + spacing) * CGFloat(i)
+                return CGRect(
+                    x: frame.minX,
+                    y: originY,
+                    width: frame.width,
+                    height: rowHeight
+                )
+            }
+        case .horizontal:
+            let totalSpacing = spacing * CGFloat(count - 1)
+            let available = max(0, frame.width - totalSpacing)
+            let colWidth = available / CGFloat(count)
+            return (0..<count).map { i in
+                let originX = frame.minX + (colWidth + spacing) * CGFloat(i)
+                return CGRect(
+                    x: originX,
+                    y: frame.minY,
+                    width: colWidth,
+                    height: frame.height
+                )
+            }
+        case .grid:
+            // Tile into the most square-ish grid we can.
+            let columns = Int(ceil(sqrt(CGFloat(count))))
+            let rows = Int(ceil(CGFloat(count) / CGFloat(columns)))
+            let cellWidth = frame.width / CGFloat(columns)
+            let cellHeight = frame.height / CGFloat(rows)
+            return (0..<count).map { i in
+                let col = i % columns
+                let row = i / columns
+                return CGRect(
+                    x: frame.minX + cellWidth * CGFloat(col),
+                    y: frame.minY + cellHeight * CGFloat(row),
+                    width: cellWidth,
+                    height: cellHeight
+                )
+            }
+        }
     }
 }

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIElement.swift
@@ -166,19 +166,13 @@ final class SwiftUIElement: NSObject, Element {
     /// (ViewElement hosting-view fallback) so top-level siblings don't all
     /// share the parent frame and overlap in the 3D scene.
     static func elements(for tree: SwiftUIElementNode, in frame: CGRect) -> [SwiftUIElement] {
-        // Flatten transparent wrappers at the root too, so the top-level
-        // siblings are the real content nodes (e.g. a ScrollView's buttons,
-        // not the ScrollView→ModifiedContent→VStack nesting).
-        let flattened = flattenedChildren(of: tree)
+        // The tree is the rootView's content (e.g. a NavigationView, a
+        // ScrollView, or a single Button). Keep the root as the top-level
+        // element — do NOT flatten it away — so a single-Button screen renders
+        // the Button (with its Text child) rather than just the Text. Only
+        // flatten transparent wrappers *inside* each child via `children`.
         let childLayout = childLayout(for: tree, inherited: .grid)
-        let childFrames = distributeFrames(
-            count: flattened.count,
-            in: frame,
-            layout: childLayout
-        )
-        return zip(flattened, childFrames).map { child, childFrame in
-            SwiftUIElement(node: child, parentFrame: childFrame, inheritedLayout: childLayout)
-        }
+        return [SwiftUIElement(node: tree, parentFrame: frame, inheritedLayout: childLayout)]
     }
 
     // MARK: - Frame distribution

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
@@ -175,6 +175,21 @@ public enum SwiftUIHierarchyBuilder {
             // Skip already-handled internal wrappers
             if label == "_tree" { continue }
             if label == "content" && typeName.contains("ModifiedContent") { continue }
+            // TupleView's content (the tuple of views) is already unwrapped by
+            // step 2; skip it here to avoid emitting the same children twice.
+            if typeName.contains("TupleView") { continue }
+
+            // Skip SwiftUI layout/infrastructure values that would otherwise be
+            // surfaced as duplicate or meaningless nodes: the internal `Tree<…>`
+            // wrapper (already unwrapped via `_tree` in step 1), the layout
+            // descriptors (`_VStackLayout`, `_HStackLayout`, …), and `Optional`
+            // wrappers around non-view plumbing. These are not semantic views
+            // and, left in, they duplicate the real content (e.g. a VStack
+            // would emit both the TupleView of Buttons *and* a redundant
+            // Tree<_VStackLayout, TupleView<…>> child), splitting the 3D
+            // frame distribution across phantom siblings.
+            let childTypeName = String(describing: type(of: child.value))
+            if isInfrastructureType(childTypeName) { continue }
 
             if isSwiftUIViewType(value: child.value) {
                 childNodes.append(buildNode(
@@ -207,6 +222,12 @@ public enum SwiftUIHierarchyBuilder {
         var nodes: [SwiftUIElementNode] = []
 
         for child in treeMirror.children {
+            // Skip the layout descriptor (`_VStackLayout`, `_HStackLayout`, …)
+            // and spacing plumbing (`Optional<CGFloat>`): they are not views and
+            // would otherwise be emitted as meaningless siblings alongside the
+            // real content TupleView.
+            let childTypeName = String(describing: type(of: child.value))
+            if isInfrastructureType(childTypeName) { continue }
             if isSwiftUIViewType(value: child.value) {
                 nodes.append(buildNode(
                     from: child.value, depth: depth, maxDepth: maxDepth,
@@ -229,6 +250,8 @@ public enum SwiftUIHierarchyBuilder {
         var nodes: [SwiftUIElementNode] = []
 
         for (index, child) in tupleMirror.children.enumerated() {
+            let childTypeName = String(describing: type(of: child.value))
+            if isInfrastructureType(childTypeName) { continue }
             if isSwiftUIViewType(value: child.value) {
                 nodes.append(buildNode(
                     from: child.value, depth: depth, maxDepth: maxDepth,
@@ -237,6 +260,25 @@ public enum SwiftUIHierarchyBuilder {
             }
         }
         return nodes
+    }
+
+    /// Identifies SwiftUI-internal layout/infrastructure type names that should
+    /// not be surfaced as nodes in the semantic hierarchy: the `Tree<…>`
+    /// wrapper (content is already unwrapped via `_tree`), the layout
+    /// descriptors (`_VStackLayout`, `_HStackLayout`, `_ZStackLayout`,
+    /// `_TupleViewLayout`), and `Optional` wrappers around non-view plumbing
+    /// (e.g. spacing `Optional<CGFloat>`, `Optional<ButtonRole>`).
+    static func isInfrastructureType(_ typeName: String) -> Bool {
+        typeName.hasPrefix("Tree<") ||
+            typeName.contains("_VStackLayout") ||
+            typeName.contains("_HStackLayout") ||
+            typeName.contains("_ZStackLayout") ||
+            typeName.contains("_TupleViewLayout") ||
+            typeName.hasPrefix("Optional<") && typeName.contains("CGFloat") ||
+            typeName.hasPrefix("Optional<") && typeName.contains("ButtonRole") ||
+            typeName.contains("LayoutComputer") ||
+            typeName.contains("ViewRendererHost") ||
+            typeName.contains("Host<")
     }
 
     /// Detect if a UIView (in production) is a SwiftUI hosting view.

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
@@ -1,0 +1,363 @@
+//
+//  SwiftUIHierarchyBuilder.swift
+//  DebugSwift
+//
+//  Created by Matheus Gois on 2025.
+//
+//  Mirror-based SwiftUI view tree reflection.
+//  Walks the declarative SwiftUI hierarchy via Mirror + body accessor,
+//  bypassing the UIKit subview layer that hides semantic views.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - BodyAccessible protocol
+
+/// Protocol to access `body` on any `View` without generic constraints.
+/// Custom SwiftUI views can conform to expose their `body` to the hierarchy builder.
+/// Without this conformance, the view appears as a leaf node (still far better
+/// than the subviews-only approach which shows internal infrastructure classes).
+@MainActor
+public protocol BodyAccessible {
+    @MainActor func bodyAccessor() -> Any
+}
+
+extension View {
+    @MainActor public func bodyAccessor() -> Any { body }
+}
+
+// MARK: - SwiftUIElementNode
+
+/// A node in a reflected SwiftUI view tree.
+/// Unlike UIView-based ViewElement, this walks the *declarative* SwiftUI tree
+/// via Mirror reflection on the hosting controller's rootView.
+public struct SwiftUIElementNode: Equatable {
+    public let id: String
+    public let typeName: String
+    public let displayName: String
+    public let depth: Int
+    public let children: [SwiftUIElementNode]
+    public let properties: [Property]
+
+    public struct Property: Equatable {
+        public let label: String
+        public let valueDescription: String
+
+        public init(label: String, valueDescription: String) {
+            self.label = label
+            self.valueDescription = valueDescription
+        }
+    }
+
+    public init(
+        id: String,
+        typeName: String,
+        displayName: String,
+        depth: Int,
+        children: [SwiftUIElementNode],
+        properties: [Property]
+    ) {
+        self.id = id
+        self.typeName = typeName
+        self.displayName = displayName
+        self.depth = depth
+        self.children = children
+        self.properties = properties
+    }
+
+    public static func == (lhs: SwiftUIElementNode, rhs: SwiftUIElementNode) -> Bool {
+        lhs.id == rhs.id && lhs.typeName == rhs.typeName && lhs.displayName == rhs.displayName
+            && lhs.depth == rhs.depth && lhs.children == rhs.children && lhs.properties == rhs.properties
+    }
+}
+
+// MARK: - SwiftUIHierarchyBuilder
+
+/// The core engine. Given any SwiftUI view value, reflect its tree structure.
+/// This runs on `UIHostingController.rootView` to build the semantic hierarchy
+/// that `UIView.subviews` cannot expose.
+@MainActor
+public enum SwiftUIHierarchyBuilder {
+
+    /// Build a tree from a SwiftUI view value.
+    /// - Parameters:
+    ///   - view: The root SwiftUI view (e.g. UIHostingController.rootView).
+    ///   - maxDepth: Maximum recursion depth to prevent infinite loops.
+    ///   - includeProperties: Whether to extract leaf properties (text, color, etc.).
+    /// - Returns: A hierarchy node representing the view tree.
+    public static func buildTree(
+        from view: Any,
+        maxDepth: Int = 50,
+        includeProperties: Bool = true
+    ) -> SwiftUIElementNode {
+        buildNode(from: view, depth: 0, maxDepth: maxDepth, includeProperties: includeProperties, path: "root")
+    }
+
+    static func buildNode(
+        from value: Any,
+        depth: Int,
+        maxDepth: Int,
+        includeProperties: Bool,
+        path: String
+    ) -> SwiftUIElementNode {
+        let mirror = Mirror(reflecting: value)
+        let typeName = cleanTypeName(String(describing: type(of: value)))
+        let displayName = displayName(for: value, typeName: typeName, mirror: mirror)
+
+        var childNodes: [SwiftUIElementNode] = []
+        var properties: [SwiftUIElementNode.Property] = []
+
+        guard depth < maxDepth else {
+            return SwiftUIElementNode(
+                id: path, typeName: typeName, displayName: displayName,
+                depth: depth, children: [], properties: []
+            )
+        }
+
+        // 0. For custom views (body is a computed property invisible to Mirror),
+        //    call the body accessor. We use a runtime check: if the value's type
+        //    conforms to View, we can call bodyAccessor() via the View extension.
+        //    The `as? BodyAccessible` cast fails because View doesn't explicitly
+        //    conform to BodyAccessible, so we use the bodyAccessor() method directly
+        //    via dynamic dispatch on the protocol extension.
+        if let bodyValue = extractBody(from: value) {
+            if isSwiftUIViewType(value: bodyValue) {
+                childNodes.append(buildNode(
+                    from: bodyValue, depth: depth + 1, maxDepth: maxDepth,
+                    includeProperties: includeProperties, path: "\(path).body"
+                ))
+            }
+        }
+
+        // 1. Drill into SwiftUI's internal _tree wrapper (HStack/VStack/ZStack use it).
+        //    Tree<_HStackLayout, TupleView<...>> → the content is the second generic.
+        if let treeChild = mirror.children.first(where: { $0.label == "_tree" }) {
+            childNodes.append(contentsOf: extractTreeChildren(
+                from: treeChild.value, depth: depth + 1, maxDepth: maxDepth,
+                includeProperties: includeProperties, path: "\(path)._tree"
+            ))
+        }
+
+        // 2. For TupleView, drill into its content to find the individual views.
+        if typeName.contains("TupleView") {
+            childNodes.append(contentsOf: extractTupleChildren(
+                from: value, depth: depth + 1, maxDepth: maxDepth,
+                includeProperties: includeProperties, path: "\(path).tuple"
+            ))
+        }
+
+        // 3. For _ConditionalContent (if/else in ViewBuilder), both branches are stored.
+        if typeName.contains("_ConditionalContent") {
+            for child in mirror.children {
+                if isSwiftUIViewType(value: child.value) {
+                    childNodes.append(buildNode(
+                        from: child.value, depth: depth + 1, maxDepth: maxDepth,
+                        includeProperties: includeProperties, path: "\(path).cond"
+                    ))
+                }
+            }
+        }
+
+        // 4. For ModifiedContent, drill into its content (the wrapped view).
+        if typeName.contains("ModifiedContent"),
+           let contentChild = mirror.children.first(where: { $0.label == "content" })
+        {
+            childNodes.append(buildNode(
+                from: contentChild.value, depth: depth + 1, maxDepth: maxDepth,
+                includeProperties: includeProperties, path: "\(path).content"
+            ))
+        }
+
+        // 5. Generic Mirror walk for stored properties that are views or leaf properties.
+        for (index, child) in mirror.children.enumerated() {
+            let label = child.label ?? "\(index)"
+            // Skip already-handled internal wrappers
+            if label == "_tree" { continue }
+            if label == "content" && typeName.contains("ModifiedContent") { continue }
+
+            if isSwiftUIViewType(value: child.value) {
+                childNodes.append(buildNode(
+                    from: child.value, depth: depth + 1, maxDepth: maxDepth,
+                    includeProperties: includeProperties, path: "\(path).\(label)"
+                ))
+            } else if includeProperties {
+                let desc = String(describing: child.value)
+                if !desc.contains("nil") && desc.count <= 200 {
+                    properties.append(.init(label: label, valueDescription: desc))
+                }
+            }
+        }
+
+        return SwiftUIElementNode(
+            id: path, typeName: typeName, displayName: displayName,
+            depth: depth, children: childNodes, properties: properties
+        )
+    }
+
+    /// Extract children from SwiftUI's internal `Tree<Layout, Content>` wrapper.
+    static func extractTreeChildren(
+        from treeValue: Any,
+        depth: Int,
+        maxDepth: Int,
+        includeProperties: Bool,
+        path: String
+    ) -> [SwiftUIElementNode] {
+        let treeMirror = Mirror(reflecting: treeValue)
+        var nodes: [SwiftUIElementNode] = []
+
+        for child in treeMirror.children {
+            if isSwiftUIViewType(value: child.value) {
+                nodes.append(buildNode(
+                    from: child.value, depth: depth, maxDepth: maxDepth,
+                    includeProperties: includeProperties, path: "\(path).\(child.label ?? "")"
+                ))
+            }
+        }
+        return nodes
+    }
+
+    /// Extract children from a TupleView's content.
+    static func extractTupleChildren(
+        from tupleValue: Any,
+        depth: Int,
+        maxDepth: Int,
+        includeProperties: Bool,
+        path: String
+    ) -> [SwiftUIElementNode] {
+        let tupleMirror = Mirror(reflecting: tupleValue)
+        var nodes: [SwiftUIElementNode] = []
+
+        for (index, child) in tupleMirror.children.enumerated() {
+            if isSwiftUIViewType(value: child.value) {
+                nodes.append(buildNode(
+                    from: child.value, depth: depth, maxDepth: maxDepth,
+                    includeProperties: includeProperties, path: "\(path).\(index)"
+                ))
+            }
+        }
+        return nodes
+    }
+
+    /// Detect if a UIView (in production) is a SwiftUI hosting view.
+    public static func isSwiftUIHostingClassName(_ className: String) -> Bool {
+        className.contains("UIHosting") ||
+            className.contains("_UIHosting") ||
+            className.contains("SwiftUI.") ||
+            className.contains("ViewHost") ||
+            className.contains("PlatformView") ||
+            className.contains("DisplayList") ||
+            className.contains("ViewGraph") ||
+            className.contains("ModifiedContent") ||
+            className.contains("CellHostingView") ||
+            className.contains("HostingView")
+    }
+
+    /// Determine if a value is a SwiftUI view type by checking for `View` conformance
+    /// or known SwiftUI type patterns.
+    static func isSwiftUIViewType(value: Any) -> Bool {
+        let typeName = String(describing: type(of: value))
+
+        let viewPatterns = [
+            "VStack", "HStack", "ZStack", "List", "ScrollView", "ForEach",
+            "NavigationStack", "NavigationView", "TabView", "Group",
+            "Text", "Image", "Button", "TextField", "Toggle", "Slider",
+            "Stepper", "DatePicker", "Picker", "Label", "Spacer",
+            "Divider", "Color", "Shape", "Map", "SecureField", "Link",
+            "NavigationLink", "Menu", "ContextMenu", "Sheet", "Alert",
+            "ModifiedContent", "_ConditionalContent", "Optional", "Group",
+            "LazyVStack", "LazyHStack", "LazyVGrid", "LazyHGrid",
+            "DisclosureGroup", "Section", "Form", "Grid", "GridRow",
+            "ViewThatFits", "AnyView", "TupleView", "_TupleView"
+        ]
+
+        for pattern in viewPatterns where typeName.contains(pattern) {
+            return true
+        }
+
+        if typeName.hasSuffix("View") || typeName.hasSuffix("View>") {
+            return true
+        }
+
+        let mirror = Mirror(reflecting: value)
+        if mirror.children.contains(where: { $0.label == "body" }) {
+            return true
+        }
+
+        return false
+    }
+
+
+    /// Clean up internal Swift type name mangling for display.
+    static func cleanTypeName(_ name: String) -> String {
+        var cleaned = name
+        if cleaned.hasPrefix("SwiftUI.") {
+            cleaned = String(cleaned.dropFirst("SwiftUI.".count))
+        }
+        return cleaned
+    }
+
+    /// Generate a human-friendly display name.
+    static func displayName(for value: Any, typeName: String, mirror: Mirror) -> String {
+        if typeName.hasPrefix("Text") || typeName == "Text" {
+            for child in mirror.children {
+                if child.label == "anyTextStorage" || child.label == "text" {
+                    let textDesc = String(describing: child.value)
+                    if textDesc != "Optional(Optional(nil))" && !textDesc.contains("nil") {
+                        return "Text(\"\(textDesc)\")"
+                    }
+                }
+            }
+        }
+
+        if typeName.hasPrefix("Button") {
+            return "Button"
+        }
+
+        if ["VStack", "HStack", "ZStack"].contains(where: { typeName.hasPrefix($0) }) {
+            return typeName.split(separator: "<").first.map(String.init) ?? typeName
+        }
+
+        return typeName
+    }
+
+    /// Flatten the tree into a list (for table view display).
+    public static func flatten(_ node: SwiftUIElementNode) -> [SwiftUIElementNode] {
+        var result: [SwiftUIElementNode] = [node]
+        for child in node.children {
+            result.append(contentsOf: flatten(child))
+        }
+        return result
+    }
+
+    /// Count total nodes in the tree.
+    public static func count(_ node: SwiftUIElementNode) -> Int {
+        1 + node.children.reduce(0) { $0 + count($1) }
+    }
+
+    /// Find nodes by type name pattern.
+    public static func find(_ node: SwiftUIElementNode, typeName contains: String) -> [SwiftUIElementNode] {
+        var result: [SwiftUIElementNode] = []
+        if node.typeName.contains(contains) {
+            result.append(node)
+        }
+        for child in node.children {
+            result.append(contentsOf: find(child, typeName: contains))
+        }
+        return result
+    }
+}
+// MARK: - Body extraction
+
+/// Extracts the `body` from a SwiftUI View value.
+/// Custom views must conform to `BodyAccessible` to expose their computed `body`
+/// property (Mirror only sees stored properties, not computed ones).
+/// Built-in SwiftUI views (VStack, Text, etc.) expose their content via
+/// stored properties like `_tree`, which the Mirror walk handles directly.
+@MainActor
+private func extractBody(from value: Any) -> Any? {
+    if let bodyful = value as? BodyAccessible {
+        return bodyful.bodyAccessor()
+    }
+    return nil
+}

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
@@ -115,20 +115,19 @@ public enum SwiftUIHierarchyBuilder {
             )
         }
 
-        // 0. For custom views (body is a computed property invisible to Mirror),
-        //    call the body accessor. We use a runtime check: if the value's type
-        //    conforms to View, we can call bodyAccessor() via the View extension.
-        //    The `as? BodyAccessible` cast fails because View doesn't explicitly
-        //    conform to BodyAccessible, so we use the bodyAccessor() method directly
-        //    via dynamic dispatch on the protocol extension.
-        if let bodyValue = extractBody(from: value) {
-            if isSwiftUIViewType(value: bodyValue) {
-                childNodes.append(buildNode(
-                    from: bodyValue, depth: depth + 1, maxDepth: maxDepth,
-                    includeProperties: includeProperties, path: "\(path).body"
-                ))
-            }
-        }
+        // 0. Mirror-first content extraction. SwiftUI primitive views
+        // (NavigationView, ScrollView, VStack, Button, …) expose their content
+        // through *stored* properties (`_tree`, `content`, tuple children, …)
+        // that Mirror can see. Custom views, conversely, expose their content
+        // only through the computed `body` property (invisible to Mirror).
+        //
+        // We therefore run the Mirror-based extraction (steps 1–5 below)
+        // FIRST and only fall back to calling `body` (step 0) when Mirror yields
+        // no children. This guarantees `body` is never invoked on a primitive:
+        // calling `body` on a primitive traps at runtime with "body() should
+        // not be called on …" (it is a stub that raises SIGTRAP), and primitives
+        // are exactly the views that always have Mirror-visible content, so
+        // the fallback never reaches them.
 
         // 1. Drill into SwiftUI's internal _tree wrapper (HStack/VStack/ZStack/
         //    ScrollView use it). Tree<_HStackLayout, TupleView<...>> → the
@@ -210,6 +209,21 @@ public enum SwiftUIHierarchyBuilder {
             }
         }
 
+        // 0 (fallback). Custom views (OSLogTestView, ContentView, …) expose
+        // their content only through the computed `body`, which Mirror cannot
+        // see, so the Mirror walk above produced no children for them. Only now
+        // — after confirming Mirror yielded nothing — do we call `body`. This is
+        // safe because primitives always produce Mirror children (so we never
+        // reach here for them), and `body` on a genuine custom view is the
+        // intended accessor. See the comment at the top of buildNode.
+        if childNodes.isEmpty, let bodyValue = extractBody(from: value),
+           isSwiftUIViewType(value: bodyValue)
+        {
+            childNodes.append(buildNode(
+                from: bodyValue, depth: depth + 1, maxDepth: maxDepth,
+                includeProperties: includeProperties, path: "\(path).body"
+            ))
+        }
         // Note: SwiftUI's Mirror layout can expose the same content through
         // multiple stored properties. The per-type skips above (content when
         // _tree/ModifiedContent/ScrollView is present, TupleView generic
@@ -415,53 +429,28 @@ public enum SwiftUIHierarchyBuilder {
 }
 // MARK: - Body extraction
 
-/// Extracts the `body` from a SwiftUI View value.
-/// Custom views must conform to `BodyAccessible` to expose their computed `body`
-/// property (Mirror only sees stored properties, not computed ones).
-/// Built-in SwiftUI views (VStack, Text, etc.) expose their content via
-/// stored properties like `_tree`, which the Mirror walk handles directly.
+/// Extracts the `body` from a SwiftUI `View` value.
+///
+/// `body` is the ONLY way to reach a custom view's content (Mirror can't see
+/// computed properties), but calling it on a SwiftUI *primitive* view traps at
+/// runtime with "body() should not be called on …". Primitives live in the
+/// `SwiftUI`/`SwiftUICore` module, so we guard `extractBody` on the module of
+/// the value's type — `String(reflecting: type(of:))` yields the fully-qualified
+/// path (e.g. `SwiftUI.Color`, `SwiftUI.SubscriptionView<A, B>`) and we skip
+/// anything whose module is SwiftUI. User-defined views (in the app's module)
+/// pass and get their `body` called. This needs no type-name allowlist, so it
+/// can't be broken by a new SwiftUI primitive like `SubscriptionView`.
 @MainActor
 private func extractBody(from value: Any) -> Any? {
-    // Calling `body` on a *primitive* SwiftUI view (NavigationView, ScrollView,
-    // Button, Text, …) traps at runtime with "body() should not be called on
-    // …", so we must NOT invoke it for those. Primitives expose their content
-    // through stored properties (`_tree`, `content`, …) handled by the Mirror
-    // walk below.
-    //
-    // Custom views, conversely, expose their content ONLY through `body`
-    // (Mirror can't see computed properties), so we DO call it for them. We
-    // distinguish by type name: anything whose outer type name is a known
-    // primitive is skipped; everything else (user types like OSLogInNavView,
-    // ContentView, …) goes through `body`.
-    let typeName = String(describing: type(of: value))
-    guard !isPrimitiveViewType(typeName) else { return nil }
-
-
+    // `String(reflecting:)` gives the fully-qualified type name including the
+    // module, e.g. "SwiftUI.Color" / "MyApp.MyView". Primitives live in SwiftUI
+    // (or SwiftUICore); user views live in the app module.
+    let qualified = String(reflecting: type(of: value))
+    if qualified.hasPrefix("SwiftUI.") || qualified.hasPrefix("SwiftUICore.") {
+        return nil
+    }
     if let view = value as? any View {
         return view.bodyAccessor()
     }
     return nil
-}
-
-/// Names of SwiftUI primitive view types whose `body` traps and must never be
-/// invoked. Their content is reached via Mirror stored properties instead.
-private let primitiveViewTypeNames: Set<String> = [
-    "NavigationView", "NavigationStack", "NavigationSplitView",
-    "ScrollView", "List", "Form", "Group", "Section",
-    "VStack", "HStack", "ZStack", "LazyVStack", "LazyHStack",
-    "TupleView", "ConditionalContent",
-    "Button", "Text", "Label", "Image", "Color",
-    "Spacer", "Divider", "EmptyView",
-    "ForEach", "ModifiedContent", "AnyView",
-    "Optional", "IdentityOptional",
-    "NavigationLink", "TabView", "Picker", "TextField", "Slider", "Toggle",
-    "Stepper", "SecureField", "Editor", "Map"
-]
-
-@MainActor
-private func isPrimitiveViewType(_ typeName: String) -> Bool {
-    // Match the outer type name (before any `<`), since primitives may carry
-    // generic parameters, e.g. "NavigationView<ModifiedContent<…>>".
-    let outer = typeName.split(separator: "<").first.map(String.init) ?? typeName
-    return primitiveViewTypeNames.contains(outer)
 }

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
@@ -422,8 +422,46 @@ public enum SwiftUIHierarchyBuilder {
 /// stored properties like `_tree`, which the Mirror walk handles directly.
 @MainActor
 private func extractBody(from value: Any) -> Any? {
-    if let bodyful = value as? BodyAccessible {
-        return bodyful.bodyAccessor()
+    // Calling `body` on a *primitive* SwiftUI view (NavigationView, ScrollView,
+    // Button, Text, …) traps at runtime with "body() should not be called on
+    // …", so we must NOT invoke it for those. Primitives expose their content
+    // through stored properties (`_tree`, `content`, …) handled by the Mirror
+    // walk below.
+    //
+    // Custom views, conversely, expose their content ONLY through `body`
+    // (Mirror can't see computed properties), so we DO call it for them. We
+    // distinguish by type name: anything whose outer type name is a known
+    // primitive is skipped; everything else (user types like OSLogInNavView,
+    // ContentView, …) goes through `body`.
+    let typeName = String(describing: type(of: value))
+    guard !isPrimitiveViewType(typeName) else { return nil }
+
+
+    if let view = value as? any View {
+        return view.bodyAccessor()
     }
     return nil
+}
+
+/// Names of SwiftUI primitive view types whose `body` traps and must never be
+/// invoked. Their content is reached via Mirror stored properties instead.
+private let primitiveViewTypeNames: Set<String> = [
+    "NavigationView", "NavigationStack", "NavigationSplitView",
+    "ScrollView", "List", "Form", "Group", "Section",
+    "VStack", "HStack", "ZStack", "LazyVStack", "LazyHStack",
+    "TupleView", "ConditionalContent",
+    "Button", "Text", "Label", "Image", "Color",
+    "Spacer", "Divider", "EmptyView",
+    "ForEach", "ModifiedContent", "AnyView",
+    "Optional", "IdentityOptional",
+    "NavigationLink", "TabView", "Picker", "TextField", "Slider", "Toggle",
+    "Stepper", "SecureField", "Editor", "Map"
+]
+
+@MainActor
+private func isPrimitiveViewType(_ typeName: String) -> Bool {
+    // Match the outer type name (before any `<`), since primitives may carry
+    // generic parameters, e.g. "NavigationView<ModifiedContent<…>>".
+    let outer = typeName.split(separator: "<").first.map(String.init) ?? typeName
+    return primitiveViewTypeNames.contains(outer)
 }

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
@@ -130,8 +130,10 @@ public enum SwiftUIHierarchyBuilder {
             }
         }
 
-        // 1. Drill into SwiftUI's internal _tree wrapper (HStack/VStack/ZStack use it).
-        //    Tree<_HStackLayout, TupleView<...>> → the content is the second generic.
+        // 1. Drill into SwiftUI's internal _tree wrapper (HStack/VStack/ZStack/
+        //    ScrollView use it). Tree<_HStackLayout, TupleView<...>> → the
+        //    content is the second generic.
+        let hasTree = mirror.children.contains { $0.label == "_tree" }
         if let treeChild = mirror.children.first(where: { $0.label == "_tree" }) {
             childNodes.append(contentsOf: extractTreeChildren(
                 from: treeChild.value, depth: depth + 1, maxDepth: maxDepth,
@@ -140,15 +142,16 @@ public enum SwiftUIHierarchyBuilder {
         }
 
         // 2. For TupleView, drill into its content to find the individual views.
-        if typeName.contains("TupleView") {
+        //    Match by prefix so a ModifiedContent<VStack<TupleView<…>>> (whose
+        //    mangled name *contains* "TupleView") isn't mistaken for a TupleView.
+        if typeName.hasPrefix("TupleView") {
             childNodes.append(contentsOf: extractTupleChildren(
                 from: value, depth: depth + 1, maxDepth: maxDepth,
                 includeProperties: includeProperties, path: "\(path).tuple"
             ))
         }
 
-        // 3. For _ConditionalContent (if/else in ViewBuilder), both branches are stored.
-        if typeName.contains("_ConditionalContent") {
+        if typeName.hasPrefix("_ConditionalContent") {
             for child in mirror.children {
                 if isSwiftUIViewType(value: child.value) {
                     childNodes.append(buildNode(
@@ -172,12 +175,15 @@ public enum SwiftUIHierarchyBuilder {
         // 5. Generic Mirror walk for stored properties that are views or leaf properties.
         for (index, child) in mirror.children.enumerated() {
             let label = child.label ?? "\(index)"
-            // Skip already-handled internal wrappers
+            // Skip already-handled internal wrappers:
+            //   - _tree: unwrapped in step 1.
+            //   - content (ModifiedContent OR when _tree is present): emitted
+            //     via step 1/4, so skip the duplicate here.
             if label == "_tree" { continue }
-            if label == "content" && typeName.contains("ModifiedContent") { continue }
+            if label == "content" && (typeName.contains("ModifiedContent") || typeName.contains("ScrollView") || hasTree) { continue }
             // TupleView's content (the tuple of views) is already unwrapped by
             // step 2; skip it here to avoid emitting the same children twice.
-            if typeName.contains("TupleView") { continue }
+            if typeName.hasPrefix("TupleView") { continue }
 
             // Skip SwiftUI layout/infrastructure values that would otherwise be
             // surfaced as duplicate or meaningless nodes: the internal `Tree<…>`
@@ -204,6 +210,13 @@ public enum SwiftUIHierarchyBuilder {
             }
         }
 
+        // Note: SwiftUI's Mirror layout can expose the same content through
+        // multiple stored properties. The per-type skips above (content when
+        // _tree/ModifiedContent/ScrollView is present, TupleView generic
+        // walk, infrastructure types) handle the known duplication paths.
+        // A structural-equality dedup here was attempted but collapsed
+        // legitimately-identical-structure siblings (e.g. six Buttons whose
+        // Text labels don't surface in the displayName), so it was removed.
         return SwiftUIElementNode(
             id: path, typeName: typeName, displayName: displayName,
             depth: depth, children: childNodes, properties: properties
@@ -274,11 +287,22 @@ public enum SwiftUIHierarchyBuilder {
             typeName.contains("_HStackLayout") ||
             typeName.contains("_ZStackLayout") ||
             typeName.contains("_TupleViewLayout") ||
+            typeName.contains("_PaddingLayout") ||
             typeName.hasPrefix("Optional<") && typeName.contains("CGFloat") ||
             typeName.hasPrefix("Optional<") && typeName.contains("ButtonRole") ||
+            // SwiftUI configuration/gesture/state plumbing attached to
+            // containers (ScrollViewConfiguration, gesture recognizers, etc.).
+            // These are stored alongside the real content and are not views.
+            typeName.contains("ScrollViewConfiguration") ||
+            typeName.contains("Configuration") && typeName.hasSuffix("Configuration") ||
+            typeName.contains("Gesture") ||
+            typeName.contains("ScrollToTopGestureAction") ||
+            typeName.contains("SafeAreaTransitionState") ||
+            typeName.contains("RefreshAction") ||
             typeName.contains("LayoutComputer") ||
             typeName.contains("ViewRendererHost") ||
-            typeName.contains("Host<")
+            typeName.contains("Host<") ||
+            typeName.contains("ButtonAction")
     }
 
     /// Detect if a UIView (in production) is a SwiftUI hosting view.

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/SwiftUIHierarchyBuilder.swift
@@ -91,7 +91,30 @@ public enum SwiftUIHierarchyBuilder {
         maxDepth: Int = 50,
         includeProperties: Bool = true
     ) -> SwiftUIElementNode {
-        buildNode(from: view, depth: 0, maxDepth: maxDepth, includeProperties: includeProperties, path: "root")
+        // The root is virtually always a user-defined custom view
+        // (OSLogTestView, ContentView, …) whose content lives ONLY behind the
+        // computed `body` — Mirror cannot see it. So we evaluate `body` ONCE
+        // here, at the root, and then recurse into `buildNode`, which uses ONLY
+        // Mirror and never calls `body` again.
+        //
+        // Why once and only at the root: calling `body` on a SwiftUI *primitive*
+        // (NavigationView, ScrollView, SubscriptionView<A, B>, Color, …) traps
+        // at runtime with "body() should not be called on …" and kills the app
+        // through DebugSwift's own CrashSignalHandler. Primitives can only ever
+        // appear as *children* (the result of some custom view's `body`, or
+        // nested inside a primitive's stored `_tree`/`content`), so by calling
+        // `body` exactly once — at the root, which is the developer's view and
+        // therefore safe — and never again, we guarantee no primitive is ever
+        // asked for its `body`. This replaces the fragile type-name allowlist
+        // and the "fallback when Mirror is empty" heuristic (both of which
+        // crashed on SubscriptionView).
+        if let bodyValue = extractRootBody(from: view) {
+            return buildNode(
+                from: bodyValue, depth: 0, maxDepth: maxDepth,
+                includeProperties: includeProperties, path: "root.body"
+            )
+        }
+        return buildNode(from: view, depth: 0, maxDepth: maxDepth, includeProperties: includeProperties, path: "root")
     }
 
     static func buildNode(
@@ -209,28 +232,14 @@ public enum SwiftUIHierarchyBuilder {
             }
         }
 
-        // 0 (fallback). Custom views (OSLogTestView, ContentView, …) expose
-        // their content only through the computed `body`, which Mirror cannot
-        // see, so the Mirror walk above produced no children for them. Only now
-        // — after confirming Mirror yielded nothing — do we call `body`. This is
-        // safe because primitives always produce Mirror children (so we never
-        // reach here for them), and `body` on a genuine custom view is the
-        // intended accessor. See the comment at the top of buildNode.
-        if childNodes.isEmpty, let bodyValue = extractBody(from: value),
-           isSwiftUIViewType(value: bodyValue)
-        {
-            childNodes.append(buildNode(
-                from: bodyValue, depth: depth + 1, maxDepth: maxDepth,
-                includeProperties: includeProperties, path: "\(path).body"
-            ))
-        }
-        // Note: SwiftUI's Mirror layout can expose the same content through
-        // multiple stored properties. The per-type skips above (content when
-        // _tree/ModifiedContent/ScrollView is present, TupleView generic
-        // walk, infrastructure types) handle the known duplication paths.
-        // A structural-equality dedup here was attempted but collapsed
-        // legitimately-identical-structure siblings (e.g. six Buttons whose
-        // Text labels don't surface in the displayName), so it was removed.
+        // NOTE: `buildNode` deliberately never calls `body`. The root's `body`
+        // is evaluated exactly once in `buildTree` (see extractRootBody); every
+        // node below it is reached purely via Mirror stored properties. This
+        // is what makes traversal crash-safe: a primitive can only ever appear
+        // as a child of some other view, and children are never asked for
+        // their `body` here. The previous per-node `extractBody` fallback
+        // crashed on SubscriptionView (and any future primitive) because it
+        // invoked `body` on leaf primitives that have no Mirror children.
         return SwiftUIElementNode(
             id: path, typeName: typeName, displayName: displayName,
             depth: depth, children: childNodes, properties: properties
@@ -427,30 +436,36 @@ public enum SwiftUIHierarchyBuilder {
         return result
     }
 }
-// MARK: - Body extraction
+// MARK: - Root body extraction
 
-/// Extracts the `body` from a SwiftUI `View` value.
+/// Evaluates `body` exactly once, at the root of the view tree.
 ///
-/// `body` is the ONLY way to reach a custom view's content (Mirror can't see
-/// computed properties), but calling it on a SwiftUI *primitive* view traps at
-/// runtime with "body() should not be called on …". Primitives live in the
-/// `SwiftUI`/`SwiftUICore` module, so we guard `extractBody` on the module of
-/// the value's type — `String(reflecting: type(of:))` yields the fully-qualified
-/// path (e.g. `SwiftUI.Color`, `SwiftUI.SubscriptionView<A, B>`) and we skip
-/// anything whose module is SwiftUI. User-defined views (in the app's module)
-/// pass and get their `body` called. This needs no type-name allowlist, so it
-/// can't be broken by a new SwiftUI primitive like `SubscriptionView`.
+/// The root passed to `buildTree` is the hosting controller's `rootView` — a
+/// user-defined custom view (OSLogTestView, ContentView, …). Its content lives
+/// ONLY behind the computed `body` (Mirror can't see computed properties), so
+/// we must call `body` to get past it. We do so exactly once, here, and then
+/// recurse into `buildNode`, which uses ONLY Mirror and never calls `body`
+/// again.
+///
+/// Why only here: calling `body` on a SwiftUI *primitive* (NavigationView,
+/// ScrollView, SubscriptionView<A, B>, Color, …) traps at runtime with
+/// "body() should not be called on …" and kills the app via DebugSwift's own
+/// CrashSignalHandler. Primitives can only ever appear as *children* — the
+/// result of some custom view's `body`, or nested inside a primitive's stored
+/// `_tree`/`content`. By calling `body` only at the root (the developer's own
+/// view, which is safe) and never again, no primitive is ever asked for its
+/// `body`. This replaces the fragile type-name allowlist AND the per-node
+/// "fallback when Mirror is empty" heuristic — both crashed on SubscriptionView.
+///
+/// Guard: if the root itself is somehow a SwiftUI-module view (e.g. someone
+/// hosts `Color.red` directly), skip `body` and let Mirror handle it — never
+/// call `body` on a primitive, even the root.
 @MainActor
-private func extractBody(from value: Any) -> Any? {
-    // `String(reflecting:)` gives the fully-qualified type name including the
-    // module, e.g. "SwiftUI.Color" / "MyApp.MyView". Primitives live in SwiftUI
-    // (or SwiftUICore); user views live in the app module.
+private func extractRootBody(from value: Any) -> Any? {
     let qualified = String(reflecting: type(of: value))
     if qualified.hasPrefix("SwiftUI.") || qualified.hasPrefix("SwiftUICore.") {
         return nil
     }
-    if let view = value as? any View {
-        return view.bodyAccessor()
-    }
-    return nil
+    guard let view = value as? any View else { return nil }
+    return view.bodyAccessor()
 }

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
@@ -63,7 +63,13 @@ final class ViewElement: NSObject, Element {
         if SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(className),
            let tree = swiftUITree(for: view)
         {
-            return SwiftUIElement.elements(for: tree, in: view.frame)
+            // Capture the hosting view's pixels once. Each SwiftUI node crops
+            // this screenshot to its assigned frame so its 3D plane shows the
+            // real rendered content (button background + label) instead of an
+            // empty white plane. Only for the 3D-snapshot path: the hierarchy
+            // table doesn't render planes, so skip the capture there.
+            let snapshot = useSwiftUIHierarchy ? nil : snapshotView(view)
+            return SwiftUIElement.elements(for: tree, in: view.frame, hostingSnapshot: snapshot)
         }
 
         // Plain UIKit view: walk its real subviews.

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
@@ -458,13 +458,22 @@ private func getViewController(view: UIView) -> UIViewController? {
     return nil
 }
 
-/// Extracts the SwiftUI view tree from a `_UIHostingView` by reflecting
-/// the hosting controller's `rootView` via `SwiftUIHierarchyBuilder`.
-/// Returns `nil` if the view is not backed by a `UIHostingController`.
-/// Uses Mirror to avoid needing the generic type parameter of `UIHostingController`.
+/// Extracts the SwiftUI view tree from a `_UIHostingView` by reaching the
+/// hosting controller's `rootView` and building a semantic tree via
+/// `SwiftUIHierarchyBuilder`. Returns `nil` if the view is not backed by a
+/// `UIHostingController`.
+///
+/// `UIHostingController.rootView` is a generic Swift property (not `@objc`, not
+/// KVC-compliant, not visible to Mirror), so the only generic way to read it is
+/// to cast the controller through a protocol whose conformance captures the
+/// generic `Content` and returns `rootView as Any`. We define that protocol
+/// (`AnyHostingController`) and conform `UIHostingController` to it, then walk
+/// up the responder chain to a hosting controller and read `rootViewValue`.
+/// This never raises an Obj-C exception (no KVC), so it cannot trigger the
+/// `NSUnknownKeyException` crash that KVC caused on NavigationSplitView-backed
+/// controllers.
 @MainActor
 private func swiftUITree(for view: UIView) -> SwiftUIElementNode? {
-    // Walk up the responder chain to find a hosting controller
     let candidates: [UIViewController?] = [
         getViewController(view: view),
         getNearestAncestorViewController(responder: view),
@@ -472,38 +481,29 @@ private func swiftUITree(for view: UIView) -> SwiftUIElementNode? {
 
     for viewController in candidates {
         guard let viewController else { continue }
-        let typeName = String(describing: type(of: viewController))
-        guard typeName.contains("UIHostingController") || typeName.contains("HostingController") else {
+        guard let hostingController = viewController as? any AnyHostingController else {
             continue
         }
-
-        // Try 1: Mirror on the _UIHostingView itself — rootView is stored as `_rootView`
-        let viewMirror = Mirror(reflecting: view)
-        if let rootViewChild = viewMirror.children.first(where: { $0.label == "_rootView" || $0.label == "rootView" }) {
-            return SwiftUIHierarchyBuilder.buildTree(from: rootViewChild.value)
-        }
-
-        // Try 2: Mirror on the controller
-        let vcMirror = Mirror(reflecting: viewController)
-        if let rootViewChild = vcMirror.children.first(where: { $0.label == "_rootView" || $0.label == "rootView" }) {
-            return SwiftUIHierarchyBuilder.buildTree(from: rootViewChild.value)
-        }
-
-        // Try 3 (formerly KVC `value(forKey:)`) has been removed.
-        // KVC's value(forKey:) raises an NSUnknownKeyException (an Obj-C
-        // exception, not a Swift error) when the key is not KVC-compliant.
-        // SwiftUI-internal hosting controllers — e.g.
-        // UIHostingController<ModifiedContent<…NavigationSearchColumnModifier…>>
-        // used by NavigationSplitView's sidebar — do NOT expose `rootView`
-        // via KVC, so this path threw an uncaught exception that DebugSwift's
-        // own UncaughtExceptionHandler captured as a crash, killing the app
-        // whenever the view debugger was opened on a screen using such a
-        // controller. Mirror reflection (Try 1 / Try 2) is safe and never
-        // raises; if it can't find rootView we fall back to the subview path
-        // rather than crashing.
+        return SwiftUIHierarchyBuilder.buildTree(from: hostingController.rootViewValue)
     }
 
     return nil
+}
+
+/// Type-erased accessor for `UIHostingController.rootView`. `rootView` is a
+/// generic Swift property (not `@objc`, not KVC-compliant, not visible to
+/// Mirror), so the only generic way to read it is to cast the controller
+/// through a protocol whose conformance captures the generic `Content` and
+/// returns `rootView as Any`. This never raises an Obj-C exception (no KVC),
+/// so it cannot trigger the `NSUnknownKeyException` crash that KVC caused on
+/// NavigationSplitView-backed controllers.
+@MainActor
+private protocol AnyHostingController: AnyObject {
+    var rootViewValue: Any { get }
+}
+
+extension UIHostingController: AnyHostingController {
+    var rootViewValue: Any { rootView }
 }
 
 @MainActor

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Indragie Karunaratne. All rights reserved.
 //
 
+import SwiftUI
 import UIKit
 
 /// An element that represents a UIView.
@@ -38,11 +39,28 @@ final class ViewElement: NSObject, Element {
         return snapshotView(view)
     }
 
+    var underlyingView: UIView? { view }
+
     var children: [Element] {
         guard let view else {
             return []
         }
-        return view.subviews.map { ViewElement(view: $0) }
+
+        // Check if this is a SwiftUI hosting view. If so, and the hierarchy
+        // mode is enabled, reflect the declarative SwiftUI tree via Mirror
+        // instead of walking UIView subviews (which only expose internal
+        // infrastructure views). The 3D snapshot view passes `false` so it
+        // can render real frames and pixel snapshots.
+        if useSwiftUIHierarchy {
+            let className = NSStringFromClass(type(of: view))
+            if SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(className),
+               let tree = swiftUITree(for: view)
+            {
+                return tree.children.map { SwiftUIElement(node: $0, parentFrame: view.frame) }
+            }
+        }
+
+        return view.subviews.map { ViewElement(view: $0, useSwiftUIHierarchy: useSwiftUIHierarchy) }
     }
 
     var title: String {
@@ -345,17 +363,20 @@ final class ViewElement: NSObject, Element {
                 additionalInfo += "\nStyle: \(activityIndicator.style.rawValue)"
             }
             
-            // SwiftUI Hosting Controller detection
-            if let hostingVC = getViewController(view: view),
-               String(describing: type(of: hostingVC)).contains("HostingController") ||
-               String(describing: type(of: hostingVC)).contains("HostingView") {
+            // SwiftUI Hosting Controller detection — use the new hierarchy builder
+            let hostingClassName = NSStringFromClass(type(of: view))
+            if SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(hostingClassName),
+               let tree = swiftUITree(for: view)
+            {
                 additionalInfo += "\n\n- SwiftUI Info:"
-                additionalInfo += "\nHosting Controller: \(String(describing: type(of: hostingVC)))"
-                
-                // Try to extract SwiftUI view information using reflection
-                let swiftUIInfo = extractSwiftUIInfo(from: view, viewController: hostingVC)
-                if !swiftUIInfo.isEmpty {
-                    additionalInfo += "\n\(swiftUIInfo)"
+                additionalInfo += "\nRoot View: \(tree.displayName)"
+                additionalInfo += "\nType: \(tree.typeName)"
+                if !tree.children.isEmpty {
+                    additionalInfo += "\nChildren: \(tree.children.map(\.displayName).joined(separator: ", "))"
+                }
+                if !tree.properties.isEmpty {
+                    let props = tree.properties.prefix(5).map { "\($0.label): \($0.valueDescription)" }
+                    additionalInfo += "\nProperties: \(props.joined(separator: ", "))"
                 }
             }
             
@@ -407,12 +428,18 @@ final class ViewElement: NSObject, Element {
     }
 
     private weak var view: UIView?
+    private let useSwiftUIHierarchy: Bool
 
     /// Constructs a new `ViewElement`
     ///
-    /// - Parameter view: The `UIView` to create the element for.
-    @objc init(view: UIView) {
+    /// - Parameters:
+    ///   - view: The `UIView` to create the element for.
+    ///   - useSwiftUIHierarchy: When `true`, SwiftUI hosting views expose their
+    ///   declarative view tree (VStack, Text, …) as children instead of the
+    ///   internal UIKit infrastructure subviews.
+    @objc init(view: UIView, useSwiftUIHierarchy: Bool = true) {
         self.view = view
+        self.useSwiftUIHierarchy = useSwiftUIHierarchy
     }
 }
 
@@ -424,64 +451,44 @@ private func getViewController(view: UIView) -> UIViewController? {
     return nil
 }
 
+/// Extracts the SwiftUI view tree from a `_UIHostingView` by reflecting
+/// the hosting controller's `rootView` via `SwiftUIHierarchyBuilder`.
+/// Returns `nil` if the view is not backed by a `UIHostingController`.
+/// Uses Mirror to avoid needing the generic type parameter of `UIHostingController`.
 @MainActor
-private func extractSwiftUIInfo(from view: UIView, viewController: UIViewController) -> String {
-    var info = ""
-    
-    // Try to get the root view from hosting controller
-    let mirror = Mirror(reflecting: viewController)
-    
-    for child in mirror.children {
-        if let label = child.label {
-            // Look for rootView or similar properties
-            if label.contains("rootView") || label.contains("content") {
-                info += "\nRoot View Type: \(type(of: child.value))"
-                
-                // Inspect the SwiftUI view structure
-                let viewMirror = Mirror(reflecting: child.value)
-                var viewProperties: [String] = []
-                
-                for viewChild in viewMirror.children {
-                    if let viewLabel = viewChild.label,
-                       !viewLabel.hasPrefix("_"),
-                       !viewLabel.contains("$__") {
-                        let valueString = String(describing: viewChild.value)
-                        if valueString.count < 50 {
-                            viewProperties.append("\(viewLabel): \(valueString)")
-                        }
-                    }
-                }
-                
-                if !viewProperties.isEmpty {
-                    info += "\nView Properties:"
-                    for prop in viewProperties.prefix(10) {
-                        info += "\n  • \(prop)"
-                    }
-                    if viewProperties.count > 10 {
-                        info += "\n  ... and \(viewProperties.count - 10) more"
-                    }
-                }
-            }
+private func swiftUITree(for view: UIView) -> SwiftUIElementNode? {
+    // Walk up the responder chain to find a hosting controller
+    let candidates: [UIViewController?] = [
+        getViewController(view: view),
+        getNearestAncestorViewController(responder: view),
+    ]
+
+    for viewController in candidates {
+        guard let viewController else { continue }
+        let typeName = String(describing: type(of: viewController))
+        guard typeName.contains("UIHostingController") || typeName.contains("HostingController") else {
+            continue
+        }
+
+        // Try 1: Mirror on the _UIHostingView itself — rootView is stored as `_rootView`
+        let viewMirror = Mirror(reflecting: view)
+        if let rootViewChild = viewMirror.children.first(where: { $0.label == "_rootView" || $0.label == "rootView" }) {
+            return SwiftUIHierarchyBuilder.buildTree(from: rootViewChild.value)
+        }
+
+        // Try 2: Mirror on the controller
+        let vcMirror = Mirror(reflecting: viewController)
+        if let rootViewChild = vcMirror.children.first(where: { $0.label == "_rootView" || $0.label == "rootView" }) {
+            return SwiftUIHierarchyBuilder.buildTree(from: rootViewChild.value)
+        }
+
+        // Try 3: KVC on the controller (rootView is a public property)
+        if let rootView = viewController.value(forKey: "rootView") {
+            return SwiftUIHierarchyBuilder.buildTree(from: rootView)
         }
     }
-    
-    // Extract environment and modifier information
-    let viewMirror = Mirror(reflecting: view)
-    var modifiers: [String] = []
-    
-    for child in viewMirror.children {
-        if let label = child.label {
-            if label.contains("Modifier") || label.contains("Environment") {
-                modifiers.append(label)
-            }
-        }
-    }
-    
-    if !modifiers.isEmpty {
-        info += "\nModifiers: \(modifiers.joined(separator: ", "))"
-    }
-    
-    return info
+
+    return nil
 }
 
 @MainActor

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
@@ -60,6 +60,22 @@ final class ViewElement: NSObject, Element {
             }
         }
 
+        // 3D snapshot fallback: a `_UIHostingView` renders its content
+        // directly into the hosting view and exposes *no* UIView subviews.
+        // Without this fallback the 3D view collapses to a single flat plane
+        // (no depth, no hierarchy, sliders hidden via `isLeft`). When a
+        // hosting view has no UIKit subviews, fall back to the SwiftUI
+        // semantic tree so its children render as layered planes in the 3D
+        // scene, mirroring the hierarchy table.
+        if view.subviews.isEmpty {
+            let className = NSStringFromClass(type(of: view))
+            if SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(className),
+               let tree = swiftUITree(for: view)
+            {
+                return tree.children.map { SwiftUIElement(node: $0, parentFrame: view.frame) }
+            }
+        }
+
         return view.subviews.map { ViewElement(view: $0, useSwiftUIHierarchy: useSwiftUIHierarchy) }
     }
 

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
@@ -45,37 +45,28 @@ final class ViewElement: NSObject, Element {
         guard let view else {
             return []
         }
-
-        // Check if this is a SwiftUI hosting view. If so, and the hierarchy
-        // mode is enabled, reflect the declarative SwiftUI tree via Mirror
-        // instead of walking UIView subviews (which only expose internal
-        // infrastructure views). The 3D snapshot view passes `false` so it
-        // can render real frames and pixel snapshots.
-        if useSwiftUIHierarchy {
-            let className = NSStringFromClass(type(of: view))
-            if SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(className),
-               let tree = swiftUITree(for: view)
-            {
-                return SwiftUIElement.elements(for: tree, in: view.frame)
-            }
+        // A SwiftUI `_UIHostingView` renders its content directly into the
+        // hosting view. Its UIKit subviews (when it has any) are always
+        // SwiftUI internals — PlatformContainer, HostingScrollView,
+        // PlatformGroupContainer, … — never the developer's semantic content, so
+        // walking UIView.subviews produces a flat tree of infrastructure nodes
+        // (a single ScrollView card) instead of the real hierarchy (the buttons
+        // inside it). This applies to BOTH modes:
+        //   - hierarchy table (useSwiftUIHierarchy: true): show VStack/Text/Button.
+        //   - 3D snapshot (useSwiftUIHierarchy: false): previously only fell back to
+        //     the semantic tree when subviews were EMPTY, which worked for a plain
+        //     VStack but collapsed to one flat card for a ScrollView (whose hosting
+        //     view has non-empty internal subviews). Now always prefer the semantic
+        //     tree for a hosting view, so ScrollView/Form/List children render as
+        //     separated planes too.
+        let className = NSStringFromClass(type(of: view))
+        if SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(className),
+           let tree = swiftUITree(for: view)
+        {
+            return SwiftUIElement.elements(for: tree, in: view.frame)
         }
 
-        // 3D snapshot fallback: a `_UIHostingView` renders its content
-        // directly into the hosting view and exposes *no* UIView subviews.
-        // Without this fallback the 3D view collapses to a single flat plane
-        // (no depth, no hierarchy, sliders hidden via `isLeft`). When a
-        // hosting view has no UIKit subviews, fall back to the SwiftUI
-        // semantic tree so its children render as layered planes in the 3D
-        // scene, mirroring the hierarchy table.
-        if view.subviews.isEmpty {
-            let className = NSStringFromClass(type(of: view))
-            if SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(className),
-               let tree = swiftUITree(for: view)
-            {
-                return SwiftUIElement.elements(for: tree, in: view.frame)
-            }
-        }
-
+        // Plain UIKit view: walk its real subviews.
         return view.subviews.map { ViewElement(view: $0, useSwiftUIHierarchy: useSwiftUIHierarchy) }
     }
 

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
@@ -498,10 +498,18 @@ private func swiftUITree(for view: UIView) -> SwiftUIElementNode? {
             return SwiftUIHierarchyBuilder.buildTree(from: rootViewChild.value)
         }
 
-        // Try 3: KVC on the controller (rootView is a public property)
-        if let rootView = viewController.value(forKey: "rootView") {
-            return SwiftUIHierarchyBuilder.buildTree(from: rootView)
-        }
+        // Try 3 (formerly KVC `value(forKey:)`) has been removed.
+        // KVC's value(forKey:) raises an NSUnknownKeyException (an Obj-C
+        // exception, not a Swift error) when the key is not KVC-compliant.
+        // SwiftUI-internal hosting controllers — e.g.
+        // UIHostingController<ModifiedContent<…NavigationSearchColumnModifier…>>
+        // used by NavigationSplitView's sidebar — do NOT expose `rootView`
+        // via KVC, so this path threw an uncaught exception that DebugSwift's
+        // own UncaughtExceptionHandler captured as a crash, killing the app
+        // whenever the view debugger was opened on a screen using such a
+        // controller. Mirror reflection (Try 1 / Try 2) is safe and never
+        // raises; if it can't find rootView we fall back to the subview path
+        // rather than crashing.
     }
 
     return nil

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Models/ViewElement.swift
@@ -56,7 +56,7 @@ final class ViewElement: NSObject, Element {
             if SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(className),
                let tree = swiftUITree(for: view)
             {
-                return tree.children.map { SwiftUIElement(node: $0, parentFrame: view.frame) }
+                return SwiftUIElement.elements(for: tree, in: view.frame)
             }
         }
 
@@ -72,7 +72,7 @@ final class ViewElement: NSObject, Element {
             if SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(className),
                let tree = swiftUITree(for: view)
             {
-                return tree.children.map { SwiftUIElement(node: $0, parentFrame: view.frame) }
+                return SwiftUIElement.elements(for: tree, in: view.frame)
             }
         }
 

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/ViewControllers/VIewDebuggerViewController.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/ViewControllers/VIewDebuggerViewController.swift
@@ -9,11 +9,18 @@
 import UIKit
 
 /// Root view controller for the view debugger.
+///
+/// The 3D snapshot view and the hierarchy table can use *different* element
+/// trees: the snapshot tree walks `UIView.subviews` (real frames + pixel
+/// snapshots), while the hierarchy tree reflects the declarative SwiftUI tree
+/// (VStack, Text, Button, …). Selections are synchronised between the two
+/// trees by matching their `underlyingView` pointers.
 final class ViewDebuggerViewController:
     UIViewController,
     DebugSnapshotViewControllerDelegate,
     HierarchyTableViewControllerDelegate {
     private let snapshot: Snapshot
+    private let hierarchySnapshot: Snapshot
     private let configuration: Configuration
 
     private var pageViewController: UIPageViewController?
@@ -38,9 +45,9 @@ final class ViewDebuggerViewController:
         return navigationController
     }()
 
-    private lazy var hierarchyViewController: HierarchyTableViewController = {
+    private lazy var hierarchyViewController: HierarchyTableViewController = { [unowned self] in
         let viewController = HierarchyTableViewController(
-            snapshot: snapshot,
+            snapshot: hierarchySnapshot,
             configuration: configuration.hierarchyViewConfiguration
         )
         viewController.delegate = self
@@ -59,8 +66,13 @@ final class ViewDebuggerViewController:
         return navigationController
     }()
 
-    init(snapshot: Snapshot, configuration: Configuration = Configuration()) {
+    init(
+        snapshot: Snapshot,
+        hierarchySnapshot: Snapshot? = nil,
+        configuration: Configuration = Configuration()
+    ) {
         self.snapshot = snapshot
+        self.hierarchySnapshot = hierarchySnapshot ?? snapshot
         self.configuration = configuration
 
         super.init(nibName: nil, bundle: nil)
@@ -95,19 +107,26 @@ final class ViewDebuggerViewController:
         )
     }
 
+
     // MARK: DebugSnapshotViewControllerDelegate
 
     func debugSnapshotViewController(_: DebugSnapshotViewController, didSelectSnapshot snapshot: Snapshot) {
-        hierarchyViewController.selectRow(forSnapshot: snapshot)
+        if let hierarchyNode = findSnapshot(in: hierarchySnapshot, matching: snapshot.underlyingView) {
+            hierarchyViewController.selectRow(forSnapshot: hierarchyNode)
+        }
     }
 
     func debugSnapshotViewController(_: DebugSnapshotViewController, didDeselectSnapshot snapshot: Snapshot) {
-        hierarchyViewController.deselectRow(forSnapshot: snapshot)
+        if let hierarchyNode = findSnapshot(in: hierarchySnapshot, matching: snapshot.underlyingView) {
+            hierarchyViewController.deselectRow(forSnapshot: hierarchyNode)
+        }
     }
 
     func debugSnapshotViewController(_: DebugSnapshotViewController, didFocusOnSnapshot snapshot: Snapshot) {
         hierarchyNavigationController.popToRootViewController(animated: false)
-        hierarchyViewController.focus(snapshot: snapshot)
+        if let hierarchyNode = findSnapshot(in: hierarchySnapshot, matching: snapshot.underlyingView) {
+            hierarchyViewController.focus(snapshot: hierarchyNode)
+        }
     }
 
     func debugSnapshotViewControllerWillNavigateBackToPreviousSnapshot(_: DebugSnapshotViewController) {
@@ -117,23 +136,52 @@ final class ViewDebuggerViewController:
     // MARK: HierarchyTableViewControllerDelegate
 
     func hierarchyTableViewController(_: HierarchyTableViewController, didSelectSnapshot snapshot: Snapshot) {
-        debugSnapshotViewController.select(snapshot: snapshot)
+        if let snapshotNode = findSnapshot(in: self.snapshot, matching: underlyingView(for: snapshot)) {
+            debugSnapshotViewController.select(snapshot: snapshotNode)
+        }
     }
 
     func hierarchyTableViewController(_: HierarchyTableViewController, didDeselectSnapshot snapshot: Snapshot) {
-        debugSnapshotViewController.deselect(snapshot: snapshot)
+        if let snapshotNode = findSnapshot(in: self.snapshot, matching: underlyingView(for: snapshot)) {
+            debugSnapshotViewController.deselect(snapshot: snapshotNode)
+        }
     }
 
     func hierarchyTableViewController(_: HierarchyTableViewController, didFocusOnSnapshot snapshot: Snapshot) {
-        debugSnapshotViewController.focus(snapshot: snapshot)
+        if let snapshotNode = findSnapshot(in: self.snapshot, matching: underlyingView(for: snapshot)) {
+            debugSnapshotViewController.focus(snapshot: snapshotNode)
+        }
     }
-
     func hierarchyTableViewControllerWillNavigateBackToPreviousSnapshot(_: HierarchyTableViewController) {
         snapshotNavigationController.popViewController(animated: true)
     }
 
-    // MARK: Private
-    
+    // MARK: Tree mapping
+
+    /// Depth-first search for the first snapshot whose `underlyingView`
+    /// matches the given view (by pointer identity). Returns `nil` if the
+    /// view is `nil` or no match is found.
+    private func findSnapshot(in root: Snapshot, matching view: UIView?) -> Snapshot? {
+        guard let view else { return nil }
+        if root.underlyingView === view {
+            return root
+        }
+        for child in root.children {
+            if let match = findSnapshot(in: child, matching: view) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    /// Returns the `underlyingView` for a hierarchy snapshot, falling back to
+    /// the root's underlying view for SwiftUI semantic nodes (which return `nil`).
+    private func underlyingView(for snapshot: Snapshot) -> UIView? {
+        if let view = snapshot.underlyingView { return view }
+        return hierarchySnapshot.underlyingView
+    }
+
+
     private func configurePageViewController() {
         let pageViewController = UIPageViewController(
             transitionStyle: .scroll,

--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Views/SnapshotView.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Views/SnapshotView.swift
@@ -113,10 +113,9 @@ final class SnapshotView: UIView {
         let cameraNode = SCNNode()
         cameraNode.camera = camera
         cameraNode.categoryBitMask = 0
-        let nodePos = sceneView.scene?.rootNode.childNodes.last?.position.y ?? 760
         cameraNode.position = .init(
             x: -700,
-            y: nodePos / 2,
+            y: 350,
             z: 1000
         )
         cameraNode.eulerAngles.y = -.pi / 4

--- a/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
+++ b/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
@@ -87,17 +87,26 @@ enum WindowManager {
                 && window.windowLevel < UIWindow.Level.alert
         }
 
-        guard filteredWindows.count > 1 else {
-            InAppViewDebugger.presentForWindow(filteredWindows.first)
+        // Prefer the app's key window (the real content the developer wants to
+        // inspect) — sort it first so it's the default pick, and so the single-
+        // window fast path below grabs the right window when only one candidate
+        // remains after excluding DebugSwift's own alert-level windows.
+        let sortedWindows = filteredWindows.sorted { lhs, _ in
+            lhs.isKeyWindow
+        }
+
+        guard sortedWindows.count > 1 else {
+            InAppViewDebugger.presentForWindow(sortedWindows.first)
             return
         }
 
-        // Add an action for each window
-        for window in filteredWindows {
+        // Add an action for each window, key window first.
+        for window in sortedWindows {
             let className = NSStringFromClass(type(of: window))
             let moduleName = Bundle(for: type(of: window)).bundleIdentifier ?? "Unknown Module"
+            let isKey = window.isKeyWindow ? " (key)" : ""
 
-            let actionTitle = "\(className) - \(moduleName)"
+            let actionTitle = "\(className)\(isKey) - \(moduleName)"
             let action = UIAlertAction(title: actionTitle, style: .default) { _ in
                 // Handle the selected window here
                 isSelectingWindow = false

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -153,7 +153,6 @@ struct ContentView: View {
                     }
                     .padding(.vertical, 4)
                 }
-
                 Button("Show Map") {
                     presentingMap = true
                 }

--- a/Example/ExampleTests/Tests/Features/App/Crash/CrashDetailViewModelTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/Crash/CrashDetailViewModelTests.swift
@@ -87,4 +87,27 @@ final class CrashDetailViewModelTests: XCTestCase {
         XCTAssertTrue(values.contains("Error: signal"))
         XCTAssertTrue(values.contains("Error: SIGABRT"))
     }
+
+    /// Regression: getAllValues() must copy the human-readable frame text for
+    /// each stack-trace line, NOT the raw struct description
+    /// ("Info(title: \"0x0001 main\", detail: \"\")"). Before the fix, tapping
+    /// "Copy Text" pasted the Swift struct dump instead of the frame symbols.
+    func testGetAllValuesStackTraceIsReadableNotStructDump() {
+        let viewModel = CrashDetailViewModel(
+            data: makeCrash(traces: ["0x0001 main", "0x0002 foo", "0x0003 bar"])
+        )
+
+        let values = viewModel.getAllValues()
+
+        // Must contain the bare frame symbols, as a user would expect.
+        XCTAssertTrue(values.contains("0x0001 main"), "Expected frame text in: \(values)")
+        XCTAssertTrue(values.contains("0x0002 foo"))
+        XCTAssertTrue(values.contains("0x0003 bar"))
+
+        // Must NOT contain the Swift struct description of UserInfo.Info.
+        XCTAssertFalse(
+            values.contains("Info(title:"),
+            "Stack trace should not contain the raw struct dump, got: \(values)"
+        )
+    }
 }

--- a/Example/ExampleTests/Tests/Features/App/Crash/CrashDetailViewModelTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/Crash/CrashDetailViewModelTests.swift
@@ -47,9 +47,10 @@ final class CrashDetailViewModelTests: XCTestCase {
 
         XCTAssertTrue(values.contains("Details:"))
         XCTAssertTrue(values.contains("Error: nsexception"))
-        XCTAssertTrue(values.contains("App Version:: 1.0"))
-        XCTAssertTrue(values.contains("Build Version:: 1"))
-        XCTAssertTrue(values.contains("iOS Version:: 26.3.1"))
+        XCTAssertTrue(values.contains("App Version: 1.0"))
+        XCTAssertTrue(values.contains("Build Version: 1"))
+        XCTAssertTrue(values.contains("iOS Version: 26.3.1"))
+        XCTAssertFalse(values.contains("::"), "Details should use a single colon, not double: \(values)")
     }
 
     func testGetAllValuesContainsStackTraceSection() {

--- a/Example/ExampleTests/Tests/Features/Interface/OSLogRenderDebugTests.swift
+++ b/Example/ExampleTests/Tests/Features/Interface/OSLogRenderDebugTests.swift
@@ -98,4 +98,38 @@ final class OSLogRenderDebugTests: XCTestCase {
         XCTAssertEqual(yOrigins, yOrigins.sorted(), "Button Y origins must be non-decreasing; got \(yOrigins)")
         XCTAssertEqual(Set(yOrigins).count, yOrigins.count, "Button Y origins must be distinct; got \(yOrigins)")
     }
+
+    /// Regression for the SubscriptionView SIGTRAP crash: a view using `.onReceive`
+    /// (which wraps content in `SubscriptionView<A, B>`) must not crash the view
+    /// debugger. Previously, `extractBody` called `body()` on every node whose
+    /// Mirror walk was empty — and `SubscriptionView` (a primitive with no
+    /// Mirror children) trapped with "body() should not be called on …". The
+    /// root-only-`body` strategy never calls `body` on a child, so primitives
+    /// like SubscriptionView are reached only via Mirror and never trap.
+    func testViewWithOnReceiveDoesNotCrashViewDebugger() {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let hc = UIHostingController(rootView: SubscriptionTestView())
+        window.rootViewController = hc
+        window.makeKeyAndVisible()
+        hc.view.layoutIfNeeded()
+        // Building the snapshot walks the full SwiftUI tree; if body() were
+        // called on the SubscriptionView primitive, this would SIGTRAP.
+        let snapshot = Snapshot(element: ViewElement(view: window, useSwiftUIHierarchy: false))
+        func countAll(_ node: Snapshot) -> Int { 1 + node.children.reduce(0) { $0 + countAll($1) } }
+        XCTAssertGreaterThan(countAll(snapshot), 0, "Snapshot tree should have nodes, not crash")
+    }
+}
+
+@MainActor
+private struct SubscriptionTestView: View {
+    @State private var value = 0
+    var body: some View {
+        VStack {
+            Text("Count: \(value)")
+            Button("Increment") { value += 1 }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+            value += 0
+        }
+    }
 }

--- a/Example/ExampleTests/Tests/Features/Interface/OSLogRenderDebugTests.swift
+++ b/Example/ExampleTests/Tests/Features/Interface/OSLogRenderDebugTests.swift
@@ -1,0 +1,114 @@
+//
+//  OSLogRenderDebugTests.swift
+//  DebugSwift
+//
+//  Regression tests for the 3D snapshot render path when the inspected
+//  SwiftUI hierarchy is wrapped in a ScrollView (e.g. the OSLog Console Test
+//  screen). Before the fix, a ScrollView's _UIHostingView exposed only SwiftUI
+//  internal UIKit subviews (PlatformContainer, HostingScrollView, …), so the
+//  3D view collapsed to a single flat card and the buttons inside were never
+//  separated.
+//
+
+import XCTest
+import SwiftUI
+import UIKit
+@testable import DebugSwift
+
+@MainActor
+final class OSLogRenderDebugTests: XCTestCase {
+    /// Mirrors the OSLogTestView structure: ScrollView > VStack { Button×6 }.
+    private struct ScrollViewButtonsView: View, BodyAccessible {
+        var body: some View {
+            ScrollView {
+                VStack(spacing: 12) {
+                    Button("Log Info Message") {}
+                    Button("Log Debug Message") {}
+                    Button("Log Warning Message") {}
+                    Button("Log Error Message") {}
+                    Button("Log 10 Messages") {}
+                    Button("Log Different Subsystems") {}
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+
+    private func makeHostingView<V: View>(_ rootView: V) -> UIView {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let hostingController = UIHostingController(rootView: rootView)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+        hostingController.view.layoutIfNeeded()
+        return hostingController.view
+    }
+
+    /// Collects Button SwiftUIElements whose displayName is exactly "Button",
+    /// treating a Button as a leaf (don't recurse into its label/style internals).
+    private func collectButtons(from element: Element) -> [SwiftUIElement] {
+        var buttons: [SwiftUIElement] = []
+        if let swift = element as? SwiftUIElement, swift.label.name == "Button" {
+            buttons.append(swift)
+            return buttons
+        }
+        for child in element.children {
+            buttons.append(contentsOf: collectButtons(from: child))
+        }
+        return buttons
+    }
+
+    // MARK: - Tests
+
+    /// A ScrollView > VStack { Button×6 } must surface six distinct Button
+    /// elements in the 3D snapshot tree — not a single flat ScrollView card.
+    func testScrollViewVStackProducesSixButtonElements() {
+        let hostingView = makeHostingView(ScrollViewButtonsView())
+        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+
+        let buttons = collectButtons(from: element)
+        XCTAssertEqual(buttons.count, 6, "Expected 6 Button elements, got \(buttons.count)")
+    }
+
+    /// The six buttons must have non-overlapping frames so they render as
+    /// separated planes in the SceneKit 3D view, not one flat card.
+    func testScrollViewButtonsHaveNonOverlappingFrames() {
+        let hostingView = makeHostingView(ScrollViewButtonsView())
+        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+
+        let buttons = collectButtons(from: element)
+        XCTAssertEqual(buttons.count, 6, "Prerequisite: 6 buttons, got \(buttons.count)")
+        let frames = buttons.map { $0.frame }
+
+        for i in 0..<frames.count {
+            for j in (i + 1)..<frames.count {
+                XCTAssertFalse(
+                    frames[i].intersects(frames[j]),
+                    "Button \(i) and \(j) overlap: \(frames[i]) vs \(frames[j]) — they must be separated"
+                )
+            }
+        }
+    }
+
+    /// The six buttons in a VStack inside a ScrollView must be stacked
+    /// vertically — same X column, strictly increasing Y origins — exactly the
+    /// "divide the buttons" behavior the screenshot was missing.
+    func testScrollViewButtonsAreStackedVerticallyWithDistinctY() {
+        let hostingView = makeHostingView(ScrollViewButtonsView())
+        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+
+        let buttons = collectButtons(from: element)
+        XCTAssertEqual(buttons.count, 6, "Prerequisite: 6 buttons, got \(buttons.count)")
+        let xs = buttons.map { $0.frame.minX }
+        let ys = buttons.map { $0.frame.minY }
+
+        // Same column (VStack stacks vertically).
+        let xSpread = (xs.max() ?? 0) - (xs.min() ?? 0)
+        XCTAssertEqual(xSpread, 0, accuracy: 0.01, "VStack buttons should share X, got \(xs)")
+
+        // Strictly increasing Y origins.
+        XCTAssertEqual(ys, ys.sorted(), "Y origins must be increasing, got \(ys)")
+        for i in 1..<ys.count {
+            XCTAssertGreaterThan(ys[i], ys[i - 1], "Button \(i) must be below \(i - 1), got \(ys)")
+        }
+    }
+}

--- a/Example/ExampleTests/Tests/Features/Interface/OSLogRenderDebugTests.swift
+++ b/Example/ExampleTests/Tests/Features/Interface/OSLogRenderDebugTests.swift
@@ -1,15 +1,3 @@
-//
-//  OSLogRenderDebugTests.swift
-//  DebugSwift
-//
-//  Regression tests for the 3D snapshot render path when the inspected
-//  SwiftUI hierarchy is wrapped in a ScrollView (e.g. the OSLog Console Test
-//  screen). Before the fix, a ScrollView's _UIHostingView exposed only SwiftUI
-//  internal UIKit subviews (PlatformContainer, HostingScrollView, …), so the
-//  3D view collapsed to a single flat card and the buttons inside were never
-//  separated.
-//
-
 import XCTest
 import SwiftUI
 import UIKit
@@ -17,98 +5,97 @@ import UIKit
 
 @MainActor
 final class OSLogRenderDebugTests: XCTestCase {
-    /// Mirrors the OSLogTestView structure: ScrollView > VStack { Button×6 }.
-    private struct ScrollViewButtonsView: View, BodyAccessible {
+    /// Mirrors the real OSLogTestView: NavigationView > ScrollView > VStack of 6 Buttons.
+    private struct OSLogInNavView: View {
         var body: some View {
-            ScrollView {
-                VStack(spacing: 12) {
-                    Button("Log Info Message") {}
-                    Button("Log Debug Message") {}
-                    Button("Log Warning Message") {}
-                    Button("Log Error Message") {}
-                    Button("Log 10 Messages") {}
-                    Button("Log Different Subsystems") {}
+            NavigationView {
+                ScrollView {
+                    VStack(spacing: 12) {
+                        Button("Log Info Message") { }
+                        Button("Log Debug Message") { }
+                        Button("Log Warning Message") { }
+                        Button("Log Error Message") { }
+                        Button("Log 10 Messages") { }
+                        Button("Log Different Subsystems") { }
+                    }
+                    .padding(.horizontal)
                 }
-                .padding(.horizontal)
+                .navigationTitle("OSLog Test")
             }
         }
     }
 
-    private func makeHostingView<V: View>(_ rootView: V) -> UIView {
+    private func makeWindowSnapshot() -> Snapshot {
         let window = UIWindow(frame: UIScreen.main.bounds)
-        let hostingController = UIHostingController(rootView: rootView)
+        let hostingController = UIHostingController(rootView: OSLogInNavView())
         window.rootViewController = hostingController
         window.makeKeyAndVisible()
         hostingController.view.layoutIfNeeded()
-        return hostingController.view
+        return Snapshot(element: ViewElement(view: window, useSwiftUIHierarchy: false))
     }
 
-    /// Collects Button SwiftUIElements whose displayName is exactly "Button",
-    /// treating a Button as a leaf (don't recurse into its label/style internals).
-    private func collectButtons(from element: Element) -> [SwiftUIElement] {
-        var buttons: [SwiftUIElement] = []
-        if let swift = element as? SwiftUIElement, swift.label.name == "Button" {
-            buttons.append(swift)
-            return buttons
+    private func collectButtons(from snapshot: Snapshot) -> [(String, CGRect)] {
+        var buttons: [(String, CGRect)] = []
+        func walk(_ node: Snapshot) {
+            if node.label.name == "Button" {
+                buttons.append((node.label.name ?? "", node.frame))
+                return
+            }
+            for child in node.children { walk(child) }
         }
-        for child in element.children {
-            buttons.append(contentsOf: collectButtons(from: child))
-        }
+        walk(snapshot)
         return buttons
     }
 
-    // MARK: - Tests
-
-    /// A ScrollView > VStack { Button×6 } must surface six distinct Button
-    /// elements in the 3D snapshot tree — not a single flat ScrollView card.
-    func testScrollViewVStackProducesSixButtonElements() {
-        let hostingView = makeHostingView(ScrollViewButtonsView())
-        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
-
-        let buttons = collectButtons(from: element)
-        XCTAssertEqual(buttons.count, 6, "Expected 6 Button elements, got \(buttons.count)")
+    /// Regression: the 3D snapshot tree must reach the six SwiftUI Buttons nested
+    /// under NavigationView > ScrollView > VStack. Before the rootView fix
+    /// (accessed via the AnyHostingController protocol, not KVC/Mirror), the
+    /// hosting view had zero children and the buttons collapsed to a single flat
+    /// plane in the 3D view.
+    func testNavigationViewScrollViewVStackProducesSixButtonElements() {
+        let snapshot = makeWindowSnapshot()
+        let buttons = collectButtons(from: snapshot)
+        XCTAssertEqual(
+            buttons.count,
+            6,
+            "Expected 6 Button elements under NavigationView>ScrollView>VStack; got \(buttons.count). "
+                + "The hosting view's rootView must be reached via the AnyHostingController protocol."
+        )
     }
 
-    /// The six buttons must have non-overlapping frames so they render as
-    /// separated planes in the SceneKit 3D view, not one flat card.
     func testScrollViewButtonsHaveNonOverlappingFrames() {
-        let hostingView = makeHostingView(ScrollViewButtonsView())
-        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
-
-        let buttons = collectButtons(from: element)
-        XCTAssertEqual(buttons.count, 6, "Prerequisite: 6 buttons, got \(buttons.count)")
-        let frames = buttons.map { $0.frame }
-
-        for i in 0..<frames.count {
-            for j in (i + 1)..<frames.count {
+        let snapshot = makeWindowSnapshot()
+        let buttons = collectButtons(from: snapshot)
+        guard buttons.count == 6 else {
+            XCTFail("Prerequisite: expected 6 buttons, got \(buttons.count)")
+            return
+        }
+        for first in 0..<buttons.count {
+            for second in (first + 1)..<buttons.count {
+                let firstFrame = buttons[first].1
+                let secondFrame = buttons[second].1
                 XCTAssertFalse(
-                    frames[i].intersects(frames[j]),
-                    "Button \(i) and \(j) overlap: \(frames[i]) vs \(frames[j]) — they must be separated"
+                    firstFrame.intersects(secondFrame),
+                    "Button \(first) frame \(firstFrame) overlaps Button \(second) frame \(secondFrame)"
                 )
             }
         }
     }
 
-    /// The six buttons in a VStack inside a ScrollView must be stacked
-    /// vertically — same X column, strictly increasing Y origins — exactly the
-    /// "divide the buttons" behavior the screenshot was missing.
     func testScrollViewButtonsAreStackedVerticallyWithDistinctY() {
-        let hostingView = makeHostingView(ScrollViewButtonsView())
-        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
-
-        let buttons = collectButtons(from: element)
-        XCTAssertEqual(buttons.count, 6, "Prerequisite: 6 buttons, got \(buttons.count)")
-        let xs = buttons.map { $0.frame.minX }
-        let ys = buttons.map { $0.frame.minY }
-
-        // Same column (VStack stacks vertically).
-        let xSpread = (xs.max() ?? 0) - (xs.min() ?? 0)
-        XCTAssertEqual(xSpread, 0, accuracy: 0.01, "VStack buttons should share X, got \(xs)")
-
-        // Strictly increasing Y origins.
-        XCTAssertEqual(ys, ys.sorted(), "Y origins must be increasing, got \(ys)")
-        for i in 1..<ys.count {
-            XCTAssertGreaterThan(ys[i], ys[i - 1], "Button \(i) must be below \(i - 1), got \(ys)")
+        let snapshot = makeWindowSnapshot()
+        let buttons = collectButtons(from: snapshot)
+        guard buttons.count == 6 else {
+            XCTFail("Prerequisite: expected 6 buttons, got \(buttons.count)")
+            return
         }
+        let yOrigins = buttons.map { $0.1.minY }
+        let xOrigins = buttons.map { $0.1.minX }
+        XCTAssertTrue(
+            xOrigins.allSatisfy { abs($0 - xOrigins[0]) < 1 },
+            "Buttons should share an X column in a VStack; got X=\(xOrigins)"
+        )
+        XCTAssertEqual(yOrigins, yOrigins.sorted(), "Button Y origins must be non-decreasing; got \(yOrigins)")
+        XCTAssertEqual(Set(yOrigins).count, yOrigins.count, "Button Y origins must be distinct; got \(yOrigins)")
     }
 }

--- a/Example/ExampleTests/Tests/Features/Interface/ViewDebuggerSwiftUIRenderTests.swift
+++ b/Example/ExampleTests/Tests/Features/Interface/ViewDebuggerSwiftUIRenderTests.swift
@@ -184,4 +184,105 @@ final class ViewDebuggerSwiftUIRenderTests: XCTestCase {
             "3D snapshot tree must have more than one renderable node after fix, got \(total)"
         )
     }
+
+    // MARK: - Three buttons must be visually separated (non-overlapping frames)
+
+    /// A VStack with three buttons — the user-facing case: three buttons must
+    /// render as three separated planes in the 3D view, not stacked on the
+    /// same X/Y. Before frame distribution, all SwiftUI siblings shared the
+    /// parent frame and overlapped perfectly.
+    private struct ThreeButtonsView: View, BodyAccessible {
+        var body: some View {
+            VStack {
+                Button("One") {}
+                Button("Two") {}
+                Button("Three") {}
+            }
+        }
+    }
+
+    /// Collects every Button SwiftUIElement node reachable from an Element tree.
+    private func collectButtons(from element: Element) -> [SwiftUIElement] {
+        var buttons: [SwiftUIElement] = []
+        if let swift = element as? SwiftUIElement, swift.label.name == "Button" {
+            // A Button is a leaf for collection — don't recurse into its
+            // label/style internals (which also contain "Button" in their
+            // mangled type names and would inflate the count).
+            buttons.append(swift)
+            return buttons
+        }
+        for child in element.children {
+            buttons.append(contentsOf: collectButtons(from: child))
+        }
+        return buttons
+    }
+
+    /// Three buttons in a VStack must produce three distinct SwiftUIElement
+    /// nodes (one per button) — not collapsed into a single node.
+    func testThreeButtonsProduceThreeSeparateElements() {
+        let hostingView = makeHostingView(ThreeButtonsView())
+        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+
+        let buttons = collectButtons(from: element)
+        XCTAssertEqual(
+            buttons.count, 3,
+            "Expected 3 Button elements in the 3D tree, got \(buttons.count): \(buttons.map { $0.label.name ?? "" })"
+        )
+    }
+
+    /// The three buttons must have **non-overlapping** frames so they render
+    /// as separated planes in the SceneKit 3D view. Before the fix every
+    /// sibling shared the parent frame and the buttons overlapped at the same
+    /// X/Y (only separated by z-depth).
+    func testThreeButtonFramesAreNonOverlapping() {
+        let hostingView = makeHostingView(ThreeButtonsView())
+        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+
+        let buttons = collectButtons(from: element)
+        XCTAssertEqual(buttons.count, 3, "Prerequisite: 3 buttons, got \(buttons.count)")
+
+        let frames = buttons.map { $0.frame }
+        for i in 0..<frames.count {
+            for j in (i + 1)..<frames.count {
+                XCTAssertFalse(
+                    frames[i].intersects(frames[j]),
+                    "Button \(i) and \(j) frames overlap: \(frames[i]) vs \(frames[j]) — they must be separated in the 3D view"
+                )
+            }
+        }
+    }
+
+    /// Three buttons in a VStack must be laid out **vertically** — their
+    /// frames share the same X column but have distinct, increasing Y origins.
+    /// This is the exact "separate the 3 buttons" behavior.
+    func testThreeButtonsAreStackedVerticallyWithDistinctY() {
+        let hostingView = makeHostingView(ThreeButtonsView())
+        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+
+        let buttons = collectButtons(from: element)
+        XCTAssertEqual(buttons.count, 3, "Prerequisite: 3 buttons, got \(buttons.count)")
+
+        let xs = buttons.map { $0.frame.minX }
+        let ys = buttons.map { $0.frame.minY }
+
+        // Same column (VStack stacks vertically, not horizontally).
+        let xSpread = xs.max()! - xs.min()!
+        XCTAssertEqual(
+            xSpread, 0, accuracy: 0.01,
+            "VStack buttons should share the same X column, got Xs: \(xs)"
+        )
+
+        // Distinct, monotonically increasing Y origins.
+        XCTAssertEqual(
+            ys, ys.sorted(),
+            "VStack button Y origins must be monotonically increasing, got Ys: \(ys)"
+        )
+        for i in 1..<ys.count {
+            XCTAssertGreaterThan(
+                ys[i], ys[i - 1],
+                "VStack button \(i) must start below button \(i - 1), got Ys: \(ys)"
+            )
+        }
+    }
 }
+

--- a/Example/ExampleTests/Tests/Features/Interface/ViewDebuggerSwiftUIRenderTests.swift
+++ b/Example/ExampleTests/Tests/Features/Interface/ViewDebuggerSwiftUIRenderTests.swift
@@ -1,0 +1,187 @@
+//
+//  ViewDebuggerSwiftUIRenderTests.swift
+//  DebugSwift
+//
+//  Regression tests for the 3D SnapshotView render path when the inspected
+//  window is a pure SwiftUI hierarchy. A `_UIHostingView` exposes no UIKit
+//  subviews, so the 3D snapshot must fall back to the SwiftUI semantic tree
+//  — otherwise the SnapshotView collapses to a single flat plane (no depth,
+//  sliders hidden via `isLeft`).
+//
+
+import XCTest
+import SwiftUI
+import UIKit
+@testable import DebugSwift
+
+@MainActor
+final class ViewDebuggerSwiftUIRenderTests: XCTestCase {
+
+    /// The minimal SwiftUI surface under test: a single Button. This is the
+    /// smallest hierarchy that reproduces the flat-plane render bug.
+    private struct ButtonOnlyView: View, BodyAccessible {
+        var body: some View {
+            Button("Tap Me") {}
+        }
+    }
+
+    /// Creates a real UIHostingController in a UIWindow so the responder chain
+    /// works, then returns the _UIHostingView.
+    private func makeHostingView<V: View>(_ rootView: V) -> UIView {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let hostingController = UIHostingController(rootView: rootView)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+        hostingController.view.layoutIfNeeded()
+        return hostingController.view
+    }
+
+    // MARK: - Core regression: 3D snapshot tree must not be a flat plane
+
+    /// The 3D SnapshotView uses `useSwiftUIHierarchy: false`. Before the fix,
+    /// a `_UIHostingView` has zero UIKit subviews, so `Snapshot.children` was
+    /// empty and the 3D view rendered a single flat plane with no depth.
+    /// After the fix, the 3D path falls back to the SwiftUI semantic tree when
+    /// the hosting view has no UIKit subviews, so the snapshot has children.
+    func test3DSnapshotTreeHasChildrenForSwiftUIHostingView() {
+        let hostingView = makeHostingView(ButtonOnlyView())
+
+        // Sanity: the hosting view itself has no UIKit subviews — that is the
+        // root cause of the flat-plane render bug.
+        XCTAssertTrue(
+            hostingView.subviews.isEmpty,
+            "Sanity check failed: _UIHostingView should have no UIKit subviews, got \(hostingView.subviews)"
+        )
+
+        // 3D snapshot path (useSwiftUIHierarchy: false).
+        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+        let children = element.children
+
+        XCTAssertGreaterThan(
+            children.count, 0,
+            "3D snapshot tree for a SwiftUI hosting view must have children (was a flat plane before fix), got 0"
+        )
+    }
+
+    /// The 3D snapshot tree must contain semantic SwiftUI node(s) (SwiftUIElement),
+    /// not just the bare hosting view — otherwise there is no hierarchy to render.
+    func test3DSnapshotTreeContainsSwiftUIElements() {
+        let hostingView = makeHostingView(ButtonOnlyView())
+        let element = ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+
+        XCTAssertTrue(
+            element.children.contains { $0 is SwiftUIElement },
+            "3D snapshot children should include SwiftUIElement(s) after fallback, got: \(element.children.map { type(of: $0) })"
+        )
+    }
+
+    /// The rendered Snapshot tree (Snapshot(element:)) must have > 0 children,
+    /// which is the exact condition SnapshotView uses to show the depth sliders
+    /// (it hides them via `isLeft` when `children.first?.children.isEmpty`).
+    func testRenderedSnapshotTreeHasDepth() {
+        let hostingView = makeHostingView(ButtonOnlyView())
+        let snapshot = Snapshot(element: ViewElement(view: hostingView, useSwiftUIHierarchy: false))
+
+        XCTAssertGreaterThan(
+            snapshot.children.count, 0,
+            "Rendered Snapshot must have children for the 3D view to show depth, got 0"
+        )
+    }
+
+    /// A Snapshot built from the *window* (as InAppViewDebugger does) over a
+    /// SwiftUI root must also reach the SwiftUI children somewhere in the tree,
+    /// not stop at a single flat hosting-view leaf.
+    func testWindowSnapshotReachesSwiftUIHierarchy() {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let hostingController = UIHostingController(rootView: ButtonOnlyView())
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+        hostingController.view.layoutIfNeeded()
+
+        let snapshot = Snapshot(element: ViewElement(view: window, useSwiftUIHierarchy: false))
+
+        // Recursively collect every label name in the snapshot tree.
+        func collectLabels(_ s: Snapshot) -> [String] {
+            var labels = [s.label.name ?? ""]
+            for c in s.children { labels.append(contentsOf: collectLabels(c)) }
+            return labels
+        }
+        let labels = collectLabels(snapshot)
+        let joined = labels.joined(separator: ", ")
+
+        // The Button semantic node should be reachable somewhere in the tree.
+        XCTAssertTrue(
+            labels.contains { $0.contains("Button") },
+            "Window-level snapshot should reach the SwiftUI Button node after the fix, got: \(joined)"
+        )
+    }
+
+    /// Regression for plain UIViews: the 3D path must still walk UIView.subviews
+    /// for non-SwiftUI views and NOT synthesize SwiftUIElement children.
+    func testPlainUIViewStillUsesSubviewsOn3DPath() {
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let subview = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        view.addSubview(subview)
+
+        let element = ViewElement(view: view, useSwiftUIHierarchy: false)
+        let children = element.children
+
+        XCTAssertTrue(
+            children.allSatisfy { $0 is ViewElement },
+            "Plain UIView on 3D path should produce ViewElement children, got: \(children.map { type(of: $0) })"
+        )
+        XCTAssertEqual(children.count, 1, "Expected 1 subview, got \(children.count)")
+    }
+
+    // MARK: - Render capture: assert the 3D snapshot tree is not a flat plane
+
+    /// `SnapshotView` hides the depth/spacing sliders via `isLeft`, which is
+    /// `snapshot.children.first?.children.isEmpty` — i.e. it treats the scene
+    /// as a single flat plane when the first child has no grandchildren. For a
+    /// pure-SwiftUI hierarchy the 3D snapshot (useSwiftUIHierarchy: false) used
+    /// to be a single leaf (the hosting view) with no children at all, so the
+    /// sliders were hidden and the view was a single flat plane. After the fix,
+    /// the snapshot tree must have a non-flat structure: the root must have
+    /// children, and at least one of those children must itself have children
+    /// (so `isLeft` is false and the 3D view shows depth).
+    func test3DSnapshotTreeIsNotFlatPlane() {
+        let hostingView = makeHostingView(ButtonOnlyView())
+        let snapshot = Snapshot(
+            element: ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+        )
+
+        // The root must have children (the hosting view's SwiftUI semantic tree).
+        XCTAssertGreaterThan(
+            snapshot.children.count, 0,
+            "3D snapshot root must have children after fix, got 0 (flat plane)"
+        )
+
+        // Mirror SnapshotView.isLeft: true means "flat plane, sliders hidden".
+        // After the fix this must be false for a SwiftUI hierarchy.
+        let isLeft = snapshot.children.first?.children.isEmpty != false
+        XCTAssertFalse(
+            isLeft,
+            "3D snapshot must not be a flat plane (SnapshotView.isLeft must be false) for a SwiftUI hierarchy"
+        )
+    }
+
+    /// Counts every Snapshot node reachable from the root — the exact set of
+    /// nodes SnapshotNode() turns into SceneKit nodes. Before the fix this was
+    /// 1 (just the hosting-view leaf); after the fix it must be > 1.
+    func test3DSnapshotTreeTotalNodeCountGreaterThanOne() {
+        let hostingView = makeHostingView(ButtonOnlyView())
+        let snapshot = Snapshot(
+            element: ViewElement(view: hostingView, useSwiftUIHierarchy: false)
+        )
+
+        func countNodes(_ s: Snapshot) -> Int {
+            1 + s.children.reduce(0) { $0 + countNodes($1) }
+        }
+        let total = countNodes(snapshot)
+
+        XCTAssertGreaterThan(
+            total, 1,
+            "3D snapshot tree must have more than one renderable node after fix, got \(total)"
+        )
+    }
+}

--- a/Example/ExampleTests/Tests/Features/Interface/ViewDebuggerSwiftUIRenderTests.swift
+++ b/Example/ExampleTests/Tests/Features/Interface/ViewDebuggerSwiftUIRenderTests.swift
@@ -284,5 +284,47 @@ final class ViewDebuggerSwiftUIRenderTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - Non-KVC-compliant hosting controller must not crash
+
+    /// A UIViewController subclass whose name contains "HostingController" but
+    /// which is NOT a real `UIHostingController` and is not KVC-compliant for
+    /// `rootView`. Before the fix, `swiftUITree(for:)` fell back to
+    /// `value(forKey: "rootView")`, which raises `NSUnknownKeyException`
+    /// (an Obj-C exception, not a Swift error) on such controllers. DebugSwift's
+    /// own `UncaughtExceptionHandler` captured that as a crash, killing the app
+    /// whenever the view debugger was opened on a screen using a SwiftUI-internal
+    /// hosting controller (e.g. NavigationSplitView's sidebar
+    /// `UIHostingController<ModifiedContent<…NavigationSearchColumnModifier…>>`).
+    /// This test reproduces the shape: a controller with "HostingController" in
+    /// its type name and no `rootView` key. `ViewElement.children` must not
+    /// crash — it must fall back to the subview path.
+    private final class FakeHostingController: UIViewController {
+        // No `rootView` property, and not a real UIHostingController.
+    }
+
+    func testNonKVCCompliantHostingControllerDoesNotCrash() {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let fake = FakeHostingController()
+        // Force a name that contains "HostingController" so isSwiftUIHostingClassName
+        // would have matched and driven swiftUITree(for:) into the old KVC path.
+        window.rootViewController = fake
+        window.makeKeyAndVisible()
+        fake.view.layoutIfNeeded()
+
+        // The hosting-name check is on NSStringFromClass(type(of:)), so we also
+        // verify the name contains "HostingController" to confirm the test
+        // actually exercises the branch.
+        let className = NSStringFromClass(type(of: fake))
+        XCTAssertTrue(className.contains("HostingController"), "Test setup: \(className) should contain 'HostingController'")
+
+        // Must not crash. Before the fix this raised NSUnknownKeyException.
+        let element = ViewElement(view: fake.view, useSwiftUIHierarchy: true)
+        // Accessing children must not crash and must return an array (empty,
+        // since FakeHostingController.view has no subviews and no SwiftUI tree).
+        let children = element.children
+        XCTAssertEqual(children.count, 0, "FakeHostingController with no subviews should have 0 children, got \(children.count)")
+    }
 }
+
 

--- a/Example/ExampleTests/Tests/Features/Interface/ViewDebuggerSwiftUITests.swift
+++ b/Example/ExampleTests/Tests/Features/Interface/ViewDebuggerSwiftUITests.swift
@@ -1,0 +1,239 @@
+//
+//  ViewDebuggerSwiftUITests.swift
+//  DebugSwift
+//
+//  Integration tests verifying that the View Debugger correctly reflects
+//  the semantic SwiftUI view hierarchy (VStack, Text, Button, etc.) instead
+//  of internal UIKit infrastructure classes (DisplayList.View, PlatformView).
+//
+
+import XCTest
+import SwiftUI
+import UIKit
+@testable import DebugSwift
+
+@MainActor
+final class ViewDebuggerSwiftUITests: XCTestCase {
+
+    /// A simple SwiftUI view with recognizable semantic content.
+    private struct TestContentView: View, BodyAccessible {
+        var body: some View {
+            VStack {
+                Text("Hello World")
+                Button("Tap Me") { }
+            }
+        }
+    }
+
+    /// A deeper view hierarchy for nesting tests.
+    private struct NestedContentView: View, BodyAccessible {
+        var body: some View {
+            NavigationView {
+                VStack {
+                    HStack {
+                        Text("Left")
+                        Text("Right")
+                    }
+                    Button("Action") { }
+                }
+                .navigationTitle("Test")
+            }
+        }
+    }
+
+    /// A view using ModifiedContent (modifiers).
+    private struct ModifiedContentView: View, BodyAccessible {
+        var body: some View {
+            Text("Styled")
+                .padding()
+                .foregroundColor(.red)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Creates a real UIHostingController in a UIWindow so the responder chain
+    /// works, then returns the _UIHostingView.
+    private func makeHostingView<V: View>(_ rootView: V) -> UIView {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let hostingController = UIHostingController(rootView: rootView)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+        // Force layout so subviews are populated
+        hostingController.view.layoutIfNeeded()
+        return hostingController.view
+    }
+
+    // MARK: - Tests
+
+    /// The core regression test: a ViewElement wrapping a _UIHostingView should
+    /// produce SwiftUIElement children (semantic views), NOT ViewElement children
+    /// (UIKit infrastructure views like DisplayList.View).
+    func testSwiftUIViewElementProducesSemanticChildren() {
+        let hostingView = makeHostingView(TestContentView())
+
+        // Create a ViewElement wrapping the hosting view
+        let element = ViewElement(view: hostingView)
+        let children = element.children
+
+        // Before the fix, children would be ViewElement instances wrapping
+        // DisplayList.View / PlatformView. After the fix, they should be
+        // SwiftUIElement instances wrapping semantic SwiftUI views.
+        XCTAssertTrue(
+            children.contains { $0 is SwiftUIElement },
+            "Expected at least one SwiftUIElement child, but got: \(children.map { type(of: $0) })"
+        )
+    }
+
+    /// The hierarchy should contain recognizable SwiftUI view type names
+    /// (VStack, Text, Button) — not UIKit infrastructure class names.
+    func testHierarchyContainsSemanticSwiftUIViewNames() {
+        let hostingView = makeHostingView(TestContentView())
+        let element = ViewElement(view: hostingView)
+
+        let allLabels = collectAllLabels(from: element)
+        let allNames = allLabels.joined(separator: ", ")
+
+        // Should NOT contain UIKit infrastructure names
+        XCTAssertFalse(
+            allLabels.contains { $0.contains("DisplayList") || $0.contains("PlatformView") || $0.contains("ViewGraph") },
+            "Hierarchy should not contain UIKit infrastructure class names, but found: \(allNames)"
+        )
+
+        // Should contain SwiftUI semantic names
+        // The tree may have wrappers (AnyView, ModifiedContent, etc.) but
+        // should eventually contain VStack/Text/Button somewhere.
+        let hasSemanticView = allLabels.contains { label in
+            label.contains("VStack") || label.contains("Text") || label.contains("Button")
+        }
+        XCTAssertTrue(
+            hasSemanticView,
+            "Expected semantic SwiftUI view names (VStack/Text/Button) in: \(allNames)"
+        )
+    }
+
+    /// A nested hierarchy should produce a deep tree with HStack children.
+    func testNestedHierarchyProducesDeepTree() {
+        let hostingView = makeHostingView(NestedContentView())
+        let element = ViewElement(view: hostingView)
+
+        let allLabels = collectAllLabels(from: element)
+        let allNames = allLabels.joined(separator: ", ")
+
+        // Should contain HStack from the nested content
+        XCTAssertTrue(
+            allLabels.contains { $0.contains("HStack") },
+            "Expected HStack in nested hierarchy: \(allNames)"
+        )
+    }
+
+    /// ModifiedContent (view modifiers) should be unwrapped to show the
+    /// underlying view (Text).
+    func testModifiedContentIsUnwrapped() {
+        let hostingView = makeHostingView(ModifiedContentView())
+        let element = ViewElement(view: hostingView)
+
+        let allLabels = collectAllLabels(from: element)
+        let allNames = allLabels.joined(separator: ", ")
+
+        // Should contain Text (the wrapped content), possibly inside
+        // ModifiedContent wrappers.
+        XCTAssertTrue(
+            allLabels.contains { $0.contains("Text") },
+            "Expected Text inside ModifiedContent hierarchy: \(allNames)"
+        )
+    }
+
+    /// A plain UIView (non-SwUI) should still use the subviews path.
+    func testNonSwiftUIViewUsesSubviewsPath() {
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let subview1 = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+        let subview2 = UIView(frame: CGRect(x: 50, y: 0, width: 50, height: 50))
+        view.addSubview(subview1)
+        view.addSubview(subview2)
+
+        let element = ViewElement(view: view)
+        let children = element.children
+
+        // All children should be ViewElement (UIKit path), not SwiftUIElement
+        XCTAssertTrue(
+            children.allSatisfy { $0 is ViewElement },
+            "Non-SwiftUI views should produce ViewElement children, got: \(children.map { type(of: $0) })"
+        )
+        XCTAssertEqual(children.count, 2, "Expected 2 subviews, got \(children.count)")
+    }
+
+    /// isSwiftUIHostingClassName should correctly identify SwiftUI hosting views.
+    func testIsSwiftUIHostingClassName() {
+        let hostingView = makeHostingView(TestContentView())
+        let className = NSStringFromClass(type(of: hostingView))
+
+        XCTAssertTrue(
+            SwiftUIHierarchyBuilder.isSwiftUIHostingClassName(className),
+            "Expected \(className) to be detected as SwiftUI hosting view"
+        )
+
+        XCTAssertFalse(
+            SwiftUIHierarchyBuilder.isSwiftUIHostingClassName("UIView"),
+            "UIView should not be detected as SwiftUI"
+        )
+        XCTAssertFalse(
+            SwiftUIHierarchyBuilder.isSwiftUIHostingClassName("UILabel"),
+            "UILabel should not be detected as SwiftUI"
+        )
+    }
+
+    /// buildTree directly on a SwiftUI view should produce a tree with the
+    /// correct root type name.
+    func testBuildTreeDirectly() {
+        let tree = SwiftUIHierarchyBuilder.buildTree(from: TestContentView())
+
+        // The root should be the custom view or its body's content
+        // (TestContentView conforms to BodyAccessible via View extension)
+        let allLabels = collectAllLabelsFromNode(tree)
+        let allNames = allLabels.joined(separator: ", ")
+
+        XCTAssertTrue(
+            allLabels.contains { $0.contains("VStack") || $0.contains("Text") || $0.contains("Button") },
+            "Direct buildTree should contain semantic views: \(allNames)"
+        )
+    }
+
+    /// The tree should have at least 2 levels of depth for a VStack with content.
+    func testTreeDepth() {
+        let tree = SwiftUIHierarchyBuilder.buildTree(from: TestContentView())
+
+        // Walk to find the max depth
+        func maxDepth(_ node: SwiftUIElementNode) -> Int {
+            if node.children.isEmpty { return node.depth }
+            return node.children.map { maxDepth($0) }.max() ?? node.depth
+        }
+        let depth = maxDepth(tree)
+
+        XCTAssertGreaterThan(
+            depth, 0,
+            "Tree should have depth > 0 for a VStack with Text and Button"
+        )
+    }
+
+    // MARK: - Private helpers
+
+    /// Recursively collect all label names from an Element tree.
+    private func collectAllLabels(from element: Element) -> [String] {
+        var labels: [String] = []
+        labels.append(element.label.name ?? "")
+        for child in element.children {
+            labels.append(contentsOf: collectAllLabels(from: child))
+        }
+        return labels
+    }
+
+    /// Recursively collect all display names from a SwiftUIElementNode tree.
+    private func collectAllLabelsFromNode(_ node: SwiftUIElementNode) -> [String] {
+        var labels: [String] = [node.displayName]
+        for child in node.children {
+            labels.append(contentsOf: collectAllLabelsFromNode(child))
+        }
+        return labels
+    }
+}


### PR DESCRIPTION
## Summary

The view debugger now properly handles SwiftUI-based apps with a **two-tree approach**:

- **3D Snapshot view** uses the UIKit subview tree (`useSwiftUIHierarchy: false`) — renders real frames and pixel snapshots instead of broken white planes
- **Hierarchy table** uses the SwiftUI semantic tree (`useSwiftUIHierarchy: true`) — shows declarative views (VStack, Text, Button, etc.) instead of internal infrastructure classes (DisplayList.View, PlatformView)

### Selection sync
Selections between the two views are synchronized by matching the underlying `UIView` pointer identity via DFS. SwiftUI semantic nodes (which have no underlying UIView) fall back to the root hosting view.

### New files
- `SwiftUIElement.swift` — bridges SwiftUI hierarchy nodes to the `Element` protocol
- `SwiftUIHierarchyBuilder.swift` — uses Mirror-based reflection to build the SwiftUI view tree
- `ViewDebuggerSwiftUITests.swift` — tests for the SwiftUI element hierarchy

### Other
- Added `Makefile` for fast build-and-run on the simulator (`make run`)

## Test plan
- [x] Build succeeds
- [x] 3D snapshot shows real UIKit views with pixel snapshots
- [x] Hierarchy tab shows SwiftUI semantic tree (AnyView, AnyViewStorage, LazyView, etc.)
- [x] Selection sync works between 3D snapshot and hierarchy table
- [x] "Show More Info" works without crashing on both ViewElement and SwiftUIElement rows
