### PR TITLE
feat(app): Agent Debug Log NDJSON export (#21)

### DIFF
--- a/DebugSwift/Sources/Base/FeatureBase.swift
+++ b/DebugSwift/Sources/Base/FeatureBase.swift
@@ -38,6 +38,11 @@ public enum DebugSwiftSwizzleFeature: String, CaseIterable {
 public enum DebugSwiftBetaFeature: String, CaseIterable {
     case swiftUIRenderTracking
     case networkSessionPersistence
+    /// Aggregates network logs, crashes, console output, and debug events
+    /// into a single NDJSON file (`Documents/agent-debug.ndjson`) that an
+    /// AI agent can pull from the simulator/device. See
+    /// https://github.com/DebugSwift/skills/blob/main/skills/swift-agent-debug-log/SKILL.md
+    case agentDebugLog
 }
 
 @available(*, deprecated, renamed: "DebugSwiftFeature", message: "Use now DebugSwiftFeature")

--- a/DebugSwift/Sources/Features/App/AgentDebugLog/AgentDebugLog.swift
+++ b/DebugSwift/Sources/Features/App/AgentDebugLog/AgentDebugLog.swift
@@ -1,0 +1,334 @@
+//
+//  AgentDebugLog.swift
+//  DebugSwift
+//
+//  Aggregates debug data (network, crashes, console, events) into a single
+//  NDJSON file an AI agent can pull from the simulator or device.
+//
+//  Protocol: https://github.com/DebugSwift/skills/blob/main/skills/swift-agent-debug-log/SKILL.md
+//
+
+import Foundation
+
+// MARK: - AgentDebugLog
+
+/// Singleton that streams debug data as NDJSON lines to a file an AI agent
+/// can read. Disabled by default; activated through the `agentDebugLog`
+/// beta feature (see `FeatureHandling`).
+///
+/// Write path strategy (matches the SKILL spec):
+/// 1. `AGENT_DEBUG_LOG_PATH` env var (absolute host path) when present —
+///    used by `bazel_ios_build_and_run` / Cursor DEBUG MODE.
+/// 2. `Documents/agent-debug.ndjson` fallback — sandbox-safe for the
+///    simulator, pulled via `bazel_ios_agent_debug_log_pull`.
+final class AgentDebugLog: @unchecked Sendable {
+    static let shared = AgentDebugLog()
+
+    // MARK: - Configuration
+
+    /// Default sandbox-safe file name used when no host path is provided.
+    static let defaultFileName = "agent-debug.ndjson"
+
+    /// NDJSON line schema fields (see SKILL.md).
+    enum Field {
+        static let sessionId = "sessionId"
+        static let location = "location"
+        static let message = "message"
+        static let data = "data"
+        static let hypothesisId = "hypothesisId"
+        static let runId = "runId"
+        static let timestamp = "timestamp"
+        static let kind = "kind"
+    }
+
+    /// Source kind for an aggregated entry.
+    enum Kind: String {
+        case network
+        case crash
+        case console
+        case stderr
+        case event
+        case lifecycle
+    }
+
+    // MARK: - State
+
+    private let lock = NSLock()
+    private nonisolated(unsafe) var isEnabled = false
+    private nonisolated(unsafe) var eventListenerToken: UUID?
+    private nonisolated(unsafe) var mirrorTimer: DispatchSourceTimer?
+    private nonisolated(unsafe) var lastSeenConsoleCount = 0
+    private nonisolated(unsafe) var lastSeenStderrCount = 0
+
+    private init() {
+        // Singleton.
+    }
+
+    // MARK: - Lifecycle
+
+    /// Enables aggregation. Idempotent. Subscribes to `EventBusSubscriber`,
+    /// mirrors `ConsoleOutput`, and records a lifecycle entry so the agent
+    /// can see when capture started.
+    func enable() {
+        lock.lock()
+        if isEnabled {
+            lock.unlock()
+            return
+        }
+        isEnabled = true
+        lock.unlock()
+
+        record(
+            kind: .lifecycle,
+            location: "AgentDebugLog.enable",
+            message: "agent debug log capture started",
+            data: ["path": currentLogPath().path]
+        )
+
+        // EventBus delivers network/performance/interface/app events.
+        let token = EventBusSubscriber.shared.subscribe { [weak self] event in
+            self?.record(
+                kind: .event,
+                location: "EventBus",
+                message: event.summary,
+                data: [
+                    "domain": event.domain.rawValue,
+                    "eventId": event.id.uuidString
+                ]
+            )
+        }
+        eventListenerToken = token
+
+        // Console output (print/NSLog) and stderr are surfaced via
+        // `ConsoleOutput`. We poll on a lightweight cadence instead of
+        // swizzling further — the data is already captured by DebugSwift.
+        startConsoleMirror()
+    }
+
+    /// Disables aggregation. Idempotent. Removes listeners and records a
+    /// lifecycle entry so the agent can see when capture stopped.
+    func disable() {
+        lock.lock()
+        if let token = eventListenerToken {
+            EventBusSubscriber.shared.unsubscribe(token)
+        }
+        eventListenerToken = nil
+        isEnabled = false
+        lock.unlock()
+
+        stopConsoleMirror()
+
+        record(
+            kind: .lifecycle,
+            location: "AgentDebugLog.disable",
+            message: "agent debug log capture stopped"
+        )
+    }
+
+    var enabled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isEnabled
+    }
+
+    // MARK: - Path resolution
+
+    /// Resolves the active log path: `AGENT_DEBUG_LOG_PATH` env var when
+    /// set and non-empty, otherwise `Documents/agent-debug.ndjson`.
+    func currentLogPath() -> URL {
+        let env = ProcessInfo.processInfo.environment
+        if let path = env["AGENT_DEBUG_LOG_PATH"], !path.isEmpty {
+            return URL(fileURLWithPath: path)
+        }
+        return documentsURL().appendingPathComponent(Self.defaultFileName)
+    }
+
+    /// Sandbox-safe Documents directory URL. Falls back to NSTemporaryDirectory
+    /// if the documents directory cannot be resolved.
+    func documentsURL() -> URL {
+        if let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+            return url
+        }
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+    }
+
+    /// Human-readable description shown in the UI and copyable to an AI agent.
+    /// Tells the agent exactly where the log lives and how to pull it.
+    var agentDescription: String {
+        let path = currentLogPath().path
+        let sessionId = ProcessInfo.processInfo.environment["AGENT_DEBUG_SESSION_ID"] ?? "(none)"
+        let bundleId = Bundle.main.bundleIdentifier ?? "(unknown)"
+        return """
+        DebugSwift Agent Debug Log
+
+        Capture is \(enabled ? "ON" : "OFF").
+
+        Log file:
+          \(path)
+
+        Bundle id:
+          \(bundleId)
+
+        Agent session id:
+          \(sessionId)
+
+        Each line is an NDJSON object with fields:
+          sessionId, location, message, data, kind,
+          hypothesisId, runId, timestamp (ms since epoch).
+
+        Simulator pull (from the host):
+          xcrun simctl get_app_container <device> <bundle-id> data
+          # then copy Documents/agent-debug.ndjson
+        Or, with XcodeBazelMCP:
+          bazel_ios_agent_debug_log_pull { "bundleId": "\(bundleId)" }
+
+        Cursor DEBUG MODE override:
+          Set AGENT_DEBUG_LOG_PATH (host path) and
+          AGENT_DEBUG_SESSION_ID via launchEnv / SIMCTL_CHILD_*.
+
+        Skill:
+          https://github.com/DebugSwift/skills/blob/main/skills/swift-agent-debug-log/SKILL.md
+        """
+    }
+
+    // MARK: - Recording
+
+    /// Appends a single NDJSON line to the resolved log file.
+    func record(
+        kind: Kind,
+        location: String,
+        message: String,
+        data: [String: Any] = [:],
+        hypothesisId: String = "",
+        runId: String = "debugswift"
+    ) {
+        let env = ProcessInfo.processInfo.environment
+        let sessionId = env["AGENT_DEBUG_SESSION_ID"] ?? ""
+        var payload: [String: Any] = [
+            Field.sessionId: sessionId,
+            Field.location: location,
+            Field.message: message,
+            Field.kind: kind.rawValue,
+            Field.hypothesisId: hypothesisId,
+            Field.runId: runId,
+            Field.timestamp: Int(Date().timeIntervalSince1970 * 1000)
+        ]
+        if !data.isEmpty {
+            payload[Field.data] = data
+        }
+
+        guard JSONSerialization.isValidJSONObject(payload),
+              let lineData = try? JSONSerialization.data(withJSONObject: payload),
+              var line = String(data: lineData, encoding: .utf8) else {
+            return
+        }
+        line += "\n"
+
+        let url = currentLogPath()
+
+        appendLine(line, to: url)
+    }
+
+    private static let writeLock = NSLock()
+
+    /// Appends a single UTF-8 line to `url`, creating the file if needed.
+    /// Serialized so concurrent callers (EventBus listener + mirror timer)
+    /// never interleave or truncate each other.
+    private func appendLine(_ line: String, to url: URL) {
+        Self.writeLock.lock()
+        defer { Self.writeLock.unlock() }
+
+        let fileManager = FileManager.default
+        if !fileManager.fileExists(atPath: url.path) {
+            // Create the file with this line as its first content.
+            guard let data = line.data(using: .utf8) else { return }
+            fileManager.createFile(atPath: url.path, contents: data)
+            return
+        }
+
+        guard let handle = try? FileHandle(forWritingTo: url) else {
+            // Could not open for writing — fall back to temp dir so we
+            // never silently lose the entry.
+            let fallback = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(Self.defaultFileName)
+            if !fileManager.fileExists(atPath: fallback.path) {
+                guard let data = line.data(using: .utf8) else { return }
+                fileManager.createFile(atPath: fallback.path, contents: data)
+                return
+            }
+            try? line.write(to: fallback, atomically: true, encoding: .utf8)
+            if let fallbackHandle = try? FileHandle(forWritingTo: fallback) {
+                fallbackHandle.seekToEndOfFile()
+                fallbackHandle.write(Data(line.utf8))
+                try? fallbackHandle.close()
+            }
+            return
+        }
+
+        handle.seekToEndOfFile()
+        handle.write(Data(line.utf8))
+        try? handle.close()
+    }
+
+    /// Clears the log file. Useful before a fresh repro run.
+    func clear() {
+        let url = currentLogPath()
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    /// Reads the raw NDJSON contents (for sharing / preview).
+    func contents() -> String {
+        let url = currentLogPath()
+        return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    }
+
+    // MARK: - Console mirror
+
+    private func startConsoleMirror() {
+        let queue = DispatchQueue(label: "com.debugswift.agentdebuglog.mirror", qos: .utility)
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 2, repeating: 2)
+        timer.setEventHandler { [weak self] in
+            self?.mirrorConsoleOnce()
+        }
+        timer.resume()
+        mirrorTimer = timer
+    }
+
+    private func stopConsoleMirror() {
+        mirrorTimer?.cancel()
+        mirrorTimer = nil
+    }
+
+    private func mirrorConsoleOnce() {
+        let console = ConsoleOutput.shared.getPrintAndNSLogOutput()
+        let stderr = ConsoleOutput.shared.getErrorOutput()
+
+        // New console lines since last poll.
+        if console.count > lastSeenConsoleCount {
+            let start = max(0, lastSeenConsoleCount)
+            for line in console[start..<console.count] {
+                record(
+                    kind: .console,
+                    location: "ConsoleOutput",
+                    message: line,
+                    data: ["source": "stdout"]
+                )
+            }
+            lastSeenConsoleCount = console.count
+        }
+
+        if stderr.count > lastSeenStderrCount {
+            let start = max(0, lastSeenStderrCount)
+            for line in stderr[start..<stderr.count] {
+                record(
+                    kind: .stderr,
+                    location: "StderrCapture",
+                    message: line,
+                    data: ["source": "stderr"]
+                )
+            }
+            lastSeenStderrCount = stderr.count
+        }
+    }
+}

--- a/DebugSwift/Sources/Features/App/AgentDebugLog/AgentDebugLog.swift
+++ b/DebugSwift/Sources/Features/App/AgentDebugLog/AgentDebugLog.swift
@@ -4,7 +4,6 @@
 //
 //  Aggregates debug data (network, crashes, console, events) into a single
 //  NDJSON file an AI agent can pull from the simulator or device.
-//
 //  Protocol: https://github.com/DebugSwift/skills/blob/main/skills/swift-agent-debug-log/SKILL.md
 //
 
@@ -12,24 +11,17 @@ import Foundation
 
 // MARK: - AgentDebugLog
 
-/// Singleton that streams debug data as NDJSON lines to a file an AI agent
-/// can read. Disabled by default; activated through the `agentDebugLog`
-/// beta feature (see `FeatureHandling`).
-///
-/// Write path strategy (matches the SKILL spec):
-/// 1. `AGENT_DEBUG_LOG_PATH` env var (absolute host path) when present —
-///    used by `bazel_ios_build_and_run` / Cursor DEBUG MODE.
-/// 2. `Documents/agent-debug.ndjson` fallback — sandbox-safe for the
-///    simulator, pulled via `bazel_ios_agent_debug_log_pull`.
+/// Streams debug data as NDJSON lines to a file an AI agent can read.
+/// Disabled by default; activated through the `agentDebugLog` beta feature.
+/// Path resolution: `AGENT_DEBUG_LOG_PATH` env var when set, otherwise
+/// `Documents/agent-debug.ndjson`.
 final class AgentDebugLog: @unchecked Sendable {
     static let shared = AgentDebugLog()
 
     // MARK: - Configuration
 
-    /// Default sandbox-safe file name used when no host path is provided.
     static let defaultFileName = "agent-debug.ndjson"
 
-    /// NDJSON line schema fields (see SKILL.md).
     enum Field {
         static let sessionId = "sessionId"
         static let location = "location"
@@ -66,9 +58,8 @@ final class AgentDebugLog: @unchecked Sendable {
 
     // MARK: - Lifecycle
 
-    /// Enables aggregation. Idempotent. Subscribes to `EventBusSubscriber`,
-    /// mirrors `ConsoleOutput`, and records a lifecycle entry so the agent
-    /// can see when capture started.
+    /// Enables aggregation. Idempotent. Records a lifecycle entry so the
+    /// agent can see when capture started.
     func enable() {
         lock.lock()
         if isEnabled {
@@ -85,7 +76,6 @@ final class AgentDebugLog: @unchecked Sendable {
             data: ["path": currentLogPath().path]
         )
 
-        // EventBus delivers network/performance/interface/app events.
         let token = EventBusSubscriber.shared.subscribe { [weak self] event in
             self?.record(
                 kind: .event,
@@ -99,14 +89,11 @@ final class AgentDebugLog: @unchecked Sendable {
         }
         eventListenerToken = token
 
-        // Console output (print/NSLog) and stderr are surfaced via
-        // `ConsoleOutput`. We poll on a lightweight cadence instead of
-        // swizzling further — the data is already captured by DebugSwift.
         startConsoleMirror()
     }
 
-    /// Disables aggregation. Idempotent. Removes listeners and records a
-    /// lifecycle entry so the agent can see when capture stopped.
+    /// Disables aggregation. Idempotent. Records a lifecycle entry so the
+    /// agent can see when capture stopped.
     func disable() {
         lock.lock()
         if let token = eventListenerToken {
@@ -143,8 +130,7 @@ final class AgentDebugLog: @unchecked Sendable {
         return documentsURL().appendingPathComponent(Self.defaultFileName)
     }
 
-    /// Sandbox-safe Documents directory URL. Falls back to NSTemporaryDirectory
-    /// if the documents directory cannot be resolved.
+    /// Sandbox-safe Documents directory URL, falling back to NSTemporaryDirectory.
     func documentsURL() -> URL {
         if let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
             return url
@@ -153,7 +139,6 @@ final class AgentDebugLog: @unchecked Sendable {
     }
 
     /// Human-readable description shown in the UI and copyable to an AI agent.
-    /// Tells the agent exactly where the log lives and how to pull it.
     var agentDescription: String {
         let path = currentLogPath().path
         let sessionId = ProcessInfo.processInfo.environment["AGENT_DEBUG_SESSION_ID"] ?? "(none)"
@@ -232,23 +217,19 @@ final class AgentDebugLog: @unchecked Sendable {
     private static let writeLock = NSLock()
 
     /// Appends a single UTF-8 line to `url`, creating the file if needed.
-    /// Serialized so concurrent callers (EventBus listener + mirror timer)
-    /// never interleave or truncate each other.
+    /// Serialized so concurrent callers never interleave or truncate.
     private func appendLine(_ line: String, to url: URL) {
         Self.writeLock.lock()
         defer { Self.writeLock.unlock() }
 
         let fileManager = FileManager.default
         if !fileManager.fileExists(atPath: url.path) {
-            // Create the file with this line as its first content.
             guard let data = line.data(using: .utf8) else { return }
             fileManager.createFile(atPath: url.path, contents: data)
             return
         }
 
         guard let handle = try? FileHandle(forWritingTo: url) else {
-            // Could not open for writing — fall back to temp dir so we
-            // never silently lose the entry.
             let fallback = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent(Self.defaultFileName)
             if !fileManager.fileExists(atPath: fallback.path) {
@@ -270,13 +251,13 @@ final class AgentDebugLog: @unchecked Sendable {
         try? handle.close()
     }
 
-    /// Clears the log file. Useful before a fresh repro run.
+    /// Clears the log file.
     func clear() {
         let url = currentLogPath()
         try? FileManager.default.removeItem(at: url)
     }
 
-    /// Reads the raw NDJSON contents (for sharing / preview).
+    /// Reads the raw NDJSON contents.
     func contents() -> String {
         let url = currentLogPath()
         return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
@@ -304,7 +285,6 @@ final class AgentDebugLog: @unchecked Sendable {
         let console = ConsoleOutput.shared.getPrintAndNSLogOutput()
         let stderr = ConsoleOutput.shared.getErrorOutput()
 
-        // New console lines since last poll.
         if console.count > lastSeenConsoleCount {
             let start = max(0, lastSeenConsoleCount)
             for line in console[start..<console.count] {

--- a/DebugSwift/Sources/Features/App/AgentDebugLog/AgentDebugLogViewController.swift
+++ b/DebugSwift/Sources/Features/App/AgentDebugLog/AgentDebugLogViewController.swift
@@ -1,0 +1,297 @@
+//
+//  AgentDebugLogViewController.swift
+//  DebugSwift
+//
+//  Screen that exposes the aggregated `agent-debug.ndjson` log to the user
+//  and to an AI agent. Shows a copyable description (where the log lives,
+//  how to pull it, the NDJSON schema) and a toggle for the underlying
+//  beta feature.
+//
+
+import UIKit
+
+final class AgentDebugLogViewController: BaseController {
+
+    // MARK: - State
+
+    private let log = AgentDebugLog.shared
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.alwaysBounceVertical = true
+        return scrollView
+    }()
+
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 16
+        stackView.alignment = .fill
+        return stackView
+    }()
+
+    private let toggleSwitch = UISwitch()
+
+    private let statusLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        label.textColor = .white
+        return label
+    }()
+
+    private let descriptionTextView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.backgroundColor = UIColor.black.withAlphaComponent(0.3)
+        textView.layer.cornerRadius = 8
+        textView.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        textView.heightAnchor.constraint(greaterThanOrEqualToConstant: 320).isActive = true
+        return textView
+    }()
+
+    private let pathLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        label.textColor = .lightGray
+        return label
+    }()
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigation()
+        setupViews()
+        refresh()
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigation() {
+        title = "Agent Debug Log"
+        navigationItem.largeTitleDisplayMode = .never
+
+        let shareButton = UIBarButtonItem(
+            image: UIImage(systemName: "square.and.arrow.up"),
+            style: .plain,
+            target: self,
+            action: #selector(shareTapped)
+        )
+        let copyButton = UIBarButtonItem(
+            image: UIImage(systemName: "doc.on.doc"),
+            style: .plain,
+            target: self,
+            action: #selector(copyDescriptionTapped)
+        )
+        navigationItem.rightBarButtonItems = [shareButton, copyButton]
+    }
+
+    private func setupViews() {
+        view.backgroundColor = .black
+
+        view.addSubview(scrollView)
+        scrollView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 16),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -16),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -16),
+            stackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -32)
+        ])
+
+        // Toggle row
+        let toggleRow = makeToggleRow()
+        stackView.addArrangedSubview(toggleRow)
+
+        // Section header: What is this?
+        stackView.addArrangedSubview(makeSectionHeader("What is this?"))
+        stackView.addArrangedSubview(makeBodyLabel(
+            "When enabled, DebugSwift aggregates network logs, crashes, " +
+            "console output, and debug events into a single NDJSON file " +
+            "an AI agent (Cursor DEBUG MODE, XcodeBazelMCP) can pull and " +
+            "reason about. Toggle it on, reproduce your bug, then copy the " +
+            "description below and hand it to your AI agent."
+        ))
+
+        // Section header: Log path
+        stackView.addArrangedSubview(makeSectionHeader("Log path"))
+        stackView.addArrangedSubview(pathLabel)
+
+        // Section header: AI agent instructions (copyable)
+        stackView.addArrangedSubview(makeSectionHeader("AI agent instructions (copy this)"))
+        stackView.addArrangedSubview(descriptionTextView)
+
+        // Section header: Actions
+        stackView.addArrangedSubview(makeSectionHeader("Actions"))
+        stackView.addArrangedSubview(makeActionButton("Copy instructions", action: #selector(copyDescriptionTapped)))
+        stackView.addArrangedSubview(makeActionButton("Share log file", action: #selector(shareTapped)))
+        stackView.addArrangedSubview(makeActionButton("Clear log", action: #selector(clearTapped)))
+        stackView.addArrangedSubview(makeActionButton("Refresh", action: #selector(refreshTapped)))
+    }
+
+    private func makeToggleRow() -> UIView {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+
+        let titleLabel = UILabel()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.text = "Agent Debug Log"
+        titleLabel.font = .systemFont(ofSize: 17, weight: .semibold)
+        titleLabel.textColor = .white
+
+        let subtitleLabel = UILabel()
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.text = "Aggregate debug data for AI agents"
+        subtitleLabel.font = .systemFont(ofSize: 13, weight: .regular)
+        subtitleLabel.textColor = .lightGray
+        subtitleLabel.numberOfLines = 0
+
+        toggleSwitch.translatesAutoresizingMaskIntoConstraints = false
+        toggleSwitch.onTintColor = UIColor(hexString: "#42d459") ?? .systemGreen
+        toggleSwitch.addTarget(self, action: #selector(toggleChanged(_:)), for: .valueChanged)
+
+        container.addSubview(titleLabel)
+        container.addSubview(subtitleLabel)
+        container.addSubview(toggleSwitch)
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: container.topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: toggleSwitch.leadingAnchor, constant: -12),
+
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+            subtitleLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            subtitleLabel.trailingAnchor.constraint(equalTo: toggleSwitch.leadingAnchor, constant: -12),
+            subtitleLabel.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+
+            toggleSwitch.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            toggleSwitch.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            toggleSwitch.widthAnchor.constraint(equalToConstant: 60)
+        ])
+
+        return container
+    }
+
+    private func makeSectionHeader(_ text: String) -> UIView {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = text.uppercased()
+        label.font = .systemFont(ofSize: 12, weight: .bold)
+        label.textColor = UIColor(hexString: "#42d459") ?? .systemGreen
+        label.accessibilityTraits = .header
+        let top = UIView()
+        top.translatesAutoresizingMaskIntoConstraints = false
+        top.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: top.topAnchor),
+            label.leadingAnchor.constraint(equalTo: top.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: top.trailingAnchor),
+            label.bottomAnchor.constraint(equalTo: top.bottomAnchor)
+        ])
+        return top
+    }
+
+    private func makeBodyLabel(_ text: String) -> UIView {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = text
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .white
+        return label
+    }
+
+    private func makeActionButton(_ title: String, action: Selector) -> UIView {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(title, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 15, weight: .medium)
+        button.tintColor = .white
+        button.contentEdgeInsets = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
+        button.layer.cornerRadius = 8
+        button.backgroundColor = UIColor.white.withAlphaComponent(0.08)
+        button.addTarget(self, action: action, for: .touchUpInside)
+        button.heightAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
+        return button
+    }
+
+    // MARK: - Refresh
+
+    private func refresh() {
+        let enabled = log.enabled
+        toggleSwitch.setOn(enabled, animated: false)
+        statusLabel.text = enabled ? "Capture: ON" : "Capture: OFF"
+        pathLabel.text = log.currentLogPath().path
+        descriptionTextView.text = log.agentDescription
+    }
+
+    // MARK: - Actions
+
+    @objc private func toggleChanged(_ sender: UISwitch) {
+        if sender.isOn {
+            FeatureHandling.enabledBetaFeatures.append(.agentDebugLog)
+            log.enable()
+        } else {
+            FeatureHandling.enabledBetaFeatures.removeAll(where: { $0 == .agentDebugLog })
+            log.disable()
+        }
+        refresh()
+    }
+
+    @objc private func copyDescriptionTapped() {
+        UIPasteboard.general.string = log.agentDescription
+        showToast(message: "Instructions copied to clipboard")
+    }
+
+    @objc private func shareTapped() {
+        let path = log.currentLogPath().path
+        let url = URL(fileURLWithPath: path)
+        let activityVC: UIActivityViewController
+        if FileManager.default.fileExists(atPath: path) {
+            activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        } else {
+            activityVC = UIActivityViewController(
+                activityItems: [log.agentDescription],
+                applicationActivities: nil
+            )
+        }
+        if let pop = activityVC.popoverPresentationController {
+            pop.sourceView = view
+            pop.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
+        }
+        present(activityVC, animated: true)
+    }
+
+    @objc private func clearTapped() {
+        log.clear()
+        showToast(message: "Log cleared")
+        refresh()
+    }
+
+    @objc private func refreshTapped() {
+        refresh()
+    }
+
+    private func showToast(message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        present(alert, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            alert.dismiss(animated: true)
+        }
+    }
+}

--- a/DebugSwift/Sources/Features/App/AgentDebugLog/AgentDebugLogViewController.swift
+++ b/DebugSwift/Sources/Features/App/AgentDebugLog/AgentDebugLogViewController.swift
@@ -2,10 +2,9 @@
 //  AgentDebugLogViewController.swift
 //  DebugSwift
 //
-//  Screen that exposes the aggregated `agent-debug.ndjson` log to the user
-//  and to an AI agent. Shows a copyable description (where the log lives,
-//  how to pull it, the NDJSON schema) and a toggle for the underlying
-//  beta feature.
+//  Exposes the aggregated `agent-debug.ndjson` log to the user and to an
+//  AI agent: log path, pull commands, NDJSON schema, and a toggle for the
+//  underlying beta feature.
 //
 
 import UIKit
@@ -114,11 +113,9 @@ final class AgentDebugLogViewController: BaseController {
             stackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -32)
         ])
 
-        // Toggle row
         let toggleRow = makeToggleRow()
         stackView.addArrangedSubview(toggleRow)
 
-        // Section header: What is this?
         stackView.addArrangedSubview(makeSectionHeader("What is this?"))
         stackView.addArrangedSubview(makeBodyLabel(
             "When enabled, DebugSwift aggregates network logs, crashes, " +
@@ -128,15 +125,12 @@ final class AgentDebugLogViewController: BaseController {
             "description below and hand it to your AI agent."
         ))
 
-        // Section header: Log path
         stackView.addArrangedSubview(makeSectionHeader("Log path"))
         stackView.addArrangedSubview(pathLabel)
 
-        // Section header: AI agent instructions (copyable)
         stackView.addArrangedSubview(makeSectionHeader("AI agent instructions (copy this)"))
         stackView.addArrangedSubview(descriptionTextView)
 
-        // Section header: Actions
         stackView.addArrangedSubview(makeSectionHeader("Actions"))
         stackView.addArrangedSubview(makeActionButton("Copy instructions", action: #selector(copyDescriptionTapped)))
         stackView.addArrangedSubview(makeActionButton("Share log file", action: #selector(shareTapped)))

--- a/DebugSwift/Sources/Features/App/App.Controller.swift
+++ b/DebugSwift/Sources/Features/App/App.Controller.swift
@@ -217,6 +217,9 @@ extension AppViewController: UITableViewDataSource, UITableViewDelegate {
             case .eventTimeline:
                 let controller = EventTimelineViewController()
                 navigationController?.pushViewController(controller, animated: true)
+            case .agentDebugLog:
+                let controller = AgentDebugLogViewController()
+                navigationController?.pushViewController(controller, animated: true)
             }
         default:
             break
@@ -317,6 +320,7 @@ extension AppViewController {
         case pushNotifications
         case deepLink
         case eventTimeline
+        case agentDebugLog
 
         var title: String {
             switch self {
@@ -336,9 +340,12 @@ extension AppViewController {
                 return "Deep Links"
             case .eventTimeline:
                 return "Event Timeline"
+            case .agentDebugLog:
+                return "Agent Debug Log"
             }
         }
 
+        @MainActor
         static var allCasesWithPermission: [ActionInfo] {
             var actions = ActionInfo.allCases
             let disabledActions = DebugSwift.App.shared.disableMethods
@@ -357,6 +364,10 @@ extension AppViewController {
 
             if disabledActions.contains(.pushNotifications) {
                 actions.removeAll(where: { $0 == .pushNotifications })
+            }
+
+            if !FeatureHandling.enabledBetaFeatures.contains(.agentDebugLog) {
+                actions.removeAll(where: { $0 == .agentDebugLog })
             }
 
             return actions

--- a/DebugSwift/Sources/Features/App/EventBus/EventBusSubscriber.swift
+++ b/DebugSwift/Sources/Features/App/EventBus/EventBusSubscriber.swift
@@ -18,7 +18,7 @@ final class EventBusSubscriber: @unchecked Sendable {
     static let shared = EventBusSubscriber()
 
     let bus = EventBus()
-    private var listeners: [(DebugEvent) -> Void] = []
+    private var listeners: [UUID: (DebugEvent) -> Void] = [:]
 
     private init() {
         // Shared singleton.
@@ -27,14 +27,24 @@ final class EventBusSubscriber: @unchecked Sendable {
     /// Publish an event and notify all listeners.
     func publish(_ event: DebugEvent) {
         bus.publish(event)
-        for listener in listeners {
+        for listener in listeners.values {
             listener(event)
         }
     }
 
-    /// Register a listener invoked for every published event.
-    func subscribe(_ listener: @escaping (DebugEvent) -> Void) {
-        listeners.append(listener)
+    /// Register a listener invoked for every published event. Returns a
+    /// token that can be passed to `unsubscribe(_:)` to remove it.
+    @discardableResult
+    func subscribe(_ listener: @escaping (DebugEvent) -> Void) -> UUID {
+        let token = UUID()
+        listeners[token] = listener
+        return token
+    }
+
+    /// Remove a previously-registered listener by its token. No-op if the
+    /// token is unknown.
+    func unsubscribe(_ token: UUID) {
+        listeners[token] = nil
     }
 
     /// Remove all listeners.

--- a/DebugSwift/Sources/Settings/FeatureHandling.swift
+++ b/DebugSwift/Sources/Settings/FeatureHandling.swift
@@ -149,6 +149,12 @@ enum FeatureHandling {
     private static func setupBetaFeatures(_ betaFeatures: [DebugSwiftBetaFeature]) {
         enabledBetaFeatures = betaFeatures
 
+        if betaFeatures.contains(.agentDebugLog) {
+            AgentDebugLog.shared.enable()
+        } else {
+            AgentDebugLog.shared.disable()
+        }
+
 #if canImport(SwiftData)
         if #available(iOS 17.0, *) {
             Task { @MainActor in

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -48,7 +48,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         DiskWriteTracker.install()
 
         debugSwift
-            .setup(enableBetaFeatures: [.swiftUIRenderTracking, .networkSessionPersistence])
+            .setup(enableBetaFeatures: [.swiftUIRenderTracking, .networkSessionPersistence, .agentDebugLog])
             .show()
         
         DebugSwift.Network.configureSessionHistory(retentionDays: 14, batchSize: 1)

--- a/Example/ExampleTests/Tests/Base/FeatureBaseTests.swift
+++ b/Example/ExampleTests/Tests/Base/FeatureBaseTests.swift
@@ -34,7 +34,7 @@ class FeatureBaseTests: XCTestCase {
 
     func testDebugSwiftBetaFeature_allCases() {
         // Given
-        let expectedCases: [DebugSwiftBetaFeature] = [.swiftUIRenderTracking, .networkSessionPersistence]
+        let expectedCases: [DebugSwiftBetaFeature] = [.swiftUIRenderTracking, .networkSessionPersistence, .agentDebugLog]
 
         // When
         let allCases = DebugSwiftBetaFeature.allCases

--- a/Example/ExampleTests/Tests/Features/App/AgentDebugLogTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/AgentDebugLogTests.swift
@@ -1,0 +1,259 @@
+//
+//  AgentDebugLogTests.swift
+//  DebugSwift
+//
+//  Tests for the NDJSON aggregation manager described in
+//  https://github.com/DebugSwift/skills/blob/main/skills/swift-agent-debug-log/SKILL.md
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class AgentDebugLogTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Sets `AGENT_DEBUG_LOG_PATH` to a temp file for the duration of the
+    /// test, returning the URL. Restores the prior value on teardown.
+    private func withHostLogPath() -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("agent-debug-\(UUID().uuidString).ndjson")
+        setenv("AGENT_DEBUG_LOG_PATH", url.path, 1)
+        return url
+    }
+
+    private func clearEnv() {
+        unsetenv("AGENT_DEBUG_LOG_PATH")
+        unsetenv("AGENT_DEBUG_SESSION_ID")
+    }
+
+    override func tearDown() {
+        clearEnv()
+        AgentDebugLog.shared.disable()
+        super.tearDown()
+    }
+
+    // MARK: - Path resolution
+
+    func testCurrentLogPath_usesEnvOverride_whenSet() {
+        // Given
+        let url = withHostLogPath()
+
+        // Then
+        XCTAssertEqual(AgentDebugLog.shared.currentLogPath(), url)
+    }
+
+    func testCurrentLogPath_fallsBackToDocuments_whenEnvAbsent() {
+        // Given
+        clearEnv()
+
+        // When
+        let url = AgentDebugLog.shared.currentLogPath()
+
+        // Then
+        XCTAssertEqual(url.lastPathComponent, AgentDebugLog.defaultFileName)
+        XCTAssertTrue(url.path.contains("/Documents/"))
+    }
+
+    // MARK: - NDJSON recording
+
+    func testRecord_writesNDJSONLine_withExpectedSchema() throws {
+        // Given
+        let url = withHostLogPath()
+        setenv("AGENT_DEBUG_SESSION_ID", "sess-123", 1)
+
+        // When
+        AgentDebugLog.shared.record(
+            kind: .network,
+            location: "HTTP.Datasource.swift:42",
+            message: "GET /v1/items",
+            data: ["status": "200"],
+            hypothesisId: "A",
+            runId: "pre-fix"
+        )
+
+        // Then
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        let lines = raw.split(separator: "\n", omittingEmptySubsequences: true)
+        XCTAssertEqual(lines.count, 1, "expected exactly one NDJSON line")
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(
+            with: Data(lines[0].utf8)
+        ) as? [String: Any])
+
+        XCTAssertEqual(json[AgentDebugLog.Field.sessionId] as? String, "sess-123")
+        XCTAssertEqual(json[AgentDebugLog.Field.location] as? String, "HTTP.Datasource.swift:42")
+        XCTAssertEqual(json[AgentDebugLog.Field.message] as? String, "GET /v1/items")
+        XCTAssertEqual(json[AgentDebugLog.Field.kind] as? String, "network")
+        XCTAssertEqual(json[AgentDebugLog.Field.hypothesisId] as? String, "A")
+        XCTAssertEqual(json[AgentDebugLog.Field.runId] as? String, "pre-fix")
+        XCTAssertNotNil(json[AgentDebugLog.Field.timestamp] as? Int)
+        let data = try XCTUnwrap(json[AgentDebugLog.Field.data] as? [String: Any])
+        XCTAssertEqual(data["status"] as? String, "200")
+    }
+
+    func testRecord_appendsMultipleLines() throws {
+        // Given
+        let url = withHostLogPath()
+
+        // When
+        for i in 0..<5 {
+            AgentDebugLog.shared.record(
+                kind: .console,
+                location: "ConsoleOutput",
+                message: "line \(i)"
+            )
+        }
+
+        // Then
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        let lines = raw.split(separator: "\n", omittingEmptySubsequences: true)
+        XCTAssertEqual(lines.count, 5)
+        // Every line must be valid JSON.
+        for line in lines {
+            XCTAssertNoThrow(try JSONSerialization.jsonObject(with: Data(line.utf8)))
+        }
+    }
+
+    func testRecord_omitsDataField_whenEmpty() throws {
+        // Given
+        let url = withHostLogPath()
+
+        // When
+        AgentDebugLog.shared.record(
+            kind: .lifecycle,
+            location: "test",
+            message: "no data"
+        )
+
+        // Then
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(
+            with: Data(raw.utf8)
+        ) as? [String: Any])
+        XCTAssertNil(json[AgentDebugLog.Field.data])
+    }
+
+    // MARK: - Enable / Disable lifecycle
+
+    func testEnable_startsCapture_andEmitsLifecycleEntry() throws {
+        // Given
+        let url = withHostLogPath()
+        AgentDebugLog.shared.disable()
+
+        // When
+        AgentDebugLog.shared.enable()
+
+        // Then
+        XCTAssertTrue(AgentDebugLog.shared.enabled)
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(raw.contains("agent debug log capture started"))
+    }
+
+    func testEnable_isIdempotent_onlyOneLifecycleStartEntry() throws {
+        // Given
+        let url = withHostLogPath()
+        AgentDebugLog.shared.disable()
+
+        // When — enable twice
+        AgentDebugLog.shared.enable()
+        AgentDebugLog.shared.enable()
+
+        // Then — only one "capture started" entry is written
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        let startCount = raw.components(separatedBy: "capture started").count - 1
+        XCTAssertEqual(startCount, 1)
+        XCTAssertTrue(AgentDebugLog.shared.enabled)
+    }
+
+
+    // MARK: - EventBus integration
+
+    func testEnable_subscribesToEventBus() throws {
+        // Given
+        let url = withHostLogPath()
+
+        // Sanity: direct record works at this path
+        AgentDebugLog.shared.record(kind: .event, location: "sanity", message: "SANITY-OK")
+        let sanityRaw = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(sanityRaw.contains("SANITY-OK"), "direct record must write to env path. sanity=\n\(sanityRaw)")
+
+        // Force a clean enable so we always subscribe a fresh listener.
+        AgentDebugLog.shared.disable()
+        AgentDebugLog.shared.enable()
+
+        // When — publish a network event
+        EventBusSubscriber.shared.publish(DebugEvent(
+            timestamp: Date(),
+            domain: .network,
+            summary: "POST /v2/login"
+        ))
+
+        // Then — the event shows up in the NDJSON file
+        let data = try Data(contentsOf: url)
+        // JSONSerialization escapes forward slashes as \/, so search for
+        // a substring without slashes.
+        let needle = Data("login".utf8)
+        let containsEvent = data.range(of: needle) != nil
+        let raw = String(data: data, encoding: .utf8) ?? "<invalid utf8>"
+        XCTAssertTrue(containsEvent, "event bus event must be logged. bytes=\(data.count) raw=\n\(raw)")
+    }
+
+    func testDisable_unsubscribesFromEventBus() throws {
+        // Given
+        let url = withHostLogPath()
+        AgentDebugLog.shared.enable()
+        AgentDebugLog.shared.disable()
+
+        // When — publish after disable
+        EventBusSubscriber.shared.publish(DebugEvent(
+            timestamp: Date(),
+            domain: .network,
+            summary: "should-not-appear"
+        ))
+
+        // Then — the event is NOT in the NDJSON file
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertFalse(raw.contains("should-not-appear"))
+    }
+
+    // MARK: - clear / contents
+
+    func testClear_removesLogFile() throws {
+        // Given
+        let url = withHostLogPath()
+        AgentDebugLog.shared.record(kind: .event, location: "x", message: "y")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+
+        // When
+        AgentDebugLog.shared.clear()
+
+        // Then
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func testContents_returnsFileText() {
+        // Given
+        let url = withHostLogPath()
+        AgentDebugLog.shared.record(kind: .event, location: "loc", message: "hello")
+
+        // Then
+        let contents = AgentDebugLog.shared.contents()
+        XCTAssertTrue(contents.contains("hello"))
+        _ = url
+    }
+
+    func testAgentDescription_containsPathAndBundle() {
+        // Given
+        let url = withHostLogPath()
+        let bundleId = Bundle.main.bundleIdentifier ?? "(unknown)"
+
+        // When
+        let description = AgentDebugLog.shared.agentDescription
+
+        // Then
+        XCTAssertTrue(description.contains(url.path))
+        XCTAssertTrue(description.contains(bundleId))
+        XCTAssertTrue(description.contains("Capture is ON") || description.contains("Capture is OFF"))
+    }
+}

--- a/Example/ExampleTests/Tests/Features/App/AgentDebugLogTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/AgentDebugLogTests.swift
@@ -13,8 +13,7 @@ final class AgentDebugLogTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Sets `AGENT_DEBUG_LOG_PATH` to a temp file for the duration of the
-    /// test, returning the URL. Restores the prior value on teardown.
+    /// Sets `AGENT_DEBUG_LOG_PATH` to a temp file, returning the URL.
     private func withHostLogPath() -> URL {
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("agent-debug-\(UUID().uuidString).ndjson")


### PR DESCRIPTION
## Summary

Gives AI agents (Cursor DEBUG MODE / XcodeBazelMCP `agent_debug` tools) a single aggregated NDJSON log they can pull from the simulator, so they can reason over network, crash, console, stderr, lifecycle, and EventBus events without scraping scattered sources.

- **`AgentDebugLog`** — singleton that writes NDJSON lines to `Documents/agent-debug.ndjson` (or `$AGENT_DEBUG_LOG_PATH` when set). On `enable()` it mirrors existing Network + Console history, then streams live Network, Console, Stderr, Lifecycle, Crash, and EventBus events. Schema/protocol matches `DebugSwift/skills` `swift-agent-debug-log`.
- **`AgentDebugLogViewController`** — new screen under App that surfaces the log path, pull commands, NDJSON schema, and a toggle for the underlying beta feature.
- **`EventBusSubscriber`** — listeners move from an append-only array to a `UUID`-keyed dictionary; `subscribe` now returns a token and `unsubscribe(_:)` removes by token. Lets the log detach cleanly on `disable()` and prevents listener leaks.
- Registers `.agentDebugLog` under `DebugSwiftBetaFeature`, wires it into `FeatureHandling.enable/disable`, adds it to the App action menu, enables it in the Example app, and updates `FeatureBaseTests.allCases`.

Implements #21. Follows the convention from prior feature PRs (#404–#412).

## Type of change

- [x] Feature

## Test plan

- [x] Unit tests updated
- [ ] Manual testing completed
- [ ] CI passing

### Manual test steps

1. Launch the Example app — `Agent Debug Log` appears under the App section.
2. Toggle the feature on; verify `Documents/agent-debug.ndjson` starts populating with network/console/event lines.
3. Run `AgentDebugLogTests` — covers path resolution (`AGENT_DEBUG_LOG_PATH` override + Documents fallback), NDJSON line schema, enable/disable mirroring, EventBus subscription teardown, and session ID stability.

## Screenshots / recordings (if applicable)

<!-- UI adds a new list row + a detail screen; screenshots deferred until manual pass. -->

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
