### PR TITLE
fix(network): retry connection-lost requests only for idempotent methods

### DIFF
--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -634,9 +634,13 @@ extension CustomHTTPProtocol: URLSessionDataDelegate {
     }
 
     private func canRetry(error: NSError) -> Bool {
+        // Only retry idempotent methods: silently re-issuing POST/PUT/PATCH/DELETE
+        // can duplicate server-side effects.
+        let idempotentMethods = ["GET", "HEAD", "OPTIONS", "TRACE"]
         guard error.code == Int(CFNetworkErrors.cfurlErrorNetworkConnectionLost.rawValue),
               !didRetry,
-              !didReceiveData
+              !didReceiveData,
+              idempotentMethods.contains(request.httpMethod?.uppercased() ?? "")
         else {
             return false
         }


### PR DESCRIPTION
## Summary

`CustomHTTPProtocol` silently re-issues the original request on `cfurlErrorNetworkConnectionLost` when no data was received — for **any** HTTP method. Re-issuing non-idempotent requests (POST/PUT/PATCH/DELETE) can duplicate server-side effects: a payment/order POST whose connection drops after reaching the server gets sent twice, and the app never sees the first attempt. Apple's URL loading system deliberately never auto-retries POST on connection-lost for this reason.

This limits the silent retry to idempotent methods (GET/HEAD/OPTIONS/TRACE).

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [x] CI passing

### Manual test steps

1. Intercept a POST with DebugSwift enabled and kill the connection mid-flight (Network Link Conditioner / proxy) so the task fails with `networkConnectionLost` before any data arrives.
2. Before: the request is transparently re-sent (server receives it twice). After: the failure is delivered to the caller, no re-issue.
3. Repeat with GET — retry still happens as before.

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
