### PR TITLE
fix(console): resolve StderrCapture memory leak and fd-2 restoration

### DIFF
--- a/DebugSwift/Sources/Features/App/Console/Helpers/StderrCapture.swift
+++ b/DebugSwift/Sources/Features/App/Console/Helpers/StderrCapture.swift
@@ -39,7 +39,7 @@ class StderrCapture: @unchecked Sendable {
     
     private let inputPipe = Pipe()
     private let outputPipe = Pipe()
-    private var originalDescriptor = FileHandle.standardError.fileDescriptor
+    private var originalDescriptor: Int32 = -1
     
     private init() {}
     static let shared = StderrCapture()
@@ -62,29 +62,54 @@ class StderrCapture: @unchecked Sendable {
         _isCapturing = true
         stateLock.unlock()
 
+        // Save an owned copy of the real stderr fd *before* redirecting fd 2
+        // onto the capture pipe. Without this, originalDescriptor would alias
+        // the capture pipe and writeDirectlyToOriginalStderr would feed back
+        // into the capture loop (infinite recursion).
+        originalDescriptor = dup(FileHandle.standardError.fileDescriptor)
+        if originalDescriptor == -1 {
+            print("[DebugSwift] Failed to duplicate original stderr descriptor")
+            stateLock.lock()
+            _isCapturing = false
+            stateLock.unlock()
+            return
+        }
+
+        // Consume availableData synchronously inside the readabilityHandler.
+        // The read source re-fires as long as data is unconsumed, so reading
+        // it in a deferred captureQueue.async block left the source signalled
+        // and caused it to re-fire immediately, enqueuing a new dispatch block
+        // per callback and leaking unbounded _Block_copy allocations (#433).
+        // Only the heavier parsing/forwarding work is dispatched off-handler.
         inputPipe.fileHandleForReading.readabilityHandler = { [weak self] fileHandle in
             guard let self = self, self.isCapturing else { return }
-            
-            self.captureQueue.async {
-                let data = fileHandle.availableData
-                if let string = String(data: data, encoding: .utf8), !string.isEmpty {
-                    self.processingQueue.async {
-                        self.stderrMessageSafe(string: string)
-                    }
-                }
 
-                // Write back to stderr to maintain output - thread-safe
-                self.writeLock.lock()
-                defer { self.writeLock.unlock() }
-                self.outputPipe.fileHandleForWriting.write(data)
+            // Read synchronously — clears the read source's signal so it does
+            // not re-fire until new bytes arrive. Empty data means EOF.
+            let data = fileHandle.availableData
+            guard !data.isEmpty else { return }
+
+            // Forward to stderr (passthrough) on the I/O queue.
+            self.writeLock.lock()
+            self.outputPipe.fileHandleForWriting.write(data)
+            self.writeLock.unlock()
+
+            // Parse + forward to the console on a background queue; keep the
+            // readabilityHandler off the hot path.
+            self.processingQueue.async {
+                guard let string = String(data: data, encoding: .utf8),
+                      !string.isEmpty else { return }
+                self.stderrMessageSafe(string: string)
             }
         }
-        
+
         setvbuf(stderr, nil, _IONBF, 0)
 
         // Copy STDERR file descriptor to outputPipe for writing strings back to STDERR
         if dup2(FileHandle.standardError.fileDescriptor, outputPipe.fileHandleForWriting.fileDescriptor) == -1 {
             print("[DebugSwift] Failed to duplicate stderr for output pipe")
+            close(originalDescriptor)
+            originalDescriptor = -1
             stateLock.lock()
             _isCapturing = false
             stateLock.unlock()
@@ -94,6 +119,8 @@ class StderrCapture: @unchecked Sendable {
         // Intercept STDERR with inputPipe
         if dup2(inputPipe.fileHandleForWriting.fileDescriptor, FileHandle.standardError.fileDescriptor) == -1 {
             print("[DebugSwift] Failed to redirect stderr to input pipe")
+            close(originalDescriptor)
+            originalDescriptor = -1
             stateLock.lock()
             _isCapturing = false
             stateLock.unlock()
@@ -138,6 +165,15 @@ class StderrCapture: @unchecked Sendable {
         stateLock.unlock()
         
         inputPipe.fileHandleForReading.readabilityHandler = nil
+        // Restore fd 2 to the real stderr *before* freopen: "/dev/stderr"
+        // resolves to /dev/fd/2, which after the capture redirect points at
+        // the capture pipe. Without this, freopen reopens stderr onto the
+        // capture pipe and stderr stays redirected after stop.
+        if originalDescriptor != -1 {
+            dup2(originalDescriptor, FileHandle.standardError.fileDescriptor)
+            close(originalDescriptor)
+            originalDescriptor = -1
+        }
         freopen("/dev/stderr", "a", stderr)
     }
 

--- a/DebugSwift/Sources/Features/App/Console/Helpers/StderrCapture.swift
+++ b/DebugSwift/Sources/Features/App/Console/Helpers/StderrCapture.swift
@@ -59,7 +59,6 @@ class StderrCapture: @unchecked Sendable {
             stateLock.unlock()
             return
         }
-        _isCapturing = true
         stateLock.unlock()
 
         // Save an owned copy of the real stderr fd *before* redirecting fd 2
@@ -69,50 +68,15 @@ class StderrCapture: @unchecked Sendable {
         originalDescriptor = dup(FileHandle.standardError.fileDescriptor)
         if originalDescriptor == -1 {
             print("[DebugSwift] Failed to duplicate original stderr descriptor")
-            stateLock.lock()
-            _isCapturing = false
-            stateLock.unlock()
             return
         }
 
-        // Consume availableData synchronously inside the readabilityHandler.
-        // The read source re-fires as long as data is unconsumed, so reading
-        // it in a deferred captureQueue.async block left the source signalled
-        // and caused it to re-fire immediately, enqueuing a new dispatch block
-        // per callback and leaking unbounded _Block_copy allocations (#433).
-        // Only the heavier parsing/forwarding work is dispatched off-handler.
-        inputPipe.fileHandleForReading.readabilityHandler = { [weak self] fileHandle in
-            guard let self = self, self.isCapturing else { return }
-
-            // Read synchronously — clears the read source's signal so it does
-            // not re-fire until new bytes arrive. Empty data means EOF.
-            let data = fileHandle.availableData
-            guard !data.isEmpty else { return }
-
-            // Forward to stderr (passthrough) on the I/O queue.
-            self.writeLock.lock()
-            self.outputPipe.fileHandleForWriting.write(data)
-            self.writeLock.unlock()
-
-            // Parse + forward to the console on a background queue; keep the
-            // readabilityHandler off the hot path.
-            self.processingQueue.async {
-                guard let string = String(data: data, encoding: .utf8),
-                      !string.isEmpty else { return }
-                self.stderrMessageSafe(string: string)
-            }
-        }
-
         setvbuf(stderr, nil, _IONBF, 0)
-
         // Copy STDERR file descriptor to outputPipe for writing strings back to STDERR
         if dup2(FileHandle.standardError.fileDescriptor, outputPipe.fileHandleForWriting.fileDescriptor) == -1 {
             print("[DebugSwift] Failed to duplicate stderr for output pipe")
             close(originalDescriptor)
             originalDescriptor = -1
-            stateLock.lock()
-            _isCapturing = false
-            stateLock.unlock()
             return
         }
 
@@ -121,10 +85,35 @@ class StderrCapture: @unchecked Sendable {
             print("[DebugSwift] Failed to redirect stderr to input pipe")
             close(originalDescriptor)
             originalDescriptor = -1
-            stateLock.lock()
-            _isCapturing = false
-            stateLock.unlock()
             return
+        }
+        // fd 2 is now redirected and the handler is about to be armed —
+        // publish the capturing flag so isCapturing faithfully means
+        // "fd 2 is redirected and the handler is armed." Setting it earlier
+        // created a window where isCapturing returned true before fd 2 was
+        // actually redirected, causing tests to write markers to real stderr
+        // (which escaped capture) under CI startup load (#433).
+        stateLock.lock()
+        _isCapturing = true
+        stateLock.unlock()
+        // Consume availableData synchronously inside the readabilityHandler.
+        // The read source re-fires as long as data is unconsumed, so reading
+        // it in a deferred captureQueue.async block left the source signalled
+        // and caused it to re-fire immediately, enqueuing a new dispatch block
+        // per callback and leaking unbounded _Block_copy allocations (#433).
+        // Only the heavier parsing/forwarding work is dispatched off-handler.
+        inputPipe.fileHandleForReading.readabilityHandler = { [weak self] fileHandle in
+            guard let self = self, self.isCapturing else { return }
+            let data = fileHandle.availableData
+            guard !data.isEmpty else { return }
+            self.writeLock.lock()
+            self.outputPipe.fileHandleForWriting.write(data)
+            self.writeLock.unlock()
+            self.processingQueue.async {
+                guard let string = String(data: data, encoding: .utf8),
+                      !string.isEmpty else { return }
+                self.stderrMessageSafe(string: string)
+            }
         }
     }
 

--- a/DebugSwift/Sources/Features/App/Console/Helpers/StderrCapture.swift
+++ b/DebugSwift/Sources/Features/App/Console/Helpers/StderrCapture.swift
@@ -165,16 +165,24 @@ class StderrCapture: @unchecked Sendable {
         stateLock.unlock()
         
         inputPipe.fileHandleForReading.readabilityHandler = nil
-        // Restore fd 2 to the real stderr *before* freopen: "/dev/stderr"
-        // resolves to /dev/fd/2, which after the capture redirect points at
-        // the capture pipe. Without this, freopen reopens stderr onto the
-        // capture pipe and stderr stays redirected after stop.
+        // Restore fd 2 to the real stderr. The dup2 call makes fd 2 point
+        // at the original stderr destination again. We do NOT use
+        // freopen("/dev/stderr", "a", stderr) here because it closes fd 2
+        // first and then tries to open /dev/fd/2 — which is now closed,
+        // so it fails with EBADF and leaves fd 2 permanently invalid.
+        // That made the next startCapturing()'s dup(2) fail (returning -1),
+        // and silently broke all post-stop stderr output (NSLog, crash logs,
+        // OS-level writes).
+        // After dup2 restores the fd, the C stderr FILE* stream still
+        // references fd 2, so it writes to the right destination. We just
+        // clear any error state and reset the buffer mode.
         if originalDescriptor != -1 {
             dup2(originalDescriptor, FileHandle.standardError.fileDescriptor)
             close(originalDescriptor)
             originalDescriptor = -1
         }
-        freopen("/dev/stderr", "a", stderr)
+        clearerr(stderr)
+        setvbuf(stderr, nil, _IOLBF, 0)
     }
 
     private func stderrMessageSafe(string: String) {

--- a/Example/ExampleTests/Tests/Features/App/Console/StderrCaptureTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/Console/StderrCaptureTests.swift
@@ -32,15 +32,29 @@ final class StderrCaptureTests: XCTestCase {
         wait(for: [exp], timeout: 5)
     }
 
-    override func tearDown() {
-        // Always stop so fd 2 is restored even if a test fails mid-way.
+    /// Stop capture and wait for the serial captureQueue to drain so fd 2
+    /// is fully restored before the next call.
+    private func stopAndDrain(_ timeout: TimeInterval = 0.5) {
         StderrCapture.shared.stopCapturing()
-        // stopCapturing is async — give the serial captureQueue time to drain.
         let exp = expectation(description: "stop-drained")
-        DispatchQueue(label: "test.teardown").asyncAfter(deadline: .now() + 0.2) {
+        DispatchQueue(label: "test.drain").asyncAfter(deadline: .now() + timeout) {
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 5)
+        wait(for: [exp], timeout: 10)
+    }
+
+    override func setUp() {
+        // The app may have started StderrCapture at launch (enableCrashManager
+        // → startCapturing). Stop it and drain so every test starts from a
+        // known-stopped state and exercises a real startCapturing →
+        // startCapturingInternal path through the fixed code.
+        stopAndDrain()
+        super.setUp()
+    }
+
+    override func tearDown() {
+        // Always stop so fd 2 is restored even if a test fails mid-way.
+        stopAndDrain()
         super.tearDown()
     }
 
@@ -149,14 +163,7 @@ final class StderrCaptureTests: XCTestCase {
             throw XCTSkip("stderr fd-2 redirect unsupported in this environment")
         }
 
-        StderrCapture.shared.stopCapturing()
-
-        // Let stop drain on the serial captureQueue.
-        let stopDrain = expectation(description: "stop-settled")
-        DispatchQueue(label: "test.stopdrain").asyncAfter(deadline: .now() + 0.5) {
-            stopDrain.fulfill()
-        }
-        wait(for: [stopDrain], timeout: 5)
+        stopAndDrain()
 
         let marker = "DSWIFT_433_POSTSTOP_\(UUID().uuidString)"
         FileHandle.standardError.write(Data((marker + "\n").utf8))

--- a/Example/ExampleTests/Tests/Features/App/Console/StderrCaptureTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/Console/StderrCaptureTests.swift
@@ -1,0 +1,125 @@
+//
+//  StderrCaptureTests.swift
+//  ExampleTests
+//
+//  Regression test for issue #433: StderrCapture.startCapturingInternal()
+//  leaked unbounded _Block_copy allocations because the readabilityHandler
+//  deferred availableData consumption into a captureQueue.async block, so the
+//  read source stayed signalled and re-fired immediately, enqueuing a new
+//  dispatch block per callback. This test verifies that:
+//
+//    1. A single stderr write produces exactly one console entry (not
+//       thousands — the leak symptom).
+//    2. stopCapturing restores fd 2 to the real stderr so post-stop writes
+//       do not appear in the console (the originalDescriptor / freopen
+//       ordering bug).
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class StderrCaptureTests: XCTestCase {
+
+    private func waitForCaptureReady() {
+        // startCapturing() dispatches startCapturingInternal() to
+        // captureQueue.async and returns immediately. Wait for the dup2
+        // redirect to land before writing to stderr, else the marker goes
+        // to real stderr and is never captured (false failure).
+        let exp = expectation(description: "capture-ready")
+        DispatchQueue(label: "test.ready").asyncAfter(deadline: .now() + 0.3) {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+    }
+
+    override func tearDown() {
+        // Always stop so fd 2 is restored even if a test fails mid-way.
+        StderrCapture.shared.stopCapturing()
+        // stopCapturing is async — give the serial captureQueue time to drain.
+        let exp = expectation(description: "stop-drained")
+        DispatchQueue(label: "test.teardown").asyncAfter(deadline: .now() + 0.2) {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+        super.tearDown()
+    }
+
+    // MARK: - Capture
+
+    /// A single write to stderr after start should surface exactly one entry
+    /// in ConsoleOutput's error list — not hundreds/thousands, which is the
+    /// runaway-dispatch-block symptom from #433.
+    func testSingleStderrWriteProducesOneConsoleEntry() throws {
+        StderrCapture.shared.startCapturing()
+        // Wait for the dup2 redirect to land before writing (see
+        // waitForCaptureReady).
+        waitForCaptureReady()
+        // The simulator test environment may not support fd-2 redirect
+        // (dup() can fail), in which case startCapturingInternal bails
+        // out. Skip cleanly — the regression assertion is only meaningful
+        // when capture is actually live.
+        guard StderrCapture.shared.isCapturing else {
+            throw XCTSkip("stderr fd-2 redirect unsupported in this environment")
+        }
+
+        // Write a distinctive marker to stderr (fd 2, now redirected).
+        let marker = "DSWIFT_433_MARKER_\(UUID().uuidString)"
+        FileHandle.standardError.write(Data((marker + "\n").utf8))
+
+        // Wait for the processingQueue to drain the forwarded string.
+        let exp = expectation(description: "console-received")
+        DispatchQueue(label: "test.poll").asyncAfter(deadline: .now() + 1.0) {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 10)
+
+        let errors = ConsoleOutput.shared.getErrorOutput()
+        let matches = errors.filter { $0.contains(marker) }
+
+        // Must receive the marker at least once (capture works).
+        XCTAssertFalse(matches.isEmpty, "stderr marker was not captured")
+        // The leak symptom: the readabilityHandler re-fires and enqueues a
+        // block per callback, so the marker would appear many times. With the
+        // fix, one write → one entry (allow a small tolerance for the
+        // passthrough/read-source draining).
+        XCTAssertLessThanOrEqual(matches.count, 2,
+            "stderr marker appeared \(matches.count) times — readabilityHandler is re-firing (leak #433)")
+    }
+
+    // MARK: - Stop restores stderr
+
+    /// After stopCapturing, writing to stderr must NOT show up in the console
+    /// — fd 2 should be restored to the real stderr, not left pointing at the
+    /// capture pipe (the originalDescriptor/freopen ordering bug).
+    func testStopRestoresStderr() throws {
+        StderrCapture.shared.startCapturing()
+        waitForCaptureReady()
+        guard StderrCapture.shared.isCapturing else {
+            throw XCTSkip("stderr fd-2 redirect unsupported in this environment")
+        }
+
+        StderrCapture.shared.stopCapturing()
+
+        // Let stop drain on the serial captureQueue.
+        let stopDrain = expectation(description: "stop-settled")
+        DispatchQueue(label: "test.stopdrain").asyncAfter(deadline: .now() + 0.5) {
+            stopDrain.fulfill()
+        }
+        wait(for: [stopDrain], timeout: 5)
+
+        let marker = "DSWIFT_433_POSTSTOP_\(UUID().uuidString)"
+        FileHandle.standardError.write(Data((marker + "\n").utf8))
+
+        // Wait briefly for any (undesired) capture.
+        let exp = expectation(description: "poststop-wait")
+        DispatchQueue(label: "test.poststop").asyncAfter(deadline: .now() + 0.5) {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+
+        let errors = ConsoleOutput.shared.getErrorOutput()
+        let matches = errors.filter { $0.contains(marker) }
+        XCTAssertTrue(matches.isEmpty,
+            "post-stop stderr write was captured — fd 2 was not restored (stopCapturingInternal bug)")
+    }
+}

--- a/Example/ExampleTests/Tests/Features/App/Console/StderrCaptureTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/Console/StderrCaptureTests.swift
@@ -86,6 +86,57 @@ final class StderrCaptureTests: XCTestCase {
             "stderr marker appeared \(matches.count) times — readabilityHandler is re-firing (leak #433)")
     }
 
+    // MARK: - Passthrough (recursion fix)
+
+    /// Writing a stderr line containing "]" triggers stderrMessageSafe →
+    /// writeDirectlyToOriginalStderr, which writes the post-"]" fragment to
+    /// originalDescriptor. Before the fix, originalDescriptor aliased fd 2
+    /// (the capture pipe), so the fragment re-entered the capture loop and
+    /// appeared as its own console error entry. After the fix,
+    /// originalDescriptor is an owned dup of real stderr, so the fragment
+    /// exits the pipe and only the original full marker is captured.
+    func testStderrPassthroughDoesNotRecurse() throws {
+        StderrCapture.shared.startCapturing()
+        waitForCaptureReady()
+        guard StderrCapture.shared.isCapturing else {
+            throw XCTSkip("stderr fd-2 redirect unsupported in this environment")
+        }
+
+        // The "]" triggers the writeDirectlyToOriginalStderr code path in
+        // stderrMessageSafe, which splits on "]", removes the first segment,
+        // and writes the remainder to originalDescriptor.
+        let uuid = UUID().uuidString
+        let marker = "[DSWIFT_433_PASSTHROUGH] \(uuid)"
+        FileHandle.standardError.write(Data((marker + "\n").utf8))
+
+        let exp = expectation(description: "passthrough-received")
+        DispatchQueue(label: "test.passthrough").asyncAfter(deadline: .now() + 1.0) {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 10)
+
+        let errors = ConsoleOutput.shared.getErrorOutput()
+
+        // The full marker must be captured once (capture works).
+        let fullMatches = errors.filter { $0.contains(marker) }
+        XCTAssertFalse(fullMatches.isEmpty, "passthrough marker was not captured")
+        XCTAssertLessThanOrEqual(fullMatches.count, 2,
+            "full marker appeared \(fullMatches.count) times — readabilityHandler is re-firing (leak #433)")
+
+        // The distinguishing assertion for the recursion fix:
+        // stderrMessageSafe splits on "]", removes the first segment, and
+        // writes the trimmed remainder (the bare uuid) to
+        // writeDirectlyToOriginalStderr. Pre-fix, originalDescriptor aliased
+        // the capture pipe, so the bare uuid re-entered the loop and appeared
+        // as its own console error entry. Post-fix, it goes to real stderr
+        // and must NOT appear as a standalone entry.
+        let bareFragmentMatches = errors.filter {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == uuid
+        }
+        XCTAssertTrue(bareFragmentMatches.isEmpty,
+            "bare uuid fragment '\(uuid)' appeared as its own console entry — writeDirectlyToOriginalStderr re-entered the capture pipe (recursion bug)")
+    }
+
     // MARK: - Stop restores stderr
 
     /// After stopCapturing, writing to stderr must NOT show up in the console

--- a/Example/ExampleTests/Tests/Features/App/Console/StderrCaptureTests.swift
+++ b/Example/ExampleTests/Tests/Features/App/Console/StderrCaptureTests.swift
@@ -22,14 +22,15 @@ final class StderrCaptureTests: XCTestCase {
 
     private func waitForCaptureReady() {
         // startCapturing() dispatches startCapturingInternal() to
-        // captureQueue.async and returns immediately. Wait for the dup2
-        // redirect to land before writing to stderr, else the marker goes
-        // to real stderr and is never captured (false failure).
-        let exp = expectation(description: "capture-ready")
-        DispatchQueue(label: "test.ready").asyncAfter(deadline: .now() + 0.3) {
-            exp.fulfill()
+        // captureQueue.async and returns immediately. Poll isCapturing
+        // until it flips true — which now means the dup2 redirect has
+        // landed and the readabilityHandler is armed. A fixed sleep was
+        // racy under CI startup load: the marker was written to fd 2
+        // while it still pointed at real stderr and escaped capture (#433).
+        let deadline = Date().addingTimeInterval(5)
+        while !StderrCapture.shared.isCapturing, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
         }
-        wait(for: [exp], timeout: 5)
     }
 
     /// Stop capture and wait for the serial captureQueue to drain so fd 2
@@ -80,15 +81,18 @@ final class StderrCaptureTests: XCTestCase {
         let marker = "DSWIFT_433_MARKER_\(UUID().uuidString)"
         FileHandle.standardError.write(Data((marker + "\n").utf8))
 
-        // Wait for the processingQueue to drain the forwarded string.
-        let exp = expectation(description: "console-received")
-        DispatchQueue(label: "test.poll").asyncAfter(deadline: .now() + 1.0) {
-            exp.fulfill()
+        // Poll for the marker to land in ConsoleOutput. The readabilityHandler
+        // dispatches parsing to a serial processingQueue; under CI load a
+        // fixed sleep can elapse before the marker reaches addErrorOutput,
+        // producing a false failure — the exact CI failure mode from #433.
+        let deadline = Date().addingTimeInterval(5)
+        var matches: [String] = []
+        while Date() < deadline {
+            matches = ConsoleOutput.shared.getErrorOutput().filter { $0.contains(marker) }
+            if !matches.isEmpty { break }
+            Thread.sleep(forTimeInterval: 0.01)
         }
-        wait(for: [exp], timeout: 10)
 
-        let errors = ConsoleOutput.shared.getErrorOutput()
-        let matches = errors.filter { $0.contains(marker) }
 
         // Must receive the marker at least once (capture works).
         XCTAssertFalse(matches.isEmpty, "stderr marker was not captured")
@@ -123,16 +127,19 @@ final class StderrCaptureTests: XCTestCase {
         let marker = "[DSWIFT_433_PASSTHROUGH] \(uuid)"
         FileHandle.standardError.write(Data((marker + "\n").utf8))
 
-        let exp = expectation(description: "passthrough-received")
-        DispatchQueue(label: "test.passthrough").asyncAfter(deadline: .now() + 1.0) {
-            exp.fulfill()
+        // Poll for the marker to land in ConsoleOutput — same rationale as
+        // testSingleStderrWriteProducesOneConsoleEntry: the serial
+        // processingQueue can lag under CI load, and a fixed sleep produced
+        // the exact false-failure mode from #433.
+        let deadline = Date().addingTimeInterval(5)
+        var fullMatches: [String] = []
+        while Date() < deadline {
+            fullMatches = ConsoleOutput.shared.getErrorOutput().filter { $0.contains(marker) }
+            if !fullMatches.isEmpty { break }
+            Thread.sleep(forTimeInterval: 0.01)
         }
-        wait(for: [exp], timeout: 10)
-
-        let errors = ConsoleOutput.shared.getErrorOutput()
 
         // The full marker must be captured once (capture works).
-        let fullMatches = errors.filter { $0.contains(marker) }
         XCTAssertFalse(fullMatches.isEmpty, "passthrough marker was not captured")
         XCTAssertLessThanOrEqual(fullMatches.count, 2,
             "full marker appeared \(fullMatches.count) times — readabilityHandler is re-firing (leak #433)")
@@ -144,6 +151,7 @@ final class StderrCaptureTests: XCTestCase {
         // the capture pipe, so the bare uuid re-entered the loop and appeared
         // as its own console error entry. Post-fix, it goes to real stderr
         // and must NOT appear as a standalone entry.
+        let errors = ConsoleOutput.shared.getErrorOutput()
         let bareFragmentMatches = errors.filter {
             $0.trimmingCharacters(in: .whitespacesAndNewlines) == uuid
         }


### PR DESCRIPTION
## Summary

Fixes #433 — memory leak while app is idle caused by `StderrCapture` producing runaway `_Block_copy` allocations.

Four bugs in `StderrCapture` are fixed:

### 1. readabilityHandler leak (#433, primary)
The `readabilityHandler` dispatched `captureQueue.async { … }` and read `fileHandle.availableData` **inside** the async block. The read source stayed signalled because `availableData` wasn't consumed in the handler callback itself, so it re-fired immediately — enqueuing a new dispatch block per callback and leaking unbounded `_Block_copy` allocations (48/64-byte blocks matching the Instruments trace).

**Fix:** Read `availableData` synchronously inside the `readabilityHandler` to clear the dispatch source signal. Only the heavier string parsing/forwarding is dispatched to `processingQueue`.

### 2. `originalDescriptor` aliasing (infinite recursion)
`originalDescriptor` stored `FileHandle.standardError.fileDescriptor` (fd 2) directly. After `dup2` redirected fd 2 onto the capture pipe, `writeDirectlyToOriginalStderr` wrote back into the capture loop — infinite recursion.

**Fix:** `dup()` the real stderr fd before redirect so `originalDescriptor` is an owned copy that survives the redirect. Close it in `stopCapturingInternal` and on error paths.

### 3. `stopCapturingInternal` freopen breaks fd 2 (found during testing)
`freopen("/dev/stderr", "a", stderr)` closes fd 2 first, then tries to open `/dev/fd/2` — which is now closed, so it fails with `EBADF` and leaves fd 2 permanently invalid. This broke the next `startCapturing()`'s `dup(2)` (returned -1) and silently broke all post-stop stderr output (NSLog, crash logs, OS-level writes).

**Fix:** Replace `freopen` with `dup2(originalDescriptor, fd2)` + `clearerr(stderr)` + `setvbuf(stderr, nil, _IOLBF, 0)`. The `dup2` restores fd 2 to real stderr; the C `stderr` FILE* stream still references fd 2, so it writes to the right destination. `clearerr` resets error state; `setvbuf` restores line-buffered mode.

### 4. `stopCapturingInternal` fd-2 restoration ordering
The original code had no `dup2` restore before `freopen` — fd 2 stayed pointing at the capture pipe after stop, so stderr stayed redirected.

**Fix:** `dup2(originalDescriptor, FileHandle.standardError.fileDescriptor)` to restore real stderr (now combined with fix #3 — no `freopen` at all).

## Test plan

All three regression tests **pass** (previously 2/3 skipped due to the freopen bug found and fixed in this PR):

- [x] `StderrCaptureTests.testSingleStderrWriteProducesOneConsoleEntry` — **Passed** (2.4s). Verifies one stderr write produces ≤2 console entries, not thousands (the leak symptom).
- [x] `StderrCaptureTests.testStderrPassthroughDoesNotRecurse` — **Passed** (2.3s). Writes a `[marker] uuid` line; the `]` triggers `writeDirectlyToOriginalStderr`. Asserts the bare uuid fragment does NOT appear as its own console entry (the recursion-fix path).
- [x] `StderrCaptureTests.testStopRestoresStderr` — **Passed** (2.3s). After stop, writes to stderr and asserts they do NOT appear in the console (fd 2 restored).
- [x] `xcodebuild test` on Example scheme — `** TEST SUCCEEDED **`

Tests use `setUp` to stop app-launched capture so every test starts from a known-stopped state and exercises a real `startCapturing → startCapturingInternal` path through the fixed code.

Closes #433