### PR TITLE
fix(float): don't latch isShowingDebuggerView when the debugger isn't ready

### DIFF
--- a/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
+++ b/DebugSwift/Sources/Helpers/Managers/WindowManager.swift
@@ -34,20 +34,20 @@ enum WindowManager {
     }()
 
     static func presentDebugger() {
-        guard !FloatViewManager.isShowingDebuggerView else { return }
+        guard !FloatViewManager.isShowingDebuggerView,
+              let viewController = FloatViewManager.shared.floatViewController
+        else { return }
         FloatViewManager.isShowingDebuggerView = true
-        if let viewController = FloatViewManager.shared.floatViewController {
-            // Prevent clicks
-            window.isUserInteractionEnabled = false
-            // Remove keyboard, if opened.
-            UIWindow.keyWindow?.endEditing(true)
+        // Prevent clicks
+        window.isUserInteractionEnabled = false
+        // Remove keyboard, if opened.
+        UIWindow.keyWindow?.endEditing(true)
 
-            rootNavigation?.pushViewController(
-                viewController,
-                animated: true
-            )
-            window.isUserInteractionEnabled = true
-        }
+        rootNavigation?.pushViewController(
+            viewController,
+            animated: true
+        )
+        window.isUserInteractionEnabled = true
     }
 
     static func removeDebugger() {


### PR DESCRIPTION
## Summary

`WindowManager.presentDebugger()` sets `FloatViewManager.isShowingDebuggerView = true` **before** nil-checking `floatViewController`. The controller is only assigned ~1s after `setup()` (deferred via `asyncAfter` in `FeatureHandling`), so any `presentDebugger()` call inside that window — a shake handler, a ball tap injected by UI tests — latches the flag with nothing presented and nothing ever resets it:

- the floating ball is hidden by the flag's `didSet` and never comes back;
- every subsequent `presentDebugger()` dies on the guard;
- worst of all, `CustomWindow.point(inside:)` returns `true` for the whole screen while the flag is set, and `isUserInteractionEnabled = false` is only applied inside the skipped branch — the invisible window eats every touch and the host app becomes unresponsive until relaunch.

Fix: check `floatViewController` in the same guard and set the flag only when the debugger is actually presented.

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [x] CI passing

### Manual test steps

1. Call `DebugSwift.App.presentDebugger()` within 1s of `setup()` (e.g. from a shake handler right after launch).
2. Before: ball never appears, later shakes/taps do nothing, app stops responding to touches. After: the early call is a no-op and the debugger works normally once ready.

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
