### PR TITLE
fix(resources): Replace RealmManager stub with real header parsing

### DIFF
--- a/DebugSwift/Sources/Features/Resources/Database/Helpers/RealmManager.swift
+++ b/DebugSwift/Sources/Features/Resources/Database/Helpers/RealmManager.swift
@@ -2,50 +2,132 @@
 //  RealmManager.swift
 //  DebugSwift
 //
-//  Realm database operations manager (stub implementation)
+//  Realm database operations manager.
 //
+//  The Realm binary format (realm-core) has no stable public specification and
+//  evolves across file-format versions, so this manager does not parse object
+//  schemas or row data. It reads the 24-byte file header defined in
+//  realm-core's SlabAlloc::Header to validate the file and surface its
+//  file-format version to the database browser, giving the user honest
+//  feedback instead of silently returning empty results that make the browser
+//  look broken. Full introspection requires linking RealmSwift, which is an
+//  application-side dependency and out of scope for this drop-in toolkit.
 
 import Foundation
 
-// Note: This is a stub implementation. 
-// Full Realm support requires adding RealmSwift as a dependency
-// and implementing the actual Realm operations.
-
 final class RealmManager: @unchecked Sendable {
     static let shared = RealmManager()
-    
+
     private init() {}
-    
+
+    // MARK: - Table Operations
+
     func getTables(from path: String) -> [DatabaseTable] {
-        // This is a placeholder implementation
-        // Actual implementation would require:
-        // 1. Opening Realm file at the given path
-        // 2. Introspecting the schema
-        // 3. Returning table information
-        
-        Debug.print("Realm support requires RealmSwift dependency")
-        
-        // Return empty array for now
-        // In a full implementation, this would:
-        // - Open the Realm file
-        // - Get all object schemas
-        // - Convert them to DatabaseTable format
-        return []
+        guard let header = readHeader(at: path) else {
+            Debug.print("Unable to read Realm database at \(path)")
+            return []
+        }
+
+        // Surface the file itself as a single informational "table" so the
+        // browser lists Realm files and can drill into the metadata below.
+        return [
+            DatabaseTable(
+                name: header.tableName,
+                rowCount: 1,
+                columns: [
+                    DatabaseColumn(name: "Property", type: "string", isPrimaryKey: false, isNullable: false),
+                    DatabaseColumn(name: "Value", type: "string", isPrimaryKey: false, isNullable: false)
+                ]
+            )
+        ]
     }
-    
+
+    // MARK: - Data Operations
+
     func getTableData(
         from path: String,
         table: String,
         limit: Int = 100,
         offset: Int = 0
     ) -> (columns: [String], rows: [[Any?]]) {
-        // Placeholder implementation
-        return ([], [])
+        guard let header = readHeader(at: path) else {
+            return ([], [])
+        }
+
+        return (
+            ["Property", "Value"],
+            [
+                ["File", table],
+                ["Mnemonic", header.mnemonic],
+                ["File format", "\(header.fileFormat)"],
+                ["Reserved byte", String(format: "0x%02X", header.reserved)],
+                ["Flags byte", String(format: "0x%02X", header.flags)],
+                ["Top ref (slot 0)", String(format: "0x%016llX", header.topRef0)],
+                ["Top ref (slot 1)", String(format: "0x%016llX", header.topRef1)],
+                [
+                    "Note",
+                    "Object schemas and row data require RealmSwift; the Realm binary layout is not parsed in-tree."
+                ]
+            ]
+        )
     }
-    
-    // Additional methods would include:
-    // - getObjectSchema(for className: String) -> RealmObjectSchema
-    // - queryObjects(className: String, predicate: NSPredicate?) -> Results<Object>
-    // - exportToJSON(objects: Results<Object>) -> Data
-    // etc.
-} 
+
+    // MARK: - Header Parsing
+
+    /// The 24-byte Realm file header defined by `SlabAlloc::Header` in realm-core.
+    private struct RealmHeader {
+        let topRef0: UInt64
+        let topRef1: UInt64
+        let mnemonic: String
+        let fileFormat: Int
+        let reserved: UInt8
+        let flags: UInt8
+        let tableName: String
+    }
+
+    private func readHeader(at path: String) -> RealmHeader? {
+        guard let handle = FileHandle(forReadingAtPath: path) else {
+            return nil
+        }
+        defer { handle.closeFile() }
+
+        let headerData = handle.readData(ofLength: 24)
+        guard headerData.count == 24 else {
+            return nil
+        }
+
+        return headerData.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> RealmHeader? in
+            guard let base = raw.baseAddress else { return nil }
+
+            // Layout: m_top_ref[2] (16) | m_mnemonic[4] (offset 16) | m_file_format[2] (offset 20) | m_reserved (offset 22) | m_flags (offset 23)
+            let mnemonic = String(bytes: headerData[16..<20], encoding: .ascii) ?? ""
+
+            // Realm files carry the "T-DB" mnemonic in the header.
+            guard mnemonic == "T-DB" else { return nil }
+
+            // `load(fromByteOffset:as:)` honors the type's alignment and is
+            // the safe way to read unaligned integers from a raw buffer.
+            let topRef0 = base.load(fromByteOffset: 0, as: UInt64.self)
+            let topRef1 = base.load(fromByteOffset: 8, as: UInt64.self)
+
+            let fileFormatHigh = Int(headerData[20])
+            let fileFormatLow = Int(headerData[21])
+            let fileFormat = fileFormatHigh == 0 ? fileFormatLow : fileFormatHigh
+
+            let reserved = headerData[22]
+            let flags = headerData[23]
+
+            let tableName = "Realm (\(fileFormat))"
+
+            return RealmHeader(
+                topRef0: topRef0,
+                topRef1: topRef1,
+                mnemonic: mnemonic,
+                fileFormat: fileFormat,
+                reserved: reserved,
+                flags: flags,
+                tableName: tableName
+            )
+        }
+    }
+}

--- a/Example/ExampleTests/Tests/Features/Resources/Database/RealmManagerTests.swift
+++ b/Example/ExampleTests/Tests/Features/Resources/Database/RealmManagerTests.swift
@@ -1,0 +1,141 @@
+//
+//  RealmManagerTests.swift
+//  ExampleTests
+//
+//  Tests for RealmManager header parsing and metadata surfacing.
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class RealmManagerTests: XCTestCase {
+
+    private var temporaryDirectory: URL!
+    private var manager: RealmManager!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RealmManagerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        manager = RealmManager.shared
+    }
+
+    override func tearDownWithError() throws {
+        if let directory = temporaryDirectory {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        temporaryDirectory = nil
+        manager = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    private func writeRealmFile(named fileName: String, fileFormat: (UInt8, UInt8) = (24, 24)) throws -> URL {
+        let fileURL = temporaryDirectory.appendingPathComponent(fileName)
+        var data = Data(count: 128 * 1024)
+
+        // Layout: m_top_ref[2] (16) | m_mnemonic[4] (offset 16) | m_file_format[2] (offset 20) | m_reserved (offset 22) | m_flags (offset 23)
+        // Top ref slot 0: 0xFFFFFFFFFFFFFFFF (uninitialized)
+        data.withUnsafeMutableBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            base.storeBytes(of: UInt64(0xFFFFFFFFFFFFFFFF), toByteOffset: 0, as: UInt64.self)
+            base.storeBytes(of: UInt64(0), toByteOffset: 8, as: UInt64.self)
+        }
+
+        // Mnemonic "T-DB" at offset 16
+        data[16] = 0x54 // T
+        data[17] = 0x2D // -
+        data[18] = 0x44 // D
+        data[19] = 0x42 // B
+
+        // File format version at offset 20-21
+        data[20] = fileFormat.0
+        data[21] = fileFormat.1
+
+        // Reserved byte at offset 22
+        data[22] = 0x00
+
+        // Flags byte at offset 23
+        data[23] = 0x00
+
+        try data.write(to: fileURL)
+        return fileURL
+    }
+
+    private func writeNonRealmFile(named fileName: String) throws -> URL {
+        let fileURL = temporaryDirectory.appendingPathComponent(fileName)
+        try Data(repeating: 0x00, count: 1024).write(to: fileURL)
+        return fileURL
+    }
+
+    // MARK: - getTables
+
+    func testGetTablesReturnsSingleTableForValidRealmFile() throws {
+        let realmURL = try writeRealmFile(named: "test.realm")
+        let tables = manager.getTables(from: realmURL.path)
+
+        XCTAssertEqual(tables.count, 1, "Valid Realm file should surface a single informational table")
+        let table = try XCTUnwrap(tables.first)
+        XCTAssertEqual(table.rowCount, 1)
+        XCTAssertEqual(table.columns.count, 2)
+        XCTAssertEqual(table.columns.first?.name, "Property")
+        XCTAssertEqual(table.columns.last?.name, "Value")
+        XCTAssertTrue(table.name.hasPrefix("Realm ("))
+    }
+
+    func testGetTablesReturnsEmptyForNonRealmFile() throws {
+        let nonRealmURL = try writeNonRealmFile(named: "fake.realm")
+        let tables = manager.getTables(from: nonRealmURL.path)
+        XCTAssertTrue(tables.isEmpty, "Files without the T-DB mnemonic should return no tables")
+    }
+
+    func testGetTablesReturnsEmptyForMissingFile() {
+        let tables = manager.getTables(from: "/nonexistent/path/test.realm")
+        XCTAssertTrue(tables.isEmpty, "Missing files should return no tables")
+    }
+
+    func testGetTablesParsesFileFormatVersion() throws {
+        let realmURL = try writeRealmFile(named: "versioned.realm", fileFormat: (24, 24))
+        let tables = manager.getTables(from: realmURL.path)
+        let table = try XCTUnwrap(tables.first)
+        XCTAssertTrue(table.name.contains("24"), "Table name should contain the file format version, got: \(table.name)")
+    }
+
+    // MARK: - getTableData
+
+    func testGetTableDataReturnsMetadataRowsForValidRealmFile() throws {
+        let realmURL = try writeRealmFile(named: "data.realm")
+        let result = manager.getTableData(from: realmURL.path, table: "Realm (24)")
+
+        XCTAssertEqual(result.columns, ["Property", "Value"])
+        XCTAssertFalse(result.rows.isEmpty, "Should return metadata rows for a valid Realm file")
+
+        // Verify the mnemonic row
+        let mnemonicRow = result.rows.first { $0.first as? String == "Mnemonic" }
+        XCTAssertEqual(mnemonicRow?.last as? String, "T-DB")
+
+        // Verify the file format row
+        let formatRow = result.rows.first { $0.first as? String == "File format" }
+        XCTAssertEqual(formatRow?.last as? String, "24")
+
+        // Verify the note row mentions RealmSwift
+        let noteRow = result.rows.first { $0.first as? String == "Note" }
+        XCTAssertNotNil(noteRow, "A note row should be present")
+        XCTAssertTrue((noteRow?.last as? String ?? "").contains("RealmSwift"))
+    }
+
+    func testGetTableDataReturnsEmptyForNonRealmFile() throws {
+        let nonRealmURL = try writeNonRealmFile(named: "fake2.realm")
+        let result = manager.getTableData(from: nonRealmURL.path, table: "test")
+        XCTAssertTrue(result.columns.isEmpty)
+        XCTAssertTrue(result.rows.isEmpty)
+    }
+
+    func testGetTableDataReturnsEmptyForMissingFile() {
+        let result = manager.getTableData(from: "/nonexistent/path/test.realm", table: "test")
+        XCTAssertTrue(result.columns.isEmpty)
+        XCTAssertTrue(result.rows.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the `RealmManager` stub implementation (issue #386) with real Realm file header parsing.

The `RealmManager` was a stub that silently returned empty arrays, making the database browser appear broken for `.realm` files. The Realm binary format (realm-core) has no stable public specification and evolves across file-format versions, so full schema/row parsing would require linking `RealmSwift` — an application-side dependency inappropriate for a drop-in debugging toolkit.

## Changes

**`RealmManager.swift`** — Parses the 24-byte `SlabAlloc::Header` defined in [realm-core](https://github.com/realm/realm-core/blob/master/src/realm/alloc_slab.hpp):
- Validates the `T-DB` mnemonic at offset 16 to confirm the file is a Realm database
- Reads the file-format version, reserved/flags bytes, and top ref pointers
- Surfaces file metadata (mnemonic, format version, flags, top refs) to the database browser as an informational table
- Non-Realm files (no `T-DB` mnemonic) are rejected, matching `SQLiteManager`'s behavior on invalid files
- Uses iOS 13-compatible APIs (`readData(ofLength:)`, `closeFile()`, `load(fromByteOffset:as:)` for safe unaligned reads)

**`RealmManagerTests.swift`** — 7 unit tests covering:
- Valid Realm file: returns single informational table with metadata rows
- Non-Realm file (wrong mnemonic): returns empty results
- Missing file: returns empty results
- File format version parsing
- Metadata row content (mnemonic, file format, RealmSwift note)

## Test plan

- [x] `xcodebuild build` succeeds for `Example` scheme on iOS Simulator (iPhone 17 Pro, iOS 18.6)
- [x] `xcodebuild test -only-testing:ExampleTests/RealmManagerTests` — all 7 tests pass on the simulator
- [x] App launches and debug menu opens without crashes

Fixes #386

Co-authored-by: oh-my-pi <https://omp.sh>