### PR TITLE
fix(ci): Add Makefile danger targets to fix swift build validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DERIVED    ?= $(PWD)/build/DerivedData
 APP_PATH   := $(DERIVED)/Build/Products/$(CONFIG)-iphonesimulator/$(SCHEME).app
 
 # ── Rules ─────────────────────────────────────────────────────────────────
-.PHONY: build install launch run terminate booted path clean open help
+.PHONY: build install launch run terminate booted path clean open help danger danger-setup danger-local danger-ci
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -70,3 +70,26 @@ open: ## Open the Simulator app window
 
 clean: ## Remove build products
 	rm -rf $(DERIVED)/Build/Products
+
+# ── Danger ────────────────────────────────────────────────────────────────
+danger-setup: ## Clone DangerSwift deps so swift build can compile Dangerfile
+	@cp Package.swift /tmp/DebugSwift-Package.swift.bak; \
+	git clone --depth 1 https://github.com/DebugSwift/DangerSwift /tmp/DangerSwift-clone 2>/dev/null; \
+	rm -rf /tmp/DangerSwift-clone/.git /tmp/DangerSwift-clone/Readme.md; \
+	cp /tmp/DangerSwift-clone/Package.swift .; \
+	mkdir -p Sources/DangerDependencies; \
+	touch Sources/DangerDependencies/placeholder.swift; \
+	rm -rf /tmp/DangerSwift-clone; \
+	echo "✓ DangerSwift Package.swift installed (original backed up to /tmp/DebugSwift-Package.swift.bak)"
+
+danger-restore: ## Restore the original Package.swift after danger runs
+	@mv -f /tmp/DebugSwift-Package.swift.bak Package.swift 2>/dev/null; \
+	rm -rf Sources/DangerDependencies; \
+	echo "✓ Package.swift restored"
+
+danger-local: danger-setup ## Run danger-swift local (setup + build + run)
+	swift build && swift run danger-swift local; make danger-restore
+
+danger-ci: danger-setup ## Run danger-swift ci (setup + build + run)
+	swift build && swift run danger-swift ci --verbose; make danger-restore
+


### PR DESCRIPTION
## Summary

`swift build && swift run danger-swift local` fails locally because the project's `Package.swift` declares an iOS-only target (UIKit) but `swift build` uses the macOS SDK (issue #384). The CI workflow handles this by cloning DangerSwift and overwriting `Package.swift` before building — this PR replicates that flow locally.

## Changes

Added Makefile targets:
- **`danger-setup`** — Clones DangerSwift, replaces `Package.swift`, creates the `Sources/DangerDependencies` placeholder target needed by the DangerSwift package
- **`danger-local`** — setup + `swift build` + `swift run danger-swift local` + restore
- **`danger-ci`** — setup + `swift build` + `swift run danger-swift ci --verbose` + restore
- **`danger-restore`** — Restores the original `Package.swift` and cleans up `Sources/DangerDependencies`

## Test plan

- [x] `make danger-setup` — DangerSwift Package.swift installed, `swift build` succeeds
- [x] `make danger-restore` — Original Package.swift restored
- [x] `xcodebuild build` succeeds on iOS Simulator after restore

Fixes #384

Co-authored-by: oh-my-pi <https://omp.sh>