### PR TITLE
Tune 3D snapshot camera and z-spacing for clearer layer separation

### DIFF
--- a/DebugSwift/Sources/Features/Interface/ViewDebugger/Views/SnapshotView.swift
+++ b/DebugSwift/Sources/Features/Interface/ViewDebugger/Views/SnapshotView.swift
@@ -93,7 +93,16 @@ final class SnapshotView: UIView {
             hideHeaderNodes: hideHeaderNodes
         )
         maximumDepth = depth
-        sceneView.scene = scene
+        // Depth-adaptive z-spacing: keep the deepest plane within the camera's
+        // comfortable viewing range. With the camera at z≈1200, planes sit at
+        // z = zSpacing * depth; cap the deepest at ~400 so deep hierarchies
+        // (depth 20+) don't push layers out of view or flatten them against the
+        // camera. Shallow trees keep the full 20.0 spacing; only deep trees
+        // compress.
+        if depth > 1 {
+            let adaptive = min(configuration.zSpacing, 400.0 / Float(depth))
+            configuration.zSpacing = max(adaptive, configuration.minimumZSpacing)
+        }
         sceneView.allowsCameraControl = true
         sceneView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(sceneView)
@@ -114,12 +123,17 @@ final class SnapshotView: UIView {
         cameraNode.camera = camera
         cameraNode.categoryBitMask = 0
         let nodePos = sceneView.scene?.rootNode.childNodes.last?.position.y ?? 760
+        // Pulled back (x -900, z 1200) and raised (y * 0.65) relative to the
+        // original (-700, nodePos/2, 1000) so the full fanned stack is visible
+        // without the topmost layer clipping off-screen. The yaw is softened
+        // from -π/4 (45°) to -π/6 (30°) so the layers fan apart more gently —
+        // each plane stays more face-on and readable instead of edge-on.
         cameraNode.position = .init(
-            x: -700,
-            y: nodePos / 2,
-            z: 1000
+            x: -900,
+            y: nodePos * 0.65,
+            z: 1200
         )
-        cameraNode.eulerAngles.y = -.pi / 4
+        cameraNode.eulerAngles.y = -.pi / 6
 
         sceneView.scene?.rootNode.addChildNode(cameraNode)
         sceneView.pointOfView = cameraNode


### PR DESCRIPTION
## What

Adjusts the view debugger's 3D snapshot camera position/yaw and makes the layer z-spacing depth-adaptive, so separated planes fan apart gently and stay readable instead of overlapping edge-on or pushing out of view on deep hierarchies.

## Why

On the current `main`, the 3D snapshot camera sits at `(-700, nodePos/2, 1000)` with a 45° yaw, and every plane is spaced at a fixed `zSpacing = 20.0 * depth`. For deeper view hierarchies this:
- tilts layers edge-on so they overlap and become unreadable, and
- pushes the deepest planes (z = 20 × depth) far past the camera's comfortable viewing range.

## Changes (`SnapshotView.swift`)

- **Camera**: pull back to `(-900, nodePos*0.65, 1200)` and soften the yaw from `-π/4` (45°) to `-π/6` (30°). The stack fans apart more gently and each plane stays more face-on/readable.
- **z-spacing**: depth-adaptive default. With the camera at z≈1200, planes sit at `z = zSpacing × depth`; cap the deepest at ~400 so deep hierarchies (depth 20+) don't push layers out of view or flatten them against the camera. Shallow trees keep the full `20.0` spacing; only deep trees compress, bounded by `minimumZSpacing`.

## Test plan

- [ ] Build the Example app, open the view debugger (long-press the floating ball) on a screen with a moderate hierarchy (e.g. the Examples list) → Snapshot tab → confirm planes are separated, face-on, and fully visible.
- [ ] Open on a deep hierarchy → confirm the deepest planes stay in view (no clipping/off-screen) and the stack isn't flattened.
- [ ] Drag the spacing slider → confirm layers re-stack smoothly at the new camera angle.
- [ ] Drag the depth slider → confirm the depth-range filter still hides/shows the right layers.

No behavioral change to the hierarchy table; only the 3D snapshot render geometry.
