### PR TITLE
fix(resources): Rephrase generatePassword doc comment to avoid scanner false positive

### DIFF
--- a/DebugSwift/Sources/Features/Resources/Keychain/KeychainService.swift
+++ b/DebugSwift/Sources/Features/Resources/Keychain/KeychainService.swift
@@ -1104,7 +1104,7 @@ final class Keychain {
     #if os(iOS) && !targetEnvironment(macCatalyst)
     /**
      @abstract Returns a randomly generated password.
-     @return String password in the form xxx-xxx-xxx-xxx where x is taken from the sets "abcdefghkmnopqrstuvwxy", "ABCDEFGHJKLMNPQRSTUVWXYZ", "3456789" with at least one character from each set being present.
+     @return A random password with four groups of three characters, drawn from lowercase letters, uppercase letters, and digits, with at least one character from each set.
      */
     @available(iOS 8.0, *)
     final class func generatePassword() -> String {


### PR DESCRIPTION
## Summary

The `@return` doc comment on `KeychainService.swift:1107` described the password format using a pattern the automated scanner flagged as incomplete code (issue #387). The `generatePassword()` method is fully implemented.

## Changes

Rephrase the doc comment to describe the password format without the trigger pattern.

## Test plan

- [x] `xcodebuild build` succeeds on iOS Simulator
- [x] No behavior change — comment-only fix

Fixes #387

Co-authored-by: oh-my-pi <https://omp.sh>