### PR TITLE
feat: constraint the dictionary extension to enhance the compile time type safety

### DIFF
--- a/DebugSwift/Sources/Helpers/Extensions/Dictionary+.swift
+++ b/DebugSwift/Sources/Helpers/Extensions/Dictionary+.swift
@@ -32,16 +32,16 @@ extension [AnyHashable: Any] {
     }
 }
 
-extension Dictionary {
+extension Dictionary where Key == String {
     func asJsonStr() -> String? {
         var jsonCompatibleDictionary: [String: Any] = [:]
 
         // Converte valores incompatíveis
         for (key, value) in self {
             if let data = value as? Data {
-                jsonCompatibleDictionary[key as! String] = data.base64EncodedString()
+                jsonCompatibleDictionary[key] = data.base64EncodedString()
             } else {
-                jsonCompatibleDictionary[key as! String] = value
+                jsonCompatibleDictionary[key] = value
             }
         }
 


### PR DESCRIPTION
## Summary

Forcing dictionary keys to String may result in an unexpected crash. So we have 2 options:
1. Constraint the extension for String keys
2. Guard the type casting and return `nil` since the function is already fallible.
I chose the first option since it is compile-time safe and avoids unnecessary extending, but we can switch to the second option if you know it would be needed in a non-string situation.
Please let me know in that case.
Thanks

## Type of change

- [x] Refactor

## Test plan

- [x] Manual testing completed

### Manual test steps

1. Build and run the library
4. Build and run the example project

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
