### PR TITLE
feat(network): add logRequest API for traffic that bypasses URLSession (gRPC, custom transports)

### DIFF
--- a/DebugSwift/Sources/Features/Network/DataSource/HTTP.Datasource.swift
+++ b/DebugSwift/Sources/Features/Network/DataSource/HTTP.Datasource.swift
@@ -13,24 +13,23 @@ final class HttpDatasource: @unchecked Sendable {
 
     var httpModels: [HttpModel] = []
 
-    func addHttpRequest(_ model: HttpModel) -> Bool {
-        guard let modelUrl = model.url else {
-            return false
-        }
-        
+    func passesURLFilters(_ url: URL) -> Bool {
         if !DebugSwift.Network.shared.onlyURLs.isEmpty {
-            if !modelUrl.matchesAny(
+            return url.matchesAny(
                 wildcardPatterns: DebugSwift.Network.shared.onlyURLs,
                 strategy: .contains,
                 queryStrategy: .subset
-            ) {
-                return false
-            }
-        } else if modelUrl.matchesAny(
+            )
+        }
+        return !url.matchesAny(
             wildcardPatterns: DebugSwift.Network.shared.ignoredURLs,
             strategy: .contains,
             queryStrategy: .subset
-        ) {
+        )
+    }
+
+    func addHttpRequest(_ model: HttpModel) -> Bool {
+        guard let modelUrl = model.url, passesURLFilters(modelUrl) else {
             return false
         }
         

--- a/DebugSwift/Sources/Settings/DebugSwift.Network.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.Network.swift
@@ -353,14 +353,32 @@ extension DebugSwift {
             model.errorLocalizedDescription = error?.localizedDescription ?? ""
             model = ErrorHelper.handle(error, model: model)
 
-            let stored = HttpDatasource.shared.addHttpRequest(model)
-            if stored {
-                NotificationCenter.default.post(
-                    name: NSNotification.Name("reloadHttp_DebugSwift"),
-                    object: nil
-                )
+            // HttpDatasource is confined to the main thread (the capture pipeline
+            // reports via @MainActor). When called from another thread (e.g. a gRPC
+            // event loop) the store hops to main and the return value reflects URL
+            // filtering only.
+            if Thread.isMainThread {
+                let stored = HttpDatasource.shared.addHttpRequest(model)
+                if stored {
+                    NotificationCenter.default.post(
+                        name: NSNotification.Name("reloadHttp_DebugSwift"),
+                        object: nil
+                    )
+                }
+                return stored
             }
-            return stored
+
+            guard HttpDatasource.shared.passesURLFilters(url) else { return false }
+            nonisolated(unsafe) let pendingModel = model
+            DispatchQueue.main.async {
+                if HttpDatasource.shared.addHttpRequest(pendingModel) {
+                    NotificationCenter.default.post(
+                        name: NSNotification.Name("reloadHttp_DebugSwift"),
+                        object: nil
+                    )
+                }
+            }
+            return true
         }
 
         /// Configure how long Session History is kept and how often new requests are written to disk.

--- a/DebugSwift/Sources/Settings/DebugSwift.Network.swift
+++ b/DebugSwift/Sources/Settings/DebugSwift.Network.swift
@@ -276,6 +276,93 @@ extension DebugSwift {
             clearWebSocketHistory()
         }
 
+        // MARK: - Custom Request Logging
+
+        /// Logs a request that DebugSwift cannot capture automatically because it
+        /// bypasses `URLSession` — for example gRPC over SwiftNIO, a custom socket,
+        /// or any hand-rolled transport. The entry shows up in the Network tab
+        /// alongside automatically captured traffic and respects
+        /// ``ignoredURLs``/``onlyURLs`` filtering.
+        ///
+        /// Example (logging a gRPC call from a client interceptor):
+        /// ```swift
+        /// DebugSwift.Network.shared.logRequest(
+        ///     url: URL(string: "grpc://api.example.com/example.v1.UserService/GetUser")!,
+        ///     method: "POST",
+        ///     requestHeaders: requestHeaders,
+        ///     requestBody: requestJSON.data(using: .utf8),
+        ///     responseStatusCode: status.isOk ? 200 : 500,
+        ///     responseHeaders: responseHeaders,
+        ///     responseBody: responseJSON.data(using: .utf8),
+        ///     error: nil,
+        ///     startTime: callStartDate,
+        ///     endTime: Date()
+        /// )
+        /// ```
+        ///
+        /// - Parameters:
+        ///   - url: The full URL identifying the call. For non-HTTP transports use a
+        ///     descriptive scheme and path, e.g. `grpc://host/Service/Method`.
+        ///   - method: HTTP-style method label shown in the list. Defaults to `"GET"`.
+        ///   - requestHeaders: Request headers or transport metadata.
+        ///   - requestBody: Raw request payload (e.g. JSON-encoded message).
+        ///   - responseStatusCode: HTTP-style status code shown in the list.
+        ///   - responseHeaders: Response headers or trailing metadata.
+        ///   - responseBody: Raw response payload.
+        ///   - error: Transport error, if the call failed.
+        ///   - startTime: When the request started. Defaults to `endTime` (zero duration).
+        ///   - endTime: When the request finished. Defaults to now.
+        /// - Returns: `true` if the entry was stored, `false` if it was filtered out
+        ///   by ``ignoredURLs``/``onlyURLs`` or rejected as a duplicate.
+        @discardableResult
+        public func logRequest(
+            url: URL,
+            method: String = "GET",
+            requestHeaders: [String: String]? = nil,
+            requestBody: Data? = nil,
+            responseStatusCode: Int? = nil,
+            responseHeaders: [String: String]? = nil,
+            responseBody: Data? = nil,
+            error: Error? = nil,
+            startTime: Date? = nil,
+            endTime: Date = Date()
+        ) -> Bool {
+            var model = HttpModel()
+            model.url = url
+            model.method = method
+            model.requestData = requestBody
+            model.responseData = responseBody
+            model.requestHeaderFields = requestHeaders
+            model.responseHeaderFields = responseHeaders
+            model.requestId = UUID().uuidString
+            model.size = responseBody?.formattedSize()
+
+            if let responseStatusCode {
+                model.statusCode = "\(responseStatusCode)"
+            }
+            model.mineType = responseHeaders?.first { $0.key.lowercased() == "content-type" }?.value
+            model.isImage = model.mineType?.contains("image") ?? false
+
+            let start = startTime ?? endTime
+            let duration = abs(endTime.timeIntervalSince1970 - start.timeIntervalSince1970)
+            model.startTime = "\(start.formatted())"
+            model.endTime = "\(endTime.formatted())"
+            model.totalDuration = String(format: "%.4f (s)", duration)
+
+            model.errorDescription = error?.localizedDescription ?? ""
+            model.errorLocalizedDescription = error?.localizedDescription ?? ""
+            model = ErrorHelper.handle(error, model: model)
+
+            let stored = HttpDatasource.shared.addHttpRequest(model)
+            if stored {
+                NotificationCenter.default.post(
+                    name: NSNotification.Name("reloadHttp_DebugSwift"),
+                    object: nil
+                )
+            }
+            return stored
+        }
+
         /// Configure how long Session History is kept and how often new requests are written to disk.
         /// By default, Session History keeps 7 days of sessions and writes every 2 captured requests.
         /// Use a longer `retentionDays` value if you want more historical sessions available in the Session History UI.

--- a/Example/ExampleTests/Tests/Features/Network/Settings/NetworkCustomRequestLoggingTests.swift
+++ b/Example/ExampleTests/Tests/Features/Network/Settings/NetworkCustomRequestLoggingTests.swift
@@ -1,0 +1,126 @@
+//
+//  NetworkCustomRequestLoggingTests.swift
+//  DebugSwift
+//
+//  Tests for DebugSwift.Network.logRequest(...) — manual logging of traffic
+//  that bypasses URLSession (gRPC, custom sockets, etc.).
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class NetworkCustomRequestLoggingTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        HttpDatasource.shared.removeAll()
+        DebugSwift.Network.shared.ignoredURLs = []
+        DebugSwift.Network.shared.onlyURLs = []
+    }
+
+    override func tearDown() {
+        HttpDatasource.shared.removeAll()
+        DebugSwift.Network.shared.ignoredURLs = []
+        DebugSwift.Network.shared.onlyURLs = []
+        super.tearDown()
+    }
+
+    func testLogRequestStoresEntryWithAllFields() {
+        let url = URL(string: "grpc://api.example.com/example.v1.UserService/GetUser")!
+        let start = Date(timeIntervalSinceNow: -0.5)
+
+        let stored = DebugSwift.Network.shared.logRequest(
+            url: url,
+            method: "POST",
+            requestHeaders: ["grpc-accept-encoding": "gzip"],
+            requestBody: Data("{\"id\":1}".utf8),
+            responseStatusCode: 200,
+            responseHeaders: ["content-type": "application/grpc"],
+            responseBody: Data("{\"name\":\"Test\"}".utf8),
+            startTime: start,
+            endTime: Date()
+        )
+
+        XCTAssertTrue(stored)
+        XCTAssertEqual(HttpDatasource.shared.httpModels.count, 1)
+
+        let model = HttpDatasource.shared.httpModels[0]
+        XCTAssertEqual(model.url, url)
+        XCTAssertEqual(model.method, "POST")
+        XCTAssertEqual(model.statusCode, "200")
+        XCTAssertEqual(model.mineType, "application/grpc")
+        XCTAssertEqual(model.requestHeaderFields?["grpc-accept-encoding"] as? String, "gzip")
+        XCTAssertNotNil(model.requestData)
+        XCTAssertNotNil(model.responseData)
+        XCTAssertNotNil(model.totalDuration)
+        XCTAssertTrue(model.isSuccess)
+    }
+
+    func testLogRequestMarksFailureWhenErrorProvided() {
+        let error = NSError(
+            domain: "io.grpc",
+            code: 14,
+            userInfo: [NSLocalizedDescriptionKey: "unavailable"]
+        )
+
+        let stored = DebugSwift.Network.shared.logRequest(
+            url: URL(string: "grpc://api.example.com/example.v1.UserService/GetUser")!,
+            method: "POST",
+            responseStatusCode: 500,
+            error: error
+        )
+
+        XCTAssertTrue(stored)
+        let model = HttpDatasource.shared.httpModels[0]
+        XCTAssertFalse(model.isSuccess)
+        XCTAssertEqual(model.statusCode, "500")
+    }
+
+    func testLogRequestRespectsIgnoredURLs() {
+        DebugSwift.Network.shared.ignoredURLs = ["*ignored.example.com*"]
+
+        let stored = DebugSwift.Network.shared.logRequest(
+            url: URL(string: "grpc://ignored.example.com/svc/Method")!
+        )
+
+        XCTAssertFalse(stored)
+        XCTAssertTrue(HttpDatasource.shared.httpModels.isEmpty)
+    }
+
+    func testLogRequestRespectsOnlyURLs() {
+        DebugSwift.Network.shared.onlyURLs = ["*allowed.example.com*"]
+
+        let storedAllowed = DebugSwift.Network.shared.logRequest(
+            url: URL(string: "grpc://allowed.example.com/svc/Method")!
+        )
+        let storedOther = DebugSwift.Network.shared.logRequest(
+            url: URL(string: "grpc://other.example.com/svc/Method")!
+        )
+
+        XCTAssertTrue(storedAllowed)
+        XCTAssertFalse(storedOther)
+        XCTAssertEqual(HttpDatasource.shared.httpModels.count, 1)
+    }
+
+    func testLogRequestPostsReloadNotification() {
+        let reload = expectation(
+            forNotification: NSNotification.Name("reloadHttp_DebugSwift"),
+            object: nil
+        )
+
+        DebugSwift.Network.shared.logRequest(
+            url: URL(string: "https://api.example.com/v1/ping")!
+        )
+
+        wait(for: [reload], timeout: 1)
+    }
+
+    func testLogRequestDefaultsToZeroDurationWithoutStartTime() {
+        DebugSwift.Network.shared.logRequest(
+            url: URL(string: "https://api.example.com/v1/ping")!
+        )
+
+        let model = HttpDatasource.shared.httpModels[0]
+        XCTAssertEqual(model.totalDuration, "0.0000 (s)")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -426,6 +426,30 @@ DebugSwift.App.shared.customAction = {
 }
 ```
 
+### Custom Request Logging (gRPC and other non-URLSession transports)
+
+DebugSwift captures `URLSession` traffic automatically, but traffic that bypasses
+`URLSession` — gRPC over SwiftNIO, custom sockets, hand-rolled transports — is
+invisible to the swizzler. Use `logRequest` to record those calls manually; they
+show up in the Network tab next to the captured traffic and respect
+`ignoredURLs`/`onlyURLs`:
+
+```swift
+// Example: logging a gRPC call from a grpc-swift client interceptor
+DebugSwift.Network.shared.logRequest(
+    url: URL(string: "grpc://api.example.com/example.v1.UserService/GetUser")!,
+    method: "POST",
+    requestHeaders: requestMetadata,
+    requestBody: requestJSON.data(using: .utf8),
+    responseStatusCode: status.isOk ? 200 : 500,
+    responseHeaders: responseMetadata,
+    responseBody: responseJSON.data(using: .utf8),
+    error: transportError,
+    startTime: callStartDate,
+    endTime: Date()
+)
+```
+
 ### Manual URLSessionConfiguration Injection
 
 If you create `URLSessionConfiguration` instances **before** calling `DebugSwift.setup()`, you can manually inject the network monitoring protocol:


### PR DESCRIPTION
## Summary

Adds `DebugSwift.Network.shared.logRequest(...)` — a public API to log requests that bypass `URLSession` and are therefore invisible to the swizzler: gRPC over SwiftNIO (grpc-swift), custom sockets, or any hand-rolled transport. Logged entries appear in the Network tab alongside automatically captured traffic.

Today `HttpModel` and `HttpDatasource` are internal, so apps using gRPC have no way to surface those calls in DebugSwift. This is a universal entry point rather than a gRPC-specific integration: any transport can feed the Network tab through it.

## Approach

The method builds an `HttpModel` and routes it through the existing pipeline, so behavior matches automatically captured traffic:

- `ignoredURLs` / `onlyURLs` filtering via `HttpDatasource.addHttpRequest`
- status-code descriptions via `ErrorHelper`
- UI refresh via the existing `reloadHttp_DebugSwift` notification (same as `WKWebViewNetworkMonitor`)
- returns `Bool` so callers know whether the entry was stored

No changes to existing behavior — purely additive.

## Public API

```swift
// Example: logging a gRPC call from a grpc-swift client interceptor
DebugSwift.Network.shared.logRequest(
    url: URL(string: "grpc://api.example.com/example.v1.UserService/GetUser")!,
    method: "POST",
    requestHeaders: requestMetadata,
    requestBody: requestJSON.data(using: .utf8),
    responseStatusCode: status.isOk ? 200 : 500,
    responseHeaders: responseMetadata,
    responseBody: responseJSON.data(using: .utf8),
    error: transportError,
    startTime: callStartDate,
    endTime: Date()
)
```

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [x] Unit tests updated
- [x] Manual testing completed
- [x] CI passing

### Manual test steps

1. Call `DebugSwift.Network.shared.logRequest(...)` from a gRPC client interceptor (or any code path outside `URLSession`).
2. Open the Network tab — the entry appears in the list with method, status, size and duration, and opens into the standard request detail screen.
3. Add the host to `ignoredURLs` and repeat — the entry is filtered out and `logRequest` returns `false`.

## Tests

`NetworkCustomRequestLoggingTests` (6 tests): field mapping, error → `isSuccess == false`, `ignoredURLs`/`onlyURLs` filtering, reload notification, zero-duration default.

```
Test Suite 'NetworkCustomRequestLoggingTests' passed
Executed 6 tests, with 0 failures (0 unexpected)
** TEST SUCCEEDED **
```

The package also builds in Swift 6 language mode.

## Files Changed

- `DebugSwift.Network.swift` — new `logRequest(...)` public method
- `NetworkCustomRequestLoggingTests.swift` (new) — 6 tests
- `README.md` — "Custom Request Logging (gRPC and other non-URLSession transports)" section with a gRPC interceptor example

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
