### PR TITLE
Fix: floating ball's default position blocks touches even when never shown

### DIFF
--- a/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
+++ b/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
@@ -142,7 +142,7 @@ final class CustomWindow: UIWindow {
 
         let ballView = FloatViewManager.shared.ballView
         if
-            ballView.point(inside: convert(point, to: ballView), with: event) ||
+            (ballView.window === self && ballView.point(inside: convert(point, to: ballView), with: event)) ||
             FloatViewManager.isShowingDebuggerView {
             return true
         }


### PR DESCRIPTION
## Summary

- `CustomWindow.point(inside:with:)` decides whether to swallow a touch purely by testing it against `ballView`'s frame (`DSFloatChat.ballRect`, i.e. `x: 0, y: screenHeight * 0.3, width: 40, height: 40`) - it never checks whether `ballView` is actually attached to the window.
- `FloatViewManager`'s `setup()` sets `ballView.frame` as soon as `FloatViewManager.shared` is first accessed (in practice ~1s after `DebugSwift.setup()` runs, via `FeatureHandling`'s delayed `FloatViewManager.setup(...)` call), but `ballView` is only ever added to the window when it's actually toggled visible (`FloatBallView.show`'s `didSet` calls `addSubview` only when `show == true`).
- Between those two points, `ballView` has a real frame but is not part of the view hierarchy at all. Any touch landing inside that 40x40pt rect on the screen's left edge is silently swallowed by `CustomWindow`, even though the float ball has never been shown - a real, invisible dead zone, not just a theoretical edge case.
- Fix: only honor the ball hit-test when `ballView` is actually installed in this window (`ballView.window === self`).

## Type of change

- [x] Fix

## Test plan

- [x] Manual testing completed

### Manual test steps

1. Call `DebugSwift.setup()` at app launch and never call `.show()`/`.toggle()`.
2. Wait ~2s for the delayed `FloatViewManager.setup(...)` to run (lazily initializes `FloatViewManager.shared`, which sets `ballView.frame`).
3. Tap anywhere inside `x: 0...40, y: screenHeight*0.3...screenHeight*0.3+40` (left screen edge, ~30% down).
4. Before this fix: the tap never reaches the app's own view hierarchy (`ballView.point(inside:)` returns `true` purely from frame geometry). After this fix: the tap passes through normally, since `ballView.window` is `nil` at that point.

I reproduced this with instrumented logging in a real app build (confirmed `rawHit=true, inHierarchy=false` at that exact coordinate before the fix, and confirmed touches pass through correctly after applying it), then verified manually in a simulator running the patched build.

## Checklist

- [x] I reviewed my own changes
- [ ] I updated docs when needed
- [x] I considered backward compatibility