### PR TITLE
feat(network): show newest requests at the top of the Network tab

### DIFF
--- a/DebugSwift/Sources/Features/Network/Main/Network.Controller.swift
+++ b/DebugSwift/Sources/Features/Network/Main/Network.Controller.swift
@@ -140,7 +140,6 @@ final class NetworkViewController: BaseController, MainFeatureType {
         super.viewDidAppear(animated)
 
         if viewModel.firstIn {
-            scrollToBottom()
             viewModel.firstIn = false
         }
     }
@@ -168,7 +167,7 @@ final class NetworkViewController: BaseController, MainFeatureType {
             let matchedResponseModifier = notification.userInfo?["matchedResponseModifier"] as? Bool ?? false
             MainActor.assumeIsolated {
                 self?.reloadHttp(
-                    needScrollToEnd: (self?.viewModel.isReachEnd ?? true) && self?.view.window != nil,
+                    needScrollToEnd: false,
                     success: success,
                     matchedResponseModifier: matchedResponseModifier
                 )

--- a/DebugSwift/Sources/Features/Network/Main/Network.ViewModel.swift
+++ b/DebugSwift/Sources/Features/Network/Main/Network.ViewModel.swift
@@ -32,11 +32,12 @@ final class NetworkViewModel {
 
     func applyFilter(for mode: NetworkInspectorMode = .http) {
         // Select the appropriate data source based on mode
+        // Newest first, so fresh requests are visible without scrolling
         switch mode {
         case .http:
-            cacheModels = httpModels
+            cacheModels = Array(httpModels.reversed())
         case .webview:
-            cacheModels = webViewModels
+            cacheModels = Array(webViewModels.reversed())
         case .websocket:
             cacheModels = [] // WebSocket uses different data structure
         }


### PR DESCRIPTION
## Summary

The Network tab lists requests oldest-first, so on a busy app the request you just made lands at the bottom of a long list — the debugging workflow becomes "open tab, scroll to the end, repeat". This flips the list to newest-first (like most network consoles) and removes the scroll-to-bottom behavior that compensated for the old order.

Happy to gate this behind a setting (e.g. `DebugSwift.Network.shared.newestFirst`, defaulting to current behavior) if you prefer not to change the default — let me know.

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD

## Test plan

- [ ] Unit tests updated
- [x] Manual testing completed
- [x] CI passing

### Manual test steps

1. Generate a series of requests with the Network tab open.
2. New entries appear at the top without scrolling; search and detail navigation work unchanged.

## Screenshots / recordings (if applicable)

Behavior change is ordering-only; list rendering unchanged.

## Checklist

- [x] I reviewed my own changes
- [x] I updated docs when needed
- [x] I considered backward compatibility
