### PR TITLE
fix(test): Update test device from iPhone 16 to iPhone 17 Pro

### DIFF
--- a/Example/fastlane/Fastfile
+++ b/Example/fastlane/Fastfile
@@ -8,6 +8,6 @@ lane :test do
     clean:                            true,
     result_bundle:                    true,
     code_coverage:                    true,
-    devices:                          ['iPhone 16']
+    devices:                          ['iPhone 17 Pro']
   )
 end


### PR DESCRIPTION
## Summary

`xcodebuild test` validation fails because `iPhone 16` simulator is not available in the current Xcode SDK — only iPhone 17 variants exist (issue #383).

## Changes

Updated `Example/fastlane/Fastfile` device from `iPhone 16` to `iPhone 17 Pro`.

## Test plan

- [x] `xcodebuild test -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — all 51 tests pass, `** TEST SUCCEEDED **`

Fixes #383

Co-authored-by: oh-my-pi <https://omp.sh>