### PR TITLE
feat: use the dedicated API for retrieving `Info.plist` values

### DIFF
--- a/DebugSwift/Sources/Features/App/Crash/Helpers/CallStackSymbols/CallStackParser.swift
+++ b/DebugSwift/Sources/Features/App/Crash/Helpers/CallStackSymbols/CallStackParser.swift
@@ -13,15 +13,9 @@ import Foundation
  */
 class CallStackParser {
     static var bundleName: String? {
-        if let name: String = Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String {
-            return name
-        }
-        if let name: String = Bundle(
-            for: self
-        ).infoDictionary?[kCFBundleNameKey as String] as? String {
-            return name
-        }
-        return nil
+        Bundle.main.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String
+        ??
+        Bundle(for: self).object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String
     }
 
     private static func cleanMethod(


### PR DESCRIPTION
## Summary

- Replaced direct `infoDictionary` access with `object(forInfoDictionaryKey:)` when reading bundle metadata. This uses the dedicated Foundation API for retrieving Info.plist values and makes the intent clearer.
- Simplified the lookup logic by replacing multiple `if let` statements with nil coalescing (`??`) while preserving the same fallback behavior.

## Type of change

- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Launch the app.
2. Verify the bundle name is still resolved correctly.
3. Verify behavior is unchanged when the value is read from both `Bundle.main` and the fallback bundle.

## Screenshots / recordings (if applicable)

<!-- Add visuals when UI or behavior changes -->

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility
