### PR TITLE
fix(network): Rephrase challenge fallback comment to avoid scanner false positive

### DIFF
--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -803,7 +803,7 @@ extension CustomHTTPProtocol: URLSessionTaskDelegate {
                originalDelegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didReceive:completionHandler:))) {
                 originalDelegate.urlSession?(session, task: task, didReceive: challenge, completionHandler: completionHandler)
             } else {
-                // Fallback to session-level challenge if task-level not implemented
+                // Delegate the challenge to the session-level handler as fallback
                 self.urlSession(session, didReceive: challenge, completionHandler: completionHandler)
             }
         }


### PR DESCRIPTION
## Summary

The comment on `HTTPProtocol.swift:806` described working code — the session-level challenge fallback IS implemented. An automated scanner flagged "not implemented" as a placeholder trigger phrase (issue #388).

## Changes

Rephrase the comment to accurately describe the working fallback delegation without the scanner trigger phrase.

## Test plan

- [x] `xcodebuild build` succeeds on iOS Simulator
- [x] No behavior change — comment-only fix

Fixes #388

Co-authored-by: oh-my-pi <https://omp.sh>