### PR TITLE
fix(test): Update fastlane test device from iPhone 16 to iPhone 17 Pro

### DIFF
--- a/Example/fastlane/Fastfile
+++ b/Example/fastlane/Fastfile
@@ -8,6 +8,6 @@ lane :test do
     clean:                            true,
     result_bundle:                    true,
     code_coverage:                    true,
-    devices:                          ['iPhone 16']
+    devices:                          ['iPhone 17 Pro']
   )
 end


### PR DESCRIPTION
## Summary

`bundle exec fastlane test` validation fails because `iPhone 16` simulator is not available in the current Xcode SDK — only iPhone 17 variants exist (issue #382).

## Changes

Updated `Example/fastlane/Fastfile` device from `iPhone 16` to `iPhone 17 Pro`.

## Test plan

- [x] `fastlane test` from the `Example/` directory — all tests pass, `Test Succeeded`
- [x] 51 tests in 11 suites, all passing

Fixes #382

Co-authored-by: oh-my-pi <https://omp.sh>