### PR TITLE
fix(network): don't intercept server-sent-event streams

### DIFF
--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -39,6 +39,12 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             return false
         }
 
+        // Server-sent-event streams are long-lived; intercepting would buffer the
+        // whole stream in memory and delay event delivery.
+        if request.value(forHTTPHeaderField: "Accept")?.lowercased().contains("text/event-stream") == true {
+            return false
+        }
+
         for onlyScheme in DebugSwift.Network.shared.onlySchemes {
             if let scheme = request.url?.scheme?.lowercased(), scheme == onlyScheme.rawValue {
                 return true

--- a/Example/ExampleTests/Tests/Features/Network/Helpers/CustomHTTPProtocolSSETests.swift
+++ b/Example/ExampleTests/Tests/Features/Network/Helpers/CustomHTTPProtocolSSETests.swift
@@ -1,0 +1,22 @@
+//
+//  CustomHTTPProtocolSSETests.swift
+//  DebugSwift
+//
+//  Tests that server-sent-event streams are not intercepted.
+//
+
+import XCTest
+@testable import DebugSwift
+
+final class CustomHTTPProtocolSSETests: XCTestCase {
+    func testDoesNotInterceptServerSentEventRequests() {
+        var request = URLRequest(url: URL(string: "https://api.example.com/v1/events")!)
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        XCTAssertFalse(CustomHTTPProtocol.canInit(with: request))
+    }
+
+    func testInterceptsRegularHTTPSRequests() {
+        let request = URLRequest(url: URL(string: "https://api.example.com/v1/ping")!)
+        XCTAssertTrue(CustomHTTPProtocol.canInit(with: request))
+    }
+}


### PR DESCRIPTION
## Summary

Server-sent-event connections are long-lived streams, but `canServeRequest` only excludes ws/wss and WebSocket upgrade requests — SSE goes through `CustomHTTPProtocol`, which appends every chunk to its in-memory `data` buffer with no size cap for the lifetime of the connection, and adds a delivery hop for each event. An hours-long SSE session grows memory unboundedly in debug builds and can reorder/delay event delivery.

This skips interception for requests with `Accept: text/event-stream`, same as the existing WebSocket exclusions.

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [x] Unit tests updated
- [x] Manual testing completed
- [x] CI passing

### Manual test steps

1. Open an EventSource/SSE connection with DebugSwift enabled and leave it running.
2. Before: memory grows with every event and the connection appears in the Network tab only on completion. After: SSE traffic bypasses interception entirely.

## Tests

`CustomHTTPProtocolSSETests` — `canInit` returns false for `Accept: text/event-stream`, true for regular HTTPS requests.

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
