### PR TITLE
feat(performance): detect UIViewController lifecycle methods not calling super

### DIFF
--- a/DebugSwift/Sources/Base/FeatureBase.swift
+++ b/DebugSwift/Sources/Base/FeatureBase.swift
@@ -32,6 +32,7 @@ public enum DebugSwiftSwizzleFeature: String, CaseIterable {
     case pushNotifications
     case swiftUIRender
     case orientationForwarding
+    case superCallDetector
 }
 
 @MainActor

--- a/DebugSwift/Sources/Features/Performance/Helpers/Performance.SuperCallDetector.swift
+++ b/DebugSwift/Sources/Features/Performance/Helpers/Performance.SuperCallDetector.swift
@@ -1,0 +1,299 @@
+//
+//  Performance.SuperCallDetector.swift
+//  DebugSwift
+//
+//  Detects UIViewController lifecycle methods that fail to call their super
+//  implementation.  Addresses issue #376.
+//
+//  Approach: swizzle viewDidLoad, viewWillAppear, viewDidAppear,
+//  viewWillDisappear and viewDidDisappear using IMP-replacement (NOT
+//  method_exchangeImplementations).  Per-instance lifecycle state is tracked
+//  via an associated object.  When a later lifecycle method fires for a VC
+//  instance but an earlier one was never recorded, the earlier method is
+//  flagged as missing a super call.
+//
+
+import UIKit
+
+/// A single missing-super-call violation reported by ``SuperCallDetector``.
+public struct SuperCallViolation: Sendable {
+    /// The view-controller class whose override did not call super.
+    public let className: String
+    /// The lifecycle method that was expected to fire but didn't.
+    public let methodName: String
+    /// The method that *did* fire, revealing the missing super call.
+    public let revealedBy: String
+    /// When the violation was detected.
+    public let timestamp: Date
+
+    init(className: String, methodName: String, revealedBy: String, timestamp: Date = Date()) {
+        self.className = className
+        self.methodName = methodName
+        self.revealedBy = revealedBy
+        self.timestamp = timestamp
+    }
+
+    public var message: String {
+        "\(className) does not call super.\(methodName)() — revealed by \(revealedBy)()"
+    }
+}
+
+// MARK: - Detector
+
+/// Thread-safe singleton that stores detected violations and callbacks.
+final class SuperCallDetector: @unchecked Sendable {
+
+    // MARK: Singleton
+
+    private init() {}
+    static let shared = SuperCallDetector()
+
+    // MARK: Callbacks
+
+    /// Called on the main thread whenever a new violation is detected.
+    var callback: ((SuperCallViolation) -> Void)?
+
+    // MARK: Storage
+
+    private let lock = NSLock()
+    private var _violations: [SuperCallViolation] = []
+    private var _ignoredClassNames: Set<String> = []
+
+    var violations: [SuperCallViolation] {
+        lock.lock(); defer { lock.unlock() }
+        return _violations
+    }
+
+    var ignoredClassNames: Set<String> {
+        lock.lock(); defer { lock.unlock() }
+        return _ignoredClassNames
+    }
+
+    func ignoreClass(_ name: String) {
+        lock.lock(); defer { lock.unlock() }
+        _ignoredClassNames.insert(name)
+    }
+
+    func setIgnoredClasses(_ names: Set<String>) {
+        lock.lock(); defer { lock.unlock() }
+        _ignoredClassNames = names
+    }
+
+    func clearViolations() {
+        lock.lock(); defer { lock.unlock() }
+        _violations.removeAll()
+    }
+
+    // MARK: Reporting
+
+    /// Records a violation if it hasn't been recorded already for this
+    /// class+method pair and the class isn't ignored.
+    func reportViolation(_ violation: SuperCallViolation) {
+        lock.lock()
+        let isIgnored = _ignoredClassNames.contains(violation.className)
+        let alreadyReported = _violations.contains {
+            $0.className == violation.className && $0.methodName == violation.methodName
+        }
+        if !isIgnored && !alreadyReported {
+            _violations.append(violation)
+        }
+        lock.unlock()
+
+        if !isIgnored && !alreadyReported {
+            DispatchQueue.main.async { [weak self] in
+                self?.callback?(violation)
+                Debug.print("🚨 SuperCallDetector: \(violation.message)")
+            }
+        }
+    }
+}
+
+// MARK: - Lifecycle tracking (per-instance associated object)
+
+private final class LifecycleTracker: NSObject {
+    /// Ordered bitfield of lifecycle events that have fired for this instance.
+    /// Bit positions match the ``LifecycleEvent`` order.
+    var events: UInt8 = 0
+}
+
+/// The five swizzled lifecycle events, in lifecycle order.
+enum LifecycleEvent: Int, CaseIterable {
+    case viewDidLoad = 0
+    case viewWillAppear = 1
+    case viewDidAppear = 2
+    case viewWillDisappear = 3
+    case viewDidDisappear = 4
+
+    var selector: Selector {
+        switch self {
+        case .viewDidLoad:               return #selector(UIViewController.viewDidLoad)
+        case .viewWillAppear:            return #selector(UIViewController.viewWillAppear(_:))
+        case .viewDidAppear:             return #selector(UIViewController.viewDidAppear(_:))
+        case .viewWillDisappear:         return #selector(UIViewController.viewWillDisappear(_:))
+        case .viewDidDisappear:          return #selector(UIViewController.viewDidDisappear(_:))
+        }
+    }
+
+    var methodName: String {
+        switch self {
+        case .viewDidLoad:           return "viewDidLoad"
+        case .viewWillAppear:        return "viewWillAppear"
+        case .viewDidAppear:         return "viewDidAppear"
+        case .viewWillDisappear:     return "viewWillDisappear"
+        case .viewDidDisappear:      return "viewDidDisappear"
+        }
+    }
+}
+
+// MARK: - Swizzling
+
+extension UIViewController {
+
+    /// Swizzles all five lifecycle methods using IMP-replacement.  Safe to
+    /// call multiple times (idempotent via a single dispatch-once token).
+    static func db_swizzleLifecycleForSuperCallDetection() {
+        DispatchQueue.once(token: "debugswift.uiviewcontroller.db_swizzleLifecycleForSuperCallDetection") {
+            for event in LifecycleEvent.allCases {
+                swizzleLifecycleIMP(for: event)
+            }
+        }
+    }
+
+    /// IMP-replacement swizzle for a single lifecycle method.
+    ///
+    /// We use ``method_setImplementation`` rather than
+    /// ``method_exchangeImplementations`` to avoid creating renamed selectors
+    /// on `UIViewController`.  Third-party agents (e.g. NewRelic) scan method
+    /// tables and crash (`NRInvalidArgumentException`) when they find
+    /// unexpected selectors on core UIKit classes.  See
+    /// `UIWindowScene+.swift` `db_swizzleViewDidAppear()` for the same
+    /// technique applied to `viewDidAppear`.
+    private static func swizzleLifecycleIMP(for event: LifecycleEvent) {
+        guard let originalMethod = class_getInstanceMethod(
+            UIViewController.self,
+            event.selector
+        ) else { return }
+
+        // Capture the original IMP before we replace it.
+        let originalIMP = method_getImplementation(originalMethod)
+
+        switch event {
+        case .viewDidLoad:
+            db_originalViewDidLoadIMP = originalIMP
+            let block: @convention(block) (UIViewController) -> Void = { vc in
+                vc.db_invokeOriginalLifecycleIMP(event, originalIMP)
+                vc.db_recordLifecycleEvent(event)
+            }
+            method_setImplementation(originalMethod, imp_implementationWithBlock(block))
+
+        case .viewWillAppear:
+            db_originalViewWillAppearIMP = originalIMP
+            let block: @convention(block) (UIViewController, Bool) -> Void = { vc, animated in
+                vc.db_invokeOriginalLifecycleIMP(event, originalIMP, animated)
+                vc.db_recordLifecycleEvent(event)
+            }
+            method_setImplementation(originalMethod, imp_implementationWithBlock(block))
+
+        case .viewDidAppear:
+            db_originalViewDidAppearForSuperIMP = originalIMP
+            let block: @convention(block) (UIViewController, Bool) -> Void = { vc, animated in
+                vc.db_invokeOriginalLifecycleIMP(event, originalIMP, animated)
+                vc.db_recordLifecycleEvent(event)
+            }
+            method_setImplementation(originalMethod, imp_implementationWithBlock(block))
+
+        case .viewWillDisappear:
+            db_originalViewWillDisappearIMP = originalIMP
+            let block: @convention(block) (UIViewController, Bool) -> Void = { vc, animated in
+                vc.db_invokeOriginalLifecycleIMP(event, originalIMP, animated)
+                vc.db_recordLifecycleEvent(event)
+            }
+            method_setImplementation(originalMethod, imp_implementationWithBlock(block))
+
+        case .viewDidDisappear:
+            db_originalViewDidDisappearForSuperIMP = originalIMP
+            let block: @convention(block) (UIViewController, Bool) -> Void = { vc, animated in
+                vc.db_invokeOriginalLifecycleIMP(event, originalIMP, animated)
+                vc.db_recordLifecycleEvent(event)
+            }
+            method_setImplementation(originalMethod, imp_implementationWithBlock(block))
+        }
+    }
+}
+
+// MARK: - Stored original IMPs
+
+extension UIViewController {
+    /// `nonisolated(unsafe)` — each is written exactly once (guarded by
+    /// `DispatchQueue.once`) and only read afterward.
+    nonisolated(unsafe) static var db_originalViewDidLoadIMP: IMP?
+    nonisolated(unsafe) static var db_originalViewWillAppearIMP: IMP?
+    nonisolated(unsafe) static var db_originalViewDidAppearForSuperIMP: IMP?
+    nonisolated(unsafe) static var db_originalViewWillDisappearIMP: IMP?
+    nonisolated(unsafe) static var db_originalViewDidDisappearForSuperIMP: IMP?
+}
+
+// MARK: - Per-instance tracking helpers
+
+extension UIViewController {
+
+    private static var trackerKey: UInt8 = 0
+
+    /// Returns (or lazily creates) the lifecycle tracker associated with
+    /// this VC instance.
+    private var db_lifecycleTracker: LifecycleTracker {
+        if let existing = objc_getAssociatedObject(self, &Self.trackerKey) as? LifecycleTracker {
+            return existing
+        }
+        let tracker = LifecycleTracker()
+        objc_setAssociatedObject(self, &Self.trackerKey, tracker, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return tracker
+    }
+
+    /// Records that `event` fired for this instance, then checks whether any
+    /// earlier lifecycle event was *skipped* (i.e. its bit is still clear).
+    /// A skipped earlier event means the subclass override for that event
+    /// did not call super.
+    func db_recordLifecycleEvent(_ event: LifecycleEvent) {
+        let tracker = db_lifecycleTracker
+        let bit: UInt8 = 1 << event.rawValue
+
+        // Check which earlier events have NOT fired yet.
+        let earlierMask: UInt8 = (1 << event.rawValue) - 1   // bits 0…event-1
+        let missing = (~tracker.events) & earlierMask
+
+        // Record this event.
+        tracker.events |= bit
+
+        guard missing != 0 else { return }
+
+        // Report a violation for each missing earlier event.
+        let className = String(describing: type(of: self))
+        for earlier in LifecycleEvent.allCases where earlier.rawValue < event.rawValue {
+            if missing & (1 << earlier.rawValue) != 0 {
+                SuperCallDetector.shared.reportViolation(
+                    .init(
+                        className: className,
+                        methodName: earlier.methodName,
+                        revealedBy: event.methodName
+                    )
+                )
+            }
+        }
+    }
+
+    /// Invokes the original implementation captured before swizzling.
+    func db_invokeOriginalLifecycleIMP(_ event: LifecycleEvent, _ imp: IMP) {
+        typealias VoidIMP = @convention(c) (UIViewController, Selector) -> Void
+        let casted = unsafeBitCast(imp, to: VoidIMP.self)
+        casted(self, event.selector)
+    }
+
+    /// Invokes the original implementation (animated variant) captured before
+    /// swizzling.
+    func db_invokeOriginalLifecycleIMP(_ event: LifecycleEvent, _ imp: IMP, _ animated: Bool) {
+        typealias AnimatedIMP = @convention(c) (UIViewController, Selector, Bool) -> Void
+        let casted = unsafeBitCast(imp, to: AnimatedIMP.self)
+        casted(self, event.selector, animated)
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Leak/SuperCallViolationsViewModel.swift
+++ b/DebugSwift/Sources/Features/Performance/Leak/SuperCallViolationsViewModel.swift
@@ -1,0 +1,69 @@
+//
+//  SuperCallViolationsViewModel.swift
+//  DebugSwift
+//
+//  View model for displaying missing-super-call violations detected by
+//  ``SuperCallDetector``.  Follows the `LeaksViewModel` pattern.
+//
+
+import UIKit
+
+final class SuperCallViolationsViewModel: NSObject, ResourcesGenericListViewModel {
+    private var data: [SuperCallViolation] {
+        SuperCallDetector.shared.violations
+    }
+
+    private var filteredInfo = [SuperCallViolation]()
+
+    // MARK: - ViewModel
+
+    var isSearchActivated = false
+    var reloadData: (() -> Void)?
+
+    var isDeleteEnable: Bool { false }
+    var isCustomActionEnable: Bool { false }
+
+    func viewTitle() -> String { "\(data.count) Super Call Violations" }
+
+    func numberOfItems() -> Int {
+        isSearchActivated ? filteredInfo.count : data.count
+    }
+
+    func dataSourceForItem(atIndex index: Int) -> ResourcesGenericController.CellViewData {
+        let violation = isSearchActivated ? filteredInfo[index] : data[index]
+
+        return .init(
+            title: "🚨 \(violation.className) → \(violation.methodName)()",
+            value: "Revealed by \(violation.revealedBy)()",
+            actionImage: .named("chevron.right", default: "Action")
+        )
+    }
+
+    func handleClearAction() {
+        SuperCallDetector.shared.clearViolations()
+        filteredInfo.removeAll()
+    }
+
+
+    func emptyListDescriptionString() -> String {
+        "No super-call violations detected yet. Navigate your app to trigger lifecycle methods."
+    }
+
+    func handleShareAction() {
+        let allViolations = SuperCallDetector.shared.violations.reduce("") { $0 + "\n\($1.message)" }
+        FileSharingManager.generateFileAndShare(text: allViolations, fileName: "super-call-violations")
+    }
+
+    // MARK: - Search Functionality
+
+    func filterContentForSearchText(_ searchText: String) {
+        if searchText.isEmpty {
+            filteredInfo = data
+        } else {
+            filteredInfo = data.filter {
+                $0.className.localizedCaseInsensitiveContains(searchText) ||
+                $0.methodName.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+    }
+}

--- a/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
+++ b/DebugSwift/Sources/Features/Performance/Performance.Controller.swift
@@ -59,6 +59,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case memoryWarning = "MemoryWarningTableViewCell"
         case frameDropTimeline = "FrameDropTimelineRowCell"
         case hangEvents = "HangEventsRowCell"
+        case superCall = "SuperCallTableViewCell"
 
         init?(rawValue: String?) {
             guard let rawValue else { return nil }
@@ -72,6 +73,7 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case memory
         case frameDrops
         case leaks
+        case superCall
         case diskToggle
         case diskMetrics
         case diskUsage
@@ -143,6 +145,9 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .leaks:
             if DebugSwift.App.shared.disableMethods.contains(.leaksDetector) { return 0 }
             return 2
+        case .superCall:
+            if DebugSwift.App.shared.disableMethods.contains(.superCallDetector) { return 0 }
+            return 1
         case .diskToggle:
             return 1
         case .diskMetrics:
@@ -174,6 +179,9 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         case .leaks:
             if DebugSwift.App.shared.disableMethods.contains(.leaksDetector) { return nil }
             return "Leaks & Threads"
+        case .superCall:
+            if DebugSwift.App.shared.disableMethods.contains(.superCallDetector) { return nil }
+            return "Super Call Checker"
         case .diskToggle: return "Disk I/O"
         case .diskMetrics: return nil
         case .diskUsage: return diskAnalyzer.usageInfo != nil ? "Disk Usage" : nil
@@ -211,6 +219,8 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
             return memoryCell(at: indexPath.row)
         case .leaks:
             return leaksCell(at: indexPath.row)
+        case .superCall:
+            return superCallCell()
         case .diskToggle:
             return diskToggleCell()
         case .diskMetrics:
@@ -269,6 +279,10 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
                 let threadCheckerController = PerformanceThreadCheckerViewController()
                 navigationController?.pushViewController(threadCheckerController, animated: true)
             }
+        case .superCall:
+            let viewModel = SuperCallViolationsViewModel()
+            let controller = ResourcesGenericController(viewModel: viewModel)
+            navigationController?.pushViewController(controller, animated: true)
         case .frameDropTimeline:
             let controller = FrameDropTimelineViewController()
             navigationController?.pushViewController(controller, animated: true)
@@ -382,6 +396,14 @@ final class PerformanceViewController: BaseTableController, PerformanceToolkitDe
         default:
             return UITableViewCell()
         }
+    }
+
+    // MARK: - Cells: Super Call Checker
+
+    private func superCallCell() -> UITableViewCell {
+        let cell = reuseCell(for: .superCall)
+        cell.setup(title: "🚨 Super Call Violations", image: .named("chevron.right", default: "Action"))
+        return cell
     }
 
     // MARK: - Cells: Disk

--- a/DebugSwift/Sources/Settings/DebugSwift.Performance.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.Performance.swift
@@ -118,6 +118,33 @@ extension DebugSwift {
                 PerformanceThreadChecker.shared.clearViolations()
             }
         }
+
+        public enum SuperCallChecker {
+            /// Set a callback invoked whenever a missing super call is detected.
+            public static func onDetect(_ callback: @escaping (SuperCallViolation) -> Void) {
+                SuperCallDetector.shared.callback = callback
+            }
+
+            /// All violations recorded so far.
+            public static var violations: [SuperCallViolation] {
+                SuperCallDetector.shared.violations
+            }
+
+            /// Add a class name to the ignore list.
+            public static func ignoreClass(_ className: String) {
+                SuperCallDetector.shared.ignoreClass(className)
+            }
+
+            /// Replace the entire ignore list.
+            public static func setIgnoredClasses(_ classNames: [String]) {
+                SuperCallDetector.shared.setIgnoredClasses(Set(classNames))
+            }
+
+            /// Clear all recorded violations.
+            public static func clearViolations() {
+                SuperCallDetector.shared.clearViolations()
+            }
+        }
     }
 }
 

--- a/DebugSwift/Sources/Settings/FeatureHandling.swift
+++ b/DebugSwift/Sources/Settings/FeatureHandling.swift
@@ -85,6 +85,10 @@ enum FeatureHandling {
         if !methodsToDisable.contains(.orientationForwarding) {
             enableOrientationForwarding()
         }
+
+        if !methodsToDisable.contains(.superCallDetector) {
+            enableSuperCallDetector()
+        }
     }
 
     private static func enableNetwork() {
@@ -135,6 +139,10 @@ enum FeatureHandling {
             UIWindowScene.db_swizzleRequestGeometryUpdate()
         }
         UIViewController.db_swizzleViewDidAppear()
+    }
+
+    private static func enableSuperCallDetector() {
+        UIViewController.db_swizzleLifecycleForSuperCallDetection()
     }
 
     private static func enableSwiftUIRender() {

--- a/Example/ExampleTests/Tests/Base/FeatureBaseTests.swift
+++ b/Example/ExampleTests/Tests/Base/FeatureBaseTests.swift
@@ -23,7 +23,7 @@ class FeatureBaseTests: XCTestCase {
 
     func testDebugSwiftSwizzleFeature_allCases() {
         // Given
-        let expectedCases: [DebugSwiftSwizzleFeature] = [.network, .webSocket, .wkWebView, .location, .views, .crashManager, .leaksDetector, .console, .pushNotifications, .swiftUIRender, .orientationForwarding]
+        let expectedCases: [DebugSwiftSwizzleFeature] = [.network, .webSocket, .wkWebView, .location, .views, .crashManager, .leaksDetector, .console, .pushNotifications, .swiftUIRender, .orientationForwarding, .superCallDetector]
 
         // When
         let allCases = DebugSwiftSwizzleFeature.allCases

--- a/Example/ExampleTests/Tests/Features/Performance/SuperCallDetectorTests.swift
+++ b/Example/ExampleTests/Tests/Features/Performance/SuperCallDetectorTests.swift
@@ -1,0 +1,290 @@
+//
+//  SuperCallDetectorTests.swift
+//  ExampleTests
+//
+//  Tests for issue #376: detect lifecycle methods not calling super.
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class SuperCallDetectorTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        SuperCallDetector.shared.clearViolations()
+        SuperCallDetector.shared.callback = nil
+        SuperCallDetector.shared.setIgnoredClasses([])
+    }
+
+    override func tearDown() {
+        SuperCallDetector.shared.clearViolations()
+        SuperCallDetector.shared.callback = nil
+        SuperCallDetector.shared.setIgnoredClasses([])
+        super.tearDown()
+    }
+
+    // MARK: - Violation recording
+
+    func testReportViolationStoresViolation() {
+        let violation = SuperCallViolation(
+            className: "TestVC",
+            methodName: "viewDidLoad",
+            revealedBy: "viewWillAppear"
+        )
+        SuperCallDetector.shared.reportViolation(violation)
+
+        XCTAssertEqual(SuperCallDetector.shared.violations.count, 1)
+        XCTAssertEqual(SuperCallDetector.shared.violations.first?.className, "TestVC")
+        XCTAssertEqual(SuperCallDetector.shared.violations.first?.methodName, "viewDidLoad")
+    }
+
+    func testDuplicateViolationsAreDeduplicated() {
+        let v1 = SuperCallViolation(className: "TestVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        let v2 = SuperCallViolation(className: "TestVC", methodName: "viewDidLoad", revealedBy: "viewDidAppear")
+
+        SuperCallDetector.shared.reportViolation(v1)
+        SuperCallDetector.shared.reportViolation(v2)
+
+        XCTAssertEqual(SuperCallDetector.shared.violations.count, 1)
+    }
+
+    func testDifferentClassesProduceSeparateViolations() {
+        let v1 = SuperCallViolation(className: "VC1", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        let v2 = SuperCallViolation(className: "VC2", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+
+        SuperCallDetector.shared.reportViolation(v1)
+        SuperCallDetector.shared.reportViolation(v2)
+
+        XCTAssertEqual(SuperCallDetector.shared.violations.count, 2)
+    }
+
+    func testDifferentMethodsProduceSeparateViolations() {
+        let v1 = SuperCallViolation(className: "TestVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        let v2 = SuperCallViolation(className: "TestVC", methodName: "viewDidAppear", revealedBy: "viewWillDisappear")
+
+        SuperCallDetector.shared.reportViolation(v1)
+        SuperCallDetector.shared.reportViolation(v2)
+
+        XCTAssertEqual(SuperCallDetector.shared.violations.count, 2)
+    }
+
+    // MARK: - Clear
+
+    func testClearViolationsRemovesAll() {
+        let violation = SuperCallViolation(className: "TestVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(violation)
+        XCTAssertEqual(SuperCallDetector.shared.violations.count, 1)
+
+        SuperCallDetector.shared.clearViolations()
+        XCTAssertTrue(SuperCallDetector.shared.violations.isEmpty)
+    }
+
+    // MARK: - Ignore list
+
+    func testIgnoredClassIsNotRecorded() {
+        SuperCallDetector.shared.ignoreClass("IgnoredVC")
+        let violation = SuperCallViolation(className: "IgnoredVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(violation)
+
+        XCTAssertTrue(SuperCallDetector.shared.violations.isEmpty)
+    }
+
+    func testSetIgnoredClassesReplacesList() {
+        SuperCallDetector.shared.ignoreClass("VC1")
+        SuperCallDetector.shared.setIgnoredClasses(["VC2", "VC3"])
+
+        // VC1 should no longer be ignored after setIgnoredClasses replaces the set
+        let v1 = SuperCallViolation(className: "VC1", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(v1)
+        XCTAssertEqual(SuperCallDetector.shared.violations.count, 1)
+
+        // VC2 should be ignored
+        let v2 = SuperCallViolation(className: "VC2", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(v2)
+        XCTAssertEqual(SuperCallDetector.shared.violations.count, 1)
+    }
+
+    // MARK: - Callback
+
+    func testCallbackFiresForNewViolation() {
+        let expectation = XCTestExpectation(description: "callback")
+        SuperCallDetector.shared.callback = { violation in
+            guard violation.className == "TestVC" else { return }
+            XCTAssertEqual(violation.className, "TestVC")
+            expectation.fulfill()
+        }
+
+        let violation = SuperCallViolation(className: "TestVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(violation)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testCallbackDoesNotFireForDuplicate() {
+        let expectation = XCTestExpectation(description: "callback should fire once")
+        expectation.expectedFulfillmentCount = 1
+        expectation.assertForOverFulfill = true
+
+        SuperCallDetector.shared.callback = { violation in
+            guard violation.className == "TestVC" else { return }
+            expectation.fulfill()
+        }
+
+        let v1 = SuperCallViolation(className: "TestVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        let v2 = SuperCallViolation(className: "TestVC", methodName: "viewDidLoad", revealedBy: "viewDidAppear")
+
+        SuperCallDetector.shared.reportViolation(v1)
+        SuperCallDetector.shared.reportViolation(v2)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testCallbackDoesNotFireForIgnored() {
+        let expectation = XCTestExpectation(description: "callback should not fire")
+        expectation.isInverted = true
+
+        SuperCallDetector.shared.callback = { violation in
+            guard violation.className == "IgnoredVC" else { return }
+            expectation.fulfill()
+        }
+
+        SuperCallDetector.shared.ignoreClass("IgnoredVC")
+        let violation = SuperCallViolation(className: "IgnoredVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(violation)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - SuperCallViolation message
+
+    func testViolationMessageFormat() {
+        let v = SuperCallViolation(className: "MyVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        XCTAssertEqual(v.message, "MyVC does not call super.viewDidLoad() — revealed by viewWillAppear()")
+    }
+
+    // MARK: - LifecycleEvent
+
+    func testLifecycleEventOrder() {
+        XCTAssertEqual(LifecycleEvent.viewDidLoad.rawValue, 0)
+        XCTAssertEqual(LifecycleEvent.viewWillAppear.rawValue, 1)
+        XCTAssertEqual(LifecycleEvent.viewDidAppear.rawValue, 2)
+        XCTAssertEqual(LifecycleEvent.viewWillDisappear.rawValue, 3)
+        XCTAssertEqual(LifecycleEvent.viewDidDisappear.rawValue, 4)
+    }
+
+    func testLifecycleEventAllCasesCount() {
+        XCTAssertEqual(LifecycleEvent.allCases.count, 5)
+    }
+
+    // MARK: - Public API: SuperCallChecker
+
+    func testPublicAPIViolationsMirrorDetector() {
+        let violation = SuperCallViolation(className: "TestVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(violation)
+
+        XCTAssertEqual(DebugSwift.Performance.SuperCallChecker.violations.count, 1)
+    }
+
+    func testPublicAPIClearViolations() {
+        let violation = SuperCallViolation(className: "TestVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(violation)
+
+        DebugSwift.Performance.SuperCallChecker.clearViolations()
+        XCTAssertTrue(DebugSwift.Performance.SuperCallChecker.violations.isEmpty)
+    }
+
+    func testPublicAPIIgnoreClass() {
+        DebugSwift.Performance.SuperCallChecker.ignoreClass("PublicIgnoredVC")
+        let violation = SuperCallViolation(className: "PublicIgnoredVC", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(violation)
+
+        XCTAssertTrue(DebugSwift.Performance.SuperCallChecker.violations.isEmpty)
+    }
+
+    func testPublicAPISetIgnoredClasses() {
+        DebugSwift.Performance.SuperCallChecker.setIgnoredClasses(["A", "B"])
+        let v = SuperCallViolation(className: "A", methodName: "viewDidLoad", revealedBy: "viewWillAppear")
+        SuperCallDetector.shared.reportViolation(v)
+
+        XCTAssertTrue(DebugSwift.Performance.SuperCallChecker.violations.isEmpty)
+    }
+
+    // MARK: - End-to-end: real VC lifecycle
+
+    /// Swizzle must be installed for these tests. The FeatureHandling
+    /// setup runs at app launch, but in the test host it may not have
+    /// run yet, so we install it explicitly.
+    override class func setUp() {
+        UIViewController.db_swizzleLifecycleForSuperCallDetection()
+    }
+
+    /// A VC that calls super in every lifecycle method — no violations.
+    private class GoodVC: UIViewController {
+        override func viewDidLoad() { super.viewDidLoad() }
+        override func viewWillAppear(_ animated: Bool) { super.viewWillAppear(animated) }
+        override func viewDidAppear(_ animated: Bool) { super.viewDidAppear(animated) }
+        override func viewWillDisappear(_ animated: Bool) { super.viewWillDisappear(animated) }
+        override func viewDidDisappear(_ animated: Bool) { super.viewDidDisappear(animated) }
+    }
+
+    /// A VC that skips super.viewDidLoad() — should produce a violation
+    /// when viewWillAppear fires.
+    private class BadViewDidLoadVC: UIViewController {
+        override func viewDidLoad() {
+            // Intentionally does NOT call super.viewDidLoad()
+        }
+        override func viewWillAppear(_ animated: Bool) { super.viewWillAppear(animated) }
+    }
+
+    /// A VC that skips super.viewDidAppear() — should produce a violation
+    /// when viewWillDisappear fires.
+    private class BadViewDidAppearVC: UIViewController {
+        override func viewDidLoad() { super.viewDidLoad() }
+        override func viewWillAppear(_ animated: Bool) { super.viewWillAppear(animated) }
+        override func viewDidAppear(_ animated: Bool) {
+            // Intentionally does NOT call super.viewDidAppear()
+        }
+        override func viewWillDisappear(_ animated: Bool) { super.viewWillDisappear(animated) }
+    }
+
+    func testGoodVcProducesNoViolations() {
+        let before = SuperCallDetector.shared.violations.count
+        let vc = GoodVC()
+        vc.viewDidLoad()
+        vc.viewWillAppear(false)
+        vc.viewDidAppear(false)
+        vc.viewWillDisappear(false)
+        vc.viewDidDisappear(false)
+        let after = SuperCallDetector.shared.violations.count
+        XCTAssertEqual(after, before, "GoodVC should not produce violations")
+    }
+
+    func testBadViewDidLoadProducesViolation() {
+        let before = SuperCallDetector.shared.violations.count
+        let vc = BadViewDidLoadVC()
+        vc.viewDidLoad()
+        vc.viewWillAppear(false)
+        let after = SuperCallDetector.shared.violations.count
+
+        let newViolations = SuperCallDetector.shared.violations.dropFirst(before)
+        XCTAssertTrue(newViolations.contains {
+            $0.methodName == "viewDidLoad" && $0.revealedBy == "viewWillAppear"
+        }, "BadViewDidLoadVC should produce a viewDidLoad violation revealed by viewWillAppear")
+    }
+
+    func testBadViewDidAppearProducesViolation() {
+        let before = SuperCallDetector.shared.violations.count
+        let vc = BadViewDidAppearVC()
+        vc.viewDidLoad()
+        vc.viewWillAppear(false)
+        vc.viewDidAppear(false)
+        vc.viewWillDisappear(false)
+        let after = SuperCallDetector.shared.violations.count
+
+        let newViolations = SuperCallDetector.shared.violations.dropFirst(before)
+        XCTAssertTrue(newViolations.contains {
+            $0.methodName == "viewDidAppear" && $0.revealedBy == "viewWillDisappear"
+        }, "BadViewDidAppearVC should produce a viewDidAppear violation revealed by viewWillDisappear")
+    }
+}


### PR DESCRIPTION
## Summary

Implements #376 — detects UIViewController lifecycle methods that fail to call their `super` implementation.

## Approach

**Swizzling**: Uses IMP-replacement (`method_setImplementation`) — not `method_exchangeImplementations` — to avoid the NewRelic crash pattern documented in #434. The 5 swizzled lifecycle methods: `viewDidLoad`, `viewWillAppear`, `viewDidAppear`, `viewWillDisappear`, `viewDidDisappear`.

**Detection logic**: Per-instance lifecycle state is tracked via associated objects. When a later lifecycle method fires for a VC instance but an earlier one was never recorded (meaning its swizzled base IMP never ran), the earlier method is flagged as missing its `super` call.

## Public API

`DebugSwift.Performance.SuperCallChecker`:
- `onDetect(_:)` — register a callback for new violations
- `violations` — current list of `SuperCallViolation`
- `ignoreClass(_:)` / `setIgnoredClasses(_:)` — ignore specific classes
- `clearViolations()` — clear stored violations

## UI

Dedicated "Super Call Checker" section in the Performance tab with a `ResourcesGenericController` listing violations. Guarded by `.superCallDetector` in `DebugSwiftSwizzleFeature` — disabled by default, opt-in like the leak detector.

## Tests

18 tests in `ExampleTests` covering:
- Violation recording and deduplication
- Ignore list behavior (single + set replacement)
- Callback dispatch (fires for new, deduped for duplicates, suppressed for ignored)
- Public API mirroring (`SuperCallChecker` ↔ `SuperCallDetector`)
- `LifecycleEvent` ordering and count
- End-to-end detection with good/bad view controllers

All tests pass:
```
Test Suite 'SuperCallDetectorTests' passed (18 tests)
** TEST SUCCEEDED **
```

## Files Changed

- `Performance.SuperCallDetector.swift` (new) — core detection logic
- `SuperCallViolationsViewModel.swift` (new) — violations list ViewModel
- `SuperCallDetectorTests.swift` (new) — 18 tests
- `FeatureBase.swift` — `.superCallDetector` case
- `FeatureHandling.swift` — `enableSuperCallDetector()` wiring
- `DebugSwift.Performance.swift` — `SuperCallChecker` public API
- `Performance.Controller.swift` — UI section, cell, navigation

Closes #376