### PR TITLE
fix: HTTP header parsing correctness

### DIFF
--- a/DebugSwift/Sources/Helpers/Extensions/HTTPURLResponse+.swift
+++ b/DebugSwift/Sources/Helpers/Extensions/HTTPURLResponse+.swift
@@ -10,14 +10,14 @@ import Foundation
 
 extension HTTPURLResponse {
     func expires() -> Date? {
-        if let cc = (allHeaderFields["Cache-Control"] as? String)?.lowercased(),
+        if let cc = value(forHTTPHeaderField: "Cache-Control")?.lowercased(),
            let range = cc.range(of: "max-age="),
            let s = cc[range.upperBound...].components(separatedBy: ",").first,
            let age = TimeInterval(s) {
             return Date(timeIntervalSinceNow: age)
         }
 
-        if let ex = (allHeaderFields["Expires"] as? String)?.lowercased(),
+        if let ex = value(forHTTPHeaderField: "Expires"),
            let exp = Date.dateFormatter.date(from: ex) {
             return exp
         }


### PR DESCRIPTION
## Summary

Replaced direct `allHeaderFields` dictionary lookups with `value(forHTTPHeaderField:)` for reading HTTP response headers. This uses the dedicated Foundation API for retrieving HTTP header values, improving readability and ensuring case-insensitive header lookup while preserving existing behavior.

> [!NOTE]
> The previous implementation relied on a case-sensitive dictionary lookup (`allHeaderFields["Header-Name"]`), which is **not correct** for [HTTP headers because header names are defined as case-insensitive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers). Replacing it with `value(forHTTPHeaderField:)` fixes this while also using the dedicated Foundation API.

## Type of change

- [x] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Make requests that exercise the HTTP cache logic.
2. Verify `Cache-Control` and `Expires` headers are still interpreted correctly.
3. Confirm the caching behavior is unchanged.

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility